### PR TITLE
Expand SDK surface, rename gem to microsandbox-rb, verify against official SDKs (v0.5.7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -50,6 +51,62 @@ jobs:
 
       - name: Run unit specs
         run: bundle exec rake spec
+
+  # Real-microVM integration tests — the round-trip verification that the unit
+  # suite (which stubs the native layer) cannot provide. Boots actual sandboxes
+  # from an OCI image and exercises exec/shell/fs/metrics/logs end-to-end.
+  #
+  # Requires KVM. GitHub-hosted Linux runners expose /dev/kvm (nested virt); the
+  # udev step below grants the runner user access to it. The official repo runs
+  # the equivalent suites on self-hosted KVM runners — if GitHub-hosted KVM
+  # proves insufficient for the heavy core runtime on the first run, point this
+  # job at a self-hosted runner (set `runs-on`) exactly as upstream does.
+  #
+  # Runs on pushes to main and manual dispatch (not on every PR) so external
+  # contributors aren't gated on KVM availability.
+  integration:
+    name: integration (real microVM, KVM)
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' \
+            | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libcap-ng-dev gcc make flex bison libelf-dev bc python3-pyelftools
+
+      - uses: oxidize-rb/actions/setup-ruby-and-rust@v1
+        with:
+          ruby-version: "3.4"
+          rustup-toolchain: stable
+          bundler-cache: true
+          cargo-cache: true
+
+      - name: Compile native extension
+        run: bundle exec rake compile
+
+      # The core's `prebuilt` build.rs provisions msb + libkrunfw at compile
+      # time; install explicitly too so a missing runtime fails loudly here
+      # rather than silently skipping the integration specs.
+      - name: Ensure runtime installed
+        run: bundle exec ruby -e 'require "microsandbox"; Microsandbox.install unless Microsandbox.installed?; abort("runtime not installed") unless Microsandbox.installed?'
+
+      # Pull from AWS's public ECR mirror of the Docker library rather than
+      # docker.io: anonymous docker.io pulls are rate-limited and fail in CI
+      # with "Not authorized". The ECR mirror needs no auth and isn't throttled.
+      - name: Run integration specs (boots real microVMs)
+        env:
+          MICROSANDBOX_INTEGRATION: "1"
+          MICROSANDBOX_TEST_IMAGE: public.ecr.aws/docker/library/alpine:latest
+        run: bundle exec rspec spec/integration
 
   lint:
     name: rustfmt + clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,8 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true
       - name: Build precompiled gem
-        uses: oxidize-rb/cross-gem-action@v9
+        # v7 is the latest release of this action; pinned to its commit SHA.
+        uses: oxidize-rb/cross-gem-action@80f59339d90789841d772f412fe4a8b201a8cfa2 # v7
         with:
           platform: ${{ matrix.platform }}
           ruby-versions: "3.1,3.2,3.3,3.4"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,14 +34,18 @@ permissions:
 
 jobs:
   # Precompiled per-platform gems — a UX optimization (users skip the Rust
-  # compile). Best-effort for now: marked continue-on-error so a cross-build
-  # failure does NOT block publishing the source gem. The source gem installs
-  # everywhere (compiling the extension via rb_sys), so the release is complete
-  # without these. TODO: the rake-compiler-dock build currently fails with
-  # Bundler::GemNotFound inside the container (needs `bundle install` in the
-  # dock step) — fix and then re-enable as a publish dependency.
+  # compile). EXPERIMENTAL / not on the release path yet: this gem wraps a heavy
+  # core crate whose build.rs downloads platform-specific msb + libkrunfw and
+  # links libkrunfw/keyring, which doesn't cross-compile cleanly through the
+  # generic rake-compiler-dock/osxcross flow. So this job is gated to manual
+  # `workflow_dispatch` only — tag releases ship the source gem (which installs
+  # everywhere by compiling via rb_sys). Iterate on it with a manual dispatch;
+  # when it produces working gems on all platforms, re-add it to `publish.needs`
+  # and drop the workflow_dispatch gate. The `bundle install` below fixes the
+  # first blocker (Bundler::GemNotFound inside the dock container).
   cross-gems:
     name: gem (${{ matrix.platform }})
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     continue-on-error: true
     strategy:
@@ -76,6 +80,11 @@ jobs:
             if command -v apt-get >/dev/null 2>&1; then
               apt-get update && apt-get install -y libcap-ng-dev
             fi
+            # The dock container runs `bundle exec rake native:<plat> gem`; install
+            # the bundle (rb_sys/rake/rake-compiler) first or it fails with
+            # Bundler::GemNotFound. Skip the dev group (rspec etc. aren't needed to build).
+            bundle config set --local without development
+            bundle install --jobs 4
       - uses: actions/upload-artifact@v4
         with:
           name: gem-${{ matrix.platform }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,9 +33,17 @@ permissions:
   contents: read
 
 jobs:
+  # Precompiled per-platform gems — a UX optimization (users skip the Rust
+  # compile). Best-effort for now: marked continue-on-error so a cross-build
+  # failure does NOT block publishing the source gem. The source gem installs
+  # everywhere (compiling the extension via rb_sys), so the release is complete
+  # without these. TODO: the rake-compiler-dock build currently fails with
+  # Bundler::GemNotFound inside the container (needs `bundle install` in the
+  # dock step) — fix and then re-enable as a publish dependency.
   cross-gems:
     name: gem (${{ matrix.platform }})
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -90,7 +98,10 @@ jobs:
 
   publish:
     name: publish to RubyGems
-    needs: [cross-gems, source-gem]
+    # Only the source gem is required to publish; precompiled cross-gems are
+    # best-effort (see cross-gems above) and pushed too if they happened to
+    # build (the gem push loop globs whatever artifacts are present).
+    needs: [source-gem]
     runs-on: ubuntu-latest
     # Real tag pushes only — never on a manual dry run.
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,8 +104,16 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.4"
-      - name: Configure RubyGems trusted publishing
-        uses: rubygems/configure-trusted-publisher@v1
+      # Exchange the GitHub OIDC token for short-lived RubyGems credentials.
+      # This is the official trusted-publishing action — NO RUBYGEMS_API_KEY
+      # secret is needed. (`rubygems/release-gem` is the all-in-one wrapper that
+      # runs `rake release`; it builds a single gem and so doesn't fit pushing
+      # the several pre-built per-platform gems this pipeline produces.)
+      - name: Configure RubyGems credentials (OIDC trusted publishing)
+        # Pinned to a full commit SHA (supply-chain hardening for a workflow that
+        # holds publish privileges); the comment tracks the human-readable version.
+        # Bump the SHA when upgrading (e.g. via Dependabot).
+        uses: rubygems/configure-rubygems-credentials@dc5a8d8553e6ee01fc26761a49e99e733d17954a # v2.1.0
       - name: Push gems
         run: |
           shopt -s nullglob

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,45 @@ All notable changes to this gem are documented here. The format is based on
 [Keep a Changelog](https://keepachangelog.com/), and the version tracks the
 upstream microsandbox runtime.
 
+## [Unreleased]
+
+Closes the `Sandbox`-class lifecycle gap with the official Python/Node/Go SDKs.
+
+### Added
+
+- Asynchronous lifecycle controls on `Microsandbox::Sandbox`: `request_stop`,
+  `request_kill`, `request_drain` (send the request without waiting),
+  `wait_until_stopped` (blocks and returns a `Microsandbox::SandboxStopResult`),
+  `owns_lifecycle?`, and `detach` (disarm stop-on-drop and keep the sandbox
+  running). Mirrors the official SDKs' lifecycle surface.
+- `Microsandbox::SandboxStopResult` value object (`name`, `status`, `exit_code`,
+  `signal`, `source`, `observed_at`, `stopped?`/`crashed?`).
+- `Microsandbox::Sandbox.list_with(labels:)` — list sandboxes filtered by
+  AND-matched labels.
+- `Microsandbox.all_sandbox_metrics` — latest metrics for every running
+  sandbox, keyed by name (mirrors `all_sandbox_metrics`/`allSandboxMetrics`).
+- `Microsandbox::VolumeAlreadyExistsError`, mapped from the core
+  `VolumeAlreadyExists` variant.
+- Streaming observability: `Sandbox#metrics_stream(interval:)` →
+  `Microsandbox::MetricsStream` and `Sandbox#log_stream(sources:, since_ms:,
+  from_cursor:, until_ms:, follow:)` → `Microsandbox::LogStream`, both
+  `Enumerable` (over `Metrics` / `LogEntry`) draining the underlying core stream
+  with the GVL released.
+- Snapshots: `Microsandbox::Snapshot.create`/`get`/`list`/`remove`/`verify`/
+  `export`/`import` with `SnapshotInfo` and `SnapshotVerifyReport` value
+  objects. Boot from a snapshot via `Sandbox.create(from_snapshot:)`.
+- Expanded `Sandbox.create` options: `log_level`, `quiet_logs`, `security`
+  (`default`/`restricted`), `oci_upper_size`, `max_duration`, `idle_timeout`,
+  `ports_udp`, `rlimits`, `pull_policy` (`always`/`if-missing`/`never`),
+  `secrets` (placeholder-protected, TLS-substituted per allowed host), and the
+  `allow_all`/`non_local` network policy presets (alongside the existing
+  `public_only`/`none`).
+- Per-exec resource limits: `rlimits:` on `Sandbox#exec`/`#shell`/`#exec_stream`/
+  `#shell_stream` (e.g. `rlimits: { nofile: 65_535, cpu: [10, 20] }`).
+- CI now runs the real-microVM integration suite (`spec/integration`) on a
+  KVM-enabled runner, so the Rust↔core round-trip is exercised in automation —
+  not just compilation and unit tests.
+
 ## [0.5.7] - 2026-06-17
 
 Initial release of the Ruby SDK — native bindings (magnus + rb-sys) over the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,17 +108,52 @@ git. The override must never be committed — it would break container builds.
 
 ## Implemented surface (v1) vs roadmap
 
-**Implemented:** sandbox lifecycle (`create`/`start`/`get`/`list`/`remove`/
-`stop`/`kill`, block form), `exec`/`shell` with collected `ExecOutput`,
+**Implemented:** sandbox lifecycle (`create`/`start`/`get`/`list`/`list_with`/
+`remove`/`stop`/`kill`, the async `request_stop`/`request_kill`/`request_drain`/
+`wait_until_stopped` (→ `SandboxStopResult`) / `detach` / `owns_lifecycle?`
+controls, block form), `exec`/`shell` with collected `ExecOutput`,
 **streaming** `exec_stream`/`shell_stream` (`ExecHandle` is `Enumerable` over
 `ExecEvent`s, with stdin sink + signal/kill/resize), the full guest filesystem
-API (`fs.read`/`write`/`list`/`mkdir`/`remove`/`stat`/…), `metrics`, `logs`,
+API (`fs.read`/`write`/`list`/`mkdir`/`remove`/`stat`/…), `metrics`,
+`Microsandbox.all_sandbox_metrics`, **streaming `metrics_stream`/`log_stream`**
+(`Enumerable` over `Metrics`/`LogEntry`), `logs`,
 **OCI image-cache management** (`Image.get`/`list`/`inspect`/`remove`/`prune`),
 **named volumes** (`Volume.create`/`get`/`list`/`remove` + `volumes:` mounts),
-**boot-from-snapshot** (`from_snapshot:`), `version`/`install`/`installed?`, and
+**snapshots** (`Snapshot.create`/`get`/`list`/`remove`/`verify`/`export`/`import`
++ `from_snapshot:` boot), `version`/`install`/`installed?`, and
 the typed error hierarchy.
 
-**Roadmap:** streaming logs/metrics (`log_stream`, `metrics_stream`), snapshot
-creation/management, SSH, the raw agent client, and fine-grained
-networking/secrets/patches options. The native layer is structured so these slot
-in module-by-module, exactly as in the Python binding.
+Create options now cover `image`, `cpus`, `memory`, `oci_upper_size`, `env`,
+`workdir`, `shell`, `user`, `hostname`, `labels`, `scripts`, `entrypoint`,
+`ports`/`ports_udp`, `volumes`, `network` policy presets
+(`public_only`/`none`/`allow_all`/`non_local`), `log_level`, `quiet_logs`,
+`security`, `max_duration`, `idle_timeout`, `rlimits`, `pull_policy`, `secrets`,
+`from_snapshot`, `detached`, and `replace`/`replace_with_timeout`. `exec`/`shell`
+add per-call `rlimits`.
+
+## Verification
+
+The binding is verified at four levels:
+
+1. **Unit** (130 examples) — the Ruby layer's option normalization and value
+   objects, with the native layer stubbed.
+2. **Real-microVM integration** (`spec/integration`, opt-in via
+   `MICROSANDBOX_INTEGRATION=1`) — boots actual sandboxes and round-trips
+   `exec`/`shell`/`fs`/`metrics`/`logs`/streaming/snapshots. Run locally on
+   macOS Apple Silicon and wired into CI on a KVM runner.
+3. **Cross-SDK behavioral parity** — an identical-operations harness run through
+   this gem and through the **official Go SDK** against the same embedded runtime
+   produces byte-identical observable results (exec exit/stdout/success, env
+   propagation, non-zero-exit handling, fs round-trip + size, metrics). Both wrap
+   the same core crate, so this confirms the binding shapes data identically to
+   the official SDKs.
+4. **Packaged-gem install** — `gem install microsandbox-rb-<v>.gem` compiles the
+   shipped Rust source via `extconf.rb` and the installed gem boots a real
+   microVM, confirming the gem manifest and source-install path are complete.
+
+**Roadmap:** custom per-rule network policies (CIDR/domain/group allow-deny
+rules — the presets and secret-host allowances are covered), file patches,
+registry auth, interactive `attach`/`attach_shell` (host-TTY coupled — raw mode,
+SIGWINCH), SSH (`SshClient`/`SftpClient`/`SshServer`), and the raw agent client.
+The native layer is structured so these slot in module-by-module, exactly as in
+the Python binding.

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-# Declare gem dependencies in microsandbox.gemspec
+# Declare gem dependencies in microsandbox-rb.gemspec
 gemspec
 
 group :development do

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# microsandbox (Ruby)
+# microsandbox-rb
 
 Lightweight microVM sandboxes for Ruby — run AI agents and untrusted code with hardware-level isolation.
 
-The `microsandbox` gem provides native bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime via a Rust extension (magnus). It spins up real microVMs (not containers) in under 100 ms, runs standard OCI (Docker) images, and gives you full control over command execution, the guest filesystem, networking, and metrics — all from an idiomatic, **synchronous** Ruby API. There is no daemon to install and no server to connect to: the runtime is embedded directly in your process.
+The `microsandbox-rb` gem provides native bindings to the [microsandbox](https://github.com/superradcompany/microsandbox) runtime via a Rust extension (magnus). It spins up real microVMs (not containers) in under 100 ms, runs standard OCI (Docker) images, and gives you full control over command execution, the guest filesystem, networking, and metrics — all from an idiomatic, **synchronous** Ruby API. There is no daemon to install and no server to connect to: the runtime is embedded directly in your process.
 
 This is an **unofficial, community-maintained** Ruby implementation — not part of the official SDK family ([Rust](https://github.com/superradcompany/microsandbox/tree/main/sdk), TypeScript, Python, Go) — though it wraps the same core engine.
 
@@ -25,15 +25,18 @@ This is an **unofficial, community-maintained** Ruby implementation — not part
 
 ## Installation
 
+The gem is published as **`microsandbox-rb`**, but you still `require "microsandbox"`
+(the `microsandbox` package name was already taken on RubyGems):
+
 ```ruby
 # Gemfile
-gem "microsandbox"
+gem "microsandbox-rb", require: "microsandbox"
 ```
 
 ```bash
 bundle install
 # or
-gem install microsandbox
+gem install microsandbox-rb
 ```
 
 The first build downloads the `msb` runtime and `libkrunfw` firmware into
@@ -276,24 +279,49 @@ bundle exec rake compile
 
 ## Releasing
 
-Releases are automated by `.github/workflows/release.yml`:
+Releases are automated by `.github/workflows/release.yml` via RubyGems
+**Trusted Publishing** (OIDC) — there is no API key to store as a secret.
+
+**One-time setup** (before the first release), create a *pending* trusted
+publisher at <https://rubygems.org/profile/oidc/pending_trusted_publishers>:
+
+| Field | Value |
+|-------|-------|
+| RubyGems gem name | `microsandbox-rb` |
+| Repository owner | `ya-luotao` |
+| Repository name | `microsandbox-rb` |
+| Workflow filename | `release.yml` |
+| Environment | *(leave blank)* |
+
+On the first successful push the pending publisher auto-converts to a permanent
+one bound to the gem.
+
+**Each release:**
 
 1. Bump `Microsandbox::VERSION` (and the `tag = "vX.Y.Z"` on the core-crate
    dependency in `ext/microsandbox/Cargo.toml`) to match the upstream runtime,
    update `CHANGELOG.md`.
-2. Push a `vX.Y.Z` tag. CI builds precompiled, multi-ABI platform gems
-   (`x86_64-linux`, `aarch64-linux`, `arm64-darwin`) with
-   `rake-compiler-dock`, plus the source gem, and publishes them to RubyGems via
-   Trusted Publishing (OIDC — configure the trusted publisher in the RubyGems UI
-   first). Use the workflow's manual `dry_run` dispatch to build artifacts without
-   publishing.
+2. *(Recommended first time)* run the workflow's manual `dry_run` dispatch to
+   build all platform gems without publishing — confirms the `arm64-darwin`
+   cross-build succeeds.
+3. Push a `vX.Y.Z` tag. CI builds precompiled, multi-ABI platform gems
+   (`x86_64-linux`, `aarch64-linux`, `arm64-darwin`) with `rake-compiler-dock`,
+   plus the source gem, and pushes them to RubyGems. The publish job uses
+   `rubygems/configure-rubygems-credentials` (OIDC) with `id-token: write` — no
+   `RUBYGEMS_API_KEY` secret required.
 
 See [DESIGN.md](DESIGN.md) for the architecture and the implemented-surface
-section for what's covered today vs. on the roadmap. Covered: sandbox lifecycle,
-`exec`/`shell` (collected and streaming), the full guest filesystem, metrics,
-logs, OCI image-cache management, named volumes, and boot-from-snapshot. Still on
-the roadmap: streaming logs/metrics, snapshot creation, SSH, the raw agent
-client, and fine-grained networking/secrets/patches.
+section for what's covered today vs. on the roadmap. Covered: full sandbox
+lifecycle (including the async `request_stop`/`request_kill`/`request_drain`/
+`wait_until_stopped`/`detach`/`owns_lifecycle?` controls and label-filtered
+`list_with`), `exec`/`shell` (collected and streaming), the full guest
+filesystem, metrics (per-sandbox, `Microsandbox.all_sandbox_metrics`, and
+streaming `metrics_stream`/`log_stream`), logs, OCI image-cache management,
+named volumes, and snapshots (create/list/verify/export/import +
+boot-from-snapshot). Create options span resources, network policy presets,
+`log_level`/`security`/`rlimits`/`pull_policy`/`secrets` and more; `exec`/`shell`
+take per-call `rlimits`. Still on the roadmap: custom per-rule network policies,
+file patches, registry auth, interactive `attach`, SSH, and the raw agent client.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ This is an **unofficial, community-maintained** Ruby implementation — not part
 
 - **Ruby** >= 3.1
 - **Linux** with KVM enabled, or **macOS** on Apple Silicon (M-series)
-- Building from source additionally needs a **Rust** toolchain (stable >= 1.91)
+- A **Rust** toolchain (stable >= 1.91) — the gem currently installs as a source
+  gem and compiles the native extension on install (precompiled per-platform
+  gems are planned; see [Releasing](#releasing))
 
 ## Installation
 
@@ -38,6 +40,9 @@ bundle install
 # or
 gem install microsandbox-rb
 ```
+
+Installing compiles the Rust extension, so the first install takes a few minutes
+and needs a Rust toolchain on `PATH`.
 
 The first build downloads the `msb` runtime and `libkrunfw` firmware into
 `~/.microsandbox`. You can (re)provision them explicitly at any time:
@@ -301,14 +306,19 @@ one bound to the gem.
 1. Bump `Microsandbox::VERSION` (and the `tag = "vX.Y.Z"` on the core-crate
    dependency in `ext/microsandbox/Cargo.toml`) to match the upstream runtime,
    update `CHANGELOG.md`.
-2. *(Recommended first time)* run the workflow's manual `dry_run` dispatch to
-   build all platform gems without publishing — confirms the `arm64-darwin`
-   cross-build succeeds.
-3. Push a `vX.Y.Z` tag. CI builds precompiled, multi-ABI platform gems
-   (`x86_64-linux`, `aarch64-linux`, `arm64-darwin`) with `rake-compiler-dock`,
-   plus the source gem, and pushes them to RubyGems. The publish job uses
-   `rubygems/configure-rubygems-credentials` (OIDC) with `id-token: write` — no
+2. Push a `vX.Y.Z` tag. CI builds the **source gem** and pushes it to RubyGems
+   via `rubygems/configure-rubygems-credentials` (OIDC, `id-token: write`) — no
    `RUBYGEMS_API_KEY` secret required.
+
+> **Precompiled per-platform gems** are not on the release path yet — this gem
+> wraps a heavy core crate whose `build.rs` downloads platform-specific `msb` +
+> `libkrunfw` binaries and links `libkrunfw`/keyring, which doesn't
+> cross-compile cleanly through the generic `rake-compiler-dock`/osxcross flow.
+> The `cross-gems` job is gated to manual `workflow_dispatch` so you can iterate
+> on it (`gh workflow run release.yml`) without failing tag releases. Once it
+> produces working gems on all platforms, re-add it to `publish.needs` and drop
+> the `workflow_dispatch` gate. Until then, users install the source gem (which
+> compiles via `rb_sys`).
 
 See [DESIGN.md](DESIGN.md) for the architecture and the implemented-surface
 section for what's covered today vs. on the roadmap. Covered: full sandbox

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@
 require "bundler/gem_tasks"
 require "rb_sys/extensiontask"
 
-GEMSPEC = Gem::Specification.load("microsandbox.gemspec")
+GEMSPEC = Gem::Specification.load("microsandbox-rb.gemspec")
 
 RbSys::ExtensionTask.new("microsandbox_rb", GEMSPEC) do |ext|
   ext.lib_dir = "lib/microsandbox"

--- a/ext/microsandbox/extconf.rb
+++ b/ext/microsandbox/extconf.rb
@@ -3,6 +3,41 @@
 require "mkmf"
 require "rb_sys/mkmf"
 
+# Preflight: the embedded microsandbox core is edition 2024 and pulls smoltcp,
+# which sets a Minimum Supported Rust Version of 1.91. A `cargo` from an older
+# toolchain (commonly Homebrew's rustc, which shadows a newer rustup on PATH and
+# ignores this gem's rust-toolchain.toml) fails deep in the build with a cryptic
+# "rustc X is not supported by smoltcp" error. Detect it up front and explain
+# the fix instead.
+MSRV = Gem::Version.new("1.91")
+rustc_version = begin
+  out = `rustc --version 2>/dev/null`
+  out[/\d+\.\d+(\.\d+)?/] && Gem::Version.new(out[/\d+\.\d+(\.\d+)?/])
+rescue StandardError
+  nil
+end
+
+if rustc_version && rustc_version < MSRV
+  which_rustc = (`which rustc 2>/dev/null`.strip rescue "")
+  abort(<<~MSG)
+
+    [microsandbox-rb] Rust #{rustc_version} is too old — the embedded core requires rustc >= #{MSRV}.
+      Found: #{which_rustc.empty? ? "rustc" : which_rustc} (#{rustc_version})
+
+    This usually means an older rustc (e.g. Homebrew's) is ahead of a newer
+    rustup toolchain on your PATH. Fixes:
+
+      • Put rustup's toolchain first for the install:
+          PATH="$HOME/.cargo/bin:$PATH" gem install microsandbox-rb
+      • Or make a recent stable the default and ensure no other rustc shadows it:
+          rustup install stable && rustup default stable
+      • Or upgrade your system Rust to >= #{MSRV}.
+
+    (This gem ships a rust-toolchain.toml pinning `stable`; the rustup `cargo`
+    shim honors it, but a non-rustup `cargo` does not.)
+  MSG
+end
+
 # Builds the Rust cdylib and installs it as lib/microsandbox/microsandbox.{bundle,so}.
 # The Cargo profile is selected via the RB_SYS_CARGO_PROFILE env var (defaults to
 # release for installed gems, dev for `rake compile`).

--- a/ext/microsandbox/src/error.rs
+++ b/ext/microsandbox/src/error.rs
@@ -23,6 +23,7 @@ fn class_name(err: &MicrosandboxError) -> &'static str {
         ImageNotFound(_) => "ImageNotFoundError",
         ImageInUse(_) => "ImageInUseError",
         VolumeNotFound(_) => "VolumeNotFoundError",
+        VolumeAlreadyExists(_) => "VolumeAlreadyExistsError",
         Io(_) => "IoError",
         MetricsDisabled(_) => "MetricsDisabledError",
         MetricsUnavailable(_) => "MetricsUnavailableError",

--- a/ext/microsandbox/src/lib.rs
+++ b/ext/microsandbox/src/lib.rs
@@ -14,13 +14,28 @@ mod exec;
 mod image;
 mod runtime;
 mod sandbox;
+mod snapshot;
+mod stream;
 mod volume;
 
-use magnus::{function, prelude::*, Error, Ruby};
+use magnus::{function, prelude::*, Error, RHash, Ruby};
 
 /// Gem/runtime version string.
 fn version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+/// Latest metrics for every running sandbox, as a `{ name => metrics_hash }`
+/// Ruby Hash. Mirrors the official `all_sandbox_metrics` / `allSandboxMetrics`
+/// helpers (Python/Node/Go).
+fn all_sandbox_metrics() -> Result<RHash, Error> {
+    let map =
+        runtime::block_on(microsandbox::sandbox::all_sandbox_metrics()).map_err(error::to_ruby)?;
+    let hash = runtime::ruby().hash_new();
+    for (name, metrics) in &map {
+        hash.aset(name.as_str(), sandbox::metrics_to_hash(metrics))?;
+    }
+    Ok(hash)
 }
 
 /// Download and install the `msb` runtime + `libkrunfw` into `~/.microsandbox`.
@@ -56,9 +71,12 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     native.define_singleton_method("installed?", function!(is_installed, 0))?;
     native.define_singleton_method("set_runtime_msb_path", function!(set_runtime_msb_path, 1))?;
     native.define_singleton_method("resolved_msb_path", function!(resolved_msb_path, 0))?;
+    native.define_singleton_method("all_sandbox_metrics", function!(all_sandbox_metrics, 0))?;
 
     sandbox::define(ruby, &native)?;
     exec::define(ruby, &native)?;
+    stream::define(ruby, &native)?;
+    snapshot::define(ruby, &native)?;
     image::define(ruby, &native)?;
     volume::define(ruby, &native)?;
 

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -11,15 +11,21 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use magnus::{function, method, prelude::*, Error, RArray, RHash, RModule, RString, Ruby};
-use microsandbox::logs::{LogEntry, LogOptions, LogSource};
-use microsandbox::sandbox::{
-    FsEntry, FsEntryKind, FsMetadata, SandboxHandle, SandboxMetrics, SandboxStatus,
+use microsandbox::logs::{
+    LogCursor, LogEntry, LogOptions, LogSource, LogStreamOptions, LogStreamStart,
 };
+use microsandbox::sandbox::{
+    FsEntry, FsEntryKind, FsMetadata, PullPolicy, RlimitResource, SandboxFilter, SandboxHandle,
+    SandboxMetrics, SandboxStatus, SandboxStopResult, SecurityProfile,
+};
+use microsandbox::LogLevel;
+use microsandbox_network::policy::NetworkPolicy;
 
 use crate::conv;
 use crate::error;
 use crate::exec::ExecHandle;
 use crate::runtime::{block_on, ruby};
+use crate::stream::{LogStream, MetricsStream};
 
 #[magnus::wrap(class = "Microsandbox::Native::Sandbox", free_immediately, size)]
 pub struct Sandbox {
@@ -104,13 +110,55 @@ impl Sandbox {
         if let Some(net) = conv::opt_string(opts, "network")? {
             match net.as_str() {
                 "none" | "disabled" | "disable" | "airgapped" => b = b.disable_network(),
-                "public" | "public_only" | "all" | "default" => {}
+                // Default policy is public-only, so no builder call is needed.
+                "public" | "public_only" | "default" => {}
+                "all" | "allow_all" => b = b.network(|n| n.policy(NetworkPolicy::allow_all())),
+                "non_local" | "nonlocal" => b = b.network(|n| n.policy(NetworkPolicy::non_local())),
                 other => {
                     return Err(error::base_error(format!(
-                        "unknown network mode {other:?} (expected \"public_only\" or \"none\")"
+                        "unknown network mode {other:?} (expected one of \
+                         public_only/none/allow_all/non_local)"
                     )))
                 }
             }
+        }
+        if let Some(level) = conv::opt_string(opts, "log_level")? {
+            b = b.log_level(log_level_from_str(&level)?);
+        }
+        if conv::opt_bool(opts, "quiet_logs")? {
+            b = b.quiet_logs();
+        }
+        if let Some(profile) = conv::opt_string(opts, "security")? {
+            b = b.security(security_profile_from_str(&profile)?);
+        }
+        if let Some(policy) = conv::opt_string(opts, "pull_policy")? {
+            b = b.pull_policy(pull_policy_from_str(&policy)?);
+        }
+        if let Some(mib) = conv::opt_u32(opts, "oci_upper_size")? {
+            b = b.oci_upper_size(mib);
+        }
+        if let Some(secs) = conv::opt::<u64>(opts, "max_duration")? {
+            b = b.max_duration(secs);
+        }
+        if let Some(secs) = conv::opt::<u64>(opts, "idle_timeout")? {
+            b = b.idle_timeout(secs);
+        }
+        for (host, guest) in conv::opt_port_map(opts, "ports_udp")? {
+            b = b.port_udp(host, guest);
+        }
+        for (resource, soft, hard) in parse_rlimits(opts)? {
+            b = b.rlimit_range(resource, soft, hard);
+        }
+        // secrets: normalized by the Ruby layer to [env_var, value, allowed_host]
+        // triples. Uses the placeholder-based `secret_env` shorthand, which also
+        // auto-enables TLS interception (required for value substitution).
+        for spec in conv::opt::<Vec<Vec<String>>>(opts, "secrets")?.unwrap_or_default() {
+            if spec.len() != 3 {
+                return Err(error::base_error(
+                    "invalid secret spec (expected [env, value, host])",
+                ));
+            }
+            b = b.secret_env(spec[0].clone(), spec[1].clone(), spec[2].clone());
         }
         if conv::opt_bool(opts, "detached")? {
             b = b.detached(true);
@@ -145,6 +193,17 @@ impl Sandbox {
     /// All sandboxes as metadata hashes.
     fn list() -> Result<RArray, Error> {
         let handles = block_on(microsandbox::Sandbox::list()).map_err(error::to_ruby)?;
+        rhash_array(handles.iter().map(handle_to_hash))
+    }
+
+    /// Sandboxes filtered by required `key=value` labels (AND-matched). `opts`
+    /// carries a string→string `labels` map.
+    fn list_with(opts: RHash) -> Result<RArray, Error> {
+        let mut filter = SandboxFilter::new();
+        for (k, v) in conv::opt_string_map(opts, "labels")? {
+            filter = filter.label(k, v);
+        }
+        let handles = block_on(microsandbox::Sandbox::list_with(filter)).map_err(error::to_ruby)?;
         rhash_array(handles.iter().map(handle_to_hash))
     }
 
@@ -220,6 +279,44 @@ impl Sandbox {
         .map_err(error::to_ruby)
     }
 
+    /// Send the graceful-shutdown request and return without waiting.
+    fn request_stop(&self) -> Result<(), Error> {
+        block_on(self.inner.request_stop()).map_err(error::to_ruby)
+    }
+
+    /// Send the force-kill request and return without waiting.
+    fn request_kill(&self) -> Result<(), Error> {
+        block_on(self.inner.request_kill()).map_err(error::to_ruby)
+    }
+
+    /// Send the drain request and return without waiting.
+    fn request_drain(&self) -> Result<(), Error> {
+        block_on(self.inner.request_drain()).map_err(error::to_ruby)
+    }
+
+    /// Block until the sandbox is observed in a terminal state; returns a
+    /// stop-result Hash (name, status, exit_code, signal, observed_at_ms, source).
+    fn wait_until_stopped(&self) -> Result<RHash, Error> {
+        let result = block_on(self.inner.wait_until_stopped()).map_err(error::to_ruby)?;
+        Ok(stop_result_to_hash(&result))
+    }
+
+    /// Whether this handle owns the sandbox process lifecycle (a synchronous,
+    /// local predicate — no runtime round-trip).
+    fn owns_lifecycle(&self) -> bool {
+        self.inner.owns_lifecycle()
+    }
+
+    /// Disarm the SIGTERM safety net so the sandbox keeps running after this
+    /// handle is dropped. The core `detach` consumes the value; the core
+    /// `Sandbox` is `Clone` (Arc-backed, sharing the same process handle), so
+    /// detaching a clone disarms the shared handle just the same.
+    fn detach(&self) -> Result<(), Error> {
+        let inner = self.inner.clone();
+        block_on(inner.detach());
+        Ok(())
+    }
+
     /// Latest metrics snapshot as a Hash.
     fn metrics(&self) -> Result<RHash, Error> {
         let m = block_on(self.inner.metrics()).map_err(error::to_ruby)?;
@@ -232,6 +329,26 @@ impl Sandbox {
         let log_opts = parse_log_options(opts)?;
         let entries = block_on(self.inner.logs(&log_opts)).map_err(error::to_ruby)?;
         rhash_array(entries.iter().map(log_entry_to_hash))
+    }
+
+    /// Stream metrics snapshots at `interval` seconds. Returns a MetricsStream
+    /// to pull snapshots from.
+    fn metrics_stream(&self, interval: f64) -> MetricsStream {
+        let dur = Duration::from_secs_f64(if interval <= 0.0 { 1.0 } else { interval });
+        // `metrics_stream` is synchronous but builds a `tokio::time::interval`,
+        // which panics ("no reactor running") unless constructed inside the
+        // runtime context — so build it under `block_on`. (`log_stream` is async
+        // and already runs inside `block_on`, so it needs no such wrapper.)
+        let stream = block_on(async { self.inner.metrics_stream(dur) });
+        MetricsStream::from_stream(stream)
+    }
+
+    /// Stream captured logs as they appear. `opts`: sources, since_ms,
+    /// from_cursor, until_ms, follow. Returns a LogStream.
+    fn log_stream(&self, opts: RHash) -> Result<LogStream, Error> {
+        let log_opts = parse_log_stream_options(opts)?;
+        let stream = block_on(self.inner.log_stream(&log_opts)).map_err(error::to_ruby)?;
+        Ok(LogStream::from_stream(stream))
     }
 
     //----------------------------------------------------------------------
@@ -311,6 +428,81 @@ impl Sandbox {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Enum / rlimit parsing (string conventions mirror the Python/Go SDKs)
+//--------------------------------------------------------------------------------------------------
+
+fn log_level_from_str(s: &str) -> Result<LogLevel, Error> {
+    match s {
+        "error" => Ok(LogLevel::Error),
+        "warn" => Ok(LogLevel::Warn),
+        "info" => Ok(LogLevel::Info),
+        "debug" => Ok(LogLevel::Debug),
+        "trace" => Ok(LogLevel::Trace),
+        other => Err(error::base_error(format!(
+            "unknown log level {other:?} (expected error/warn/info/debug/trace)"
+        ))),
+    }
+}
+
+fn pull_policy_from_str(s: &str) -> Result<PullPolicy, Error> {
+    match s {
+        "always" => Ok(PullPolicy::Always),
+        "if-missing" | "if_missing" => Ok(PullPolicy::IfMissing),
+        "never" => Ok(PullPolicy::Never),
+        other => Err(error::base_error(format!(
+            "unknown pull policy {other:?} (expected always/if-missing/never)"
+        ))),
+    }
+}
+
+fn security_profile_from_str(s: &str) -> Result<SecurityProfile, Error> {
+    match s {
+        "default" => Ok(SecurityProfile::Default),
+        "restricted" => Ok(SecurityProfile::Restricted),
+        other => Err(error::base_error(format!(
+            "unknown security profile {other:?} (expected default/restricted)"
+        ))),
+    }
+}
+
+fn rlimit_resource_from_str(s: &str) -> Result<RlimitResource, Error> {
+    use RlimitResource::*;
+    Ok(match s {
+        "cpu" => Cpu,
+        "fsize" => Fsize,
+        "data" => Data,
+        "stack" => Stack,
+        "core" => Core,
+        "rss" => Rss,
+        "nproc" => Nproc,
+        "nofile" => Nofile,
+        "memlock" => Memlock,
+        "as" => As,
+        "locks" => Locks,
+        "sigpending" => Sigpending,
+        "msgqueue" => Msgqueue,
+        "nice" => Nice,
+        "rtprio" => Rtprio,
+        "rttime" => Rttime,
+        other => {
+            return Err(error::base_error(format!(
+                "unknown rlimit resource {other:?}"
+            )))
+        }
+    })
+}
+
+/// Parse the `rlimits` option — normalized by the Ruby layer to
+/// `[[resource, soft, hard], …]` triples — into core (resource, soft, hard).
+fn parse_rlimits(opts: RHash) -> Result<Vec<(RlimitResource, u64, u64)>, Error> {
+    let mut out = Vec::new();
+    for triple in conv::opt::<Vec<(String, u64, u64)>>(opts, "rlimits")?.unwrap_or_default() {
+        out.push((rlimit_resource_from_str(&triple.0)?, triple.1, triple.2));
+    }
+    Ok(out)
+}
+
+//--------------------------------------------------------------------------------------------------
 // Exec option parsing
 //--------------------------------------------------------------------------------------------------
 
@@ -322,6 +514,7 @@ struct ExecOpts {
     timeout: Option<Duration>,
     tty: bool,
     stdin: Option<Vec<u8>>,
+    rlimits: Vec<(RlimitResource, u64, u64)>,
 }
 
 impl ExecOpts {
@@ -335,6 +528,7 @@ impl ExecOpts {
             timeout: conv::opt_f64(opts, "timeout")?.map(Duration::from_secs_f64),
             tty: conv::opt_bool(opts, "tty")?,
             stdin,
+            rlimits: parse_rlimits(opts)?,
         })
     }
 
@@ -362,6 +556,9 @@ impl ExecOpts {
         }
         if let Some(stdin) = self.stdin {
             b = b.stdin_bytes(stdin);
+        }
+        for (resource, soft, hard) in self.rlimits {
+            b = b.rlimit_range(resource, soft, hard);
         }
         b
     }
@@ -430,7 +627,7 @@ fn fs_metadata_to_hash(meta: &FsMetadata) -> RHash {
     hash
 }
 
-fn metrics_to_hash(m: &SandboxMetrics) -> RHash {
+pub(crate) fn metrics_to_hash(m: &SandboxMetrics) -> RHash {
     let hash = ruby().hash_new();
     let _ = hash.aset("cpu_percent", m.cpu_percent as f64);
     let _ = hash.aset("vcpu_time_ns", m.vcpu_time_ns);
@@ -455,6 +652,17 @@ fn sandbox_status_str(status: SandboxStatus) -> &'static str {
         SandboxStatus::Stopped => "stopped",
         SandboxStatus::Crashed => "crashed",
     }
+}
+
+fn stop_result_to_hash(result: &SandboxStopResult) -> RHash {
+    let hash = ruby().hash_new();
+    let _ = hash.aset("name", result.name.clone());
+    let _ = hash.aset("status", sandbox_status_str(result.status));
+    let _ = hash.aset("exit_code", result.exit_code);
+    let _ = hash.aset("signal", result.signal);
+    let _ = hash.aset("observed_at_ms", result.observed_at.timestamp_millis());
+    let _ = hash.aset("source", result.source.clone());
+    hash
 }
 
 fn handle_to_hash(handle: &SandboxHandle) -> RHash {
@@ -513,7 +721,28 @@ fn parse_log_options(opts: RHash) -> Result<LogOptions, Error> {
     })
 }
 
-fn log_entry_to_hash(entry: &LogEntry) -> RHash {
+fn parse_log_stream_options(opts: RHash) -> Result<LogStreamOptions, Error> {
+    // `from_cursor` takes precedence over `since_ms` (the two are mutually
+    // exclusive in the official SDKs); absent both, start at the beginning.
+    let start = if let Some(cursor) = conv::opt_string(opts, "from_cursor")? {
+        let parsed: LogCursor = cursor
+            .parse()
+            .map_err(|_| error::base_error(format!("invalid log cursor {cursor:?}")))?;
+        LogStreamStart::From(parsed)
+    } else if let Some(since) = conv::opt_f64(opts, "since_ms")?.and_then(ms_to_datetime) {
+        LogStreamStart::Since(since)
+    } else {
+        LogStreamStart::Beginning
+    };
+    Ok(LogStreamOptions {
+        sources: parse_log_sources(opts)?,
+        start,
+        until: conv::opt_f64(opts, "until_ms")?.and_then(ms_to_datetime),
+        follow: conv::opt_bool(opts, "follow")?,
+    })
+}
+
+pub(crate) fn log_entry_to_hash(entry: &LogEntry) -> RHash {
     let source = match entry.source {
         LogSource::Stdout => "stdout",
         LogSource::Stderr => "stderr",
@@ -541,6 +770,7 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     class.define_singleton_method("start", function!(Sandbox::start, 2))?;
     class.define_singleton_method("get", function!(Sandbox::get, 1))?;
     class.define_singleton_method("list", function!(Sandbox::list, 0))?;
+    class.define_singleton_method("list_with", function!(Sandbox::list_with, 1))?;
     class.define_singleton_method("remove", function!(Sandbox::remove, 1))?;
 
     class.define_method("name", method!(Sandbox::name, 0))?;
@@ -550,8 +780,19 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     class.define_method("shell_stream", method!(Sandbox::shell_stream, 2))?;
     class.define_method("stop", method!(Sandbox::stop, 1))?;
     class.define_method("kill", method!(Sandbox::kill, 1))?;
+    class.define_method("request_stop", method!(Sandbox::request_stop, 0))?;
+    class.define_method("request_kill", method!(Sandbox::request_kill, 0))?;
+    class.define_method("request_drain", method!(Sandbox::request_drain, 0))?;
+    class.define_method(
+        "wait_until_stopped",
+        method!(Sandbox::wait_until_stopped, 0),
+    )?;
+    class.define_method("owns_lifecycle", method!(Sandbox::owns_lifecycle, 0))?;
+    class.define_method("detach", method!(Sandbox::detach, 0))?;
     class.define_method("metrics", method!(Sandbox::metrics, 0))?;
+    class.define_method("metrics_stream", method!(Sandbox::metrics_stream, 1))?;
     class.define_method("logs", method!(Sandbox::logs, 1))?;
+    class.define_method("log_stream", method!(Sandbox::log_stream, 1))?;
 
     class.define_method("fs_read", method!(Sandbox::fs_read, 1))?;
     class.define_method("fs_read_text", method!(Sandbox::fs_read_text, 1))?;

--- a/ext/microsandbox/src/snapshot.rs
+++ b/ext/microsandbox/src/snapshot.rs
@@ -1,0 +1,158 @@
+//! Snapshot management: `Microsandbox::Native::Snapshot`.
+//!
+//! Snapshots capture a stopped sandbox's upper layer into a portable artifact
+//! that a later `Sandbox.create(from_snapshot:)` can boot from. Exposed as
+//! singleton functions returning plain Hashes/Arrays (shaped into value objects
+//! by the Ruby layer) — there is no long-lived handle to own.
+
+use std::path::PathBuf;
+
+use magnus::{function, prelude::*, Error, RArray, RHash, RModule, Ruby};
+use microsandbox::snapshot::{
+    ExportOpts, Snapshot, SnapshotDestination, SnapshotFormat, SnapshotHandle,
+    SnapshotVerifyReport, UpperVerifyStatus,
+};
+
+use crate::conv;
+use crate::error;
+use crate::runtime::{block_on, ruby};
+
+fn format_str(format: SnapshotFormat) -> &'static str {
+    match format {
+        SnapshotFormat::Raw => "raw",
+        SnapshotFormat::Qcow2 => "qcow2",
+    }
+}
+
+/// Create a snapshot of a stopped sandbox. `opts`: name | path (destination),
+/// labels, force, record_integrity. Returns {digest, path, size_bytes}.
+fn create(source_sandbox: String, opts: RHash) -> Result<RHash, Error> {
+    let mut b = Snapshot::builder(source_sandbox);
+    if let Some(name) = conv::opt_string(opts, "name")? {
+        b = b.destination(SnapshotDestination::Name(name));
+    } else if let Some(path) = conv::opt_string(opts, "path")? {
+        b = b.destination(SnapshotDestination::Path(PathBuf::from(path)));
+    } else {
+        return Err(error::base_error(
+            "snapshot create needs a destination: pass name: or path:",
+        ));
+    }
+    for (k, v) in conv::opt_string_map(opts, "labels")? {
+        b = b.label(k, v);
+    }
+    if conv::opt_bool(opts, "force")? {
+        b = b.force();
+    }
+    if conv::opt_bool(opts, "record_integrity")? {
+        b = b.record_integrity();
+    }
+
+    let snap = block_on(b.create()).map_err(error::to_ruby)?;
+    let hash = ruby().hash_new();
+    hash.aset("digest", snap.digest().to_string())?;
+    hash.aset("path", snap.path().to_string_lossy().into_owned())?;
+    hash.aset("size_bytes", snap.size_bytes())?;
+    Ok(hash)
+}
+
+/// Metadata for one snapshot by name or digest.
+fn get(name_or_digest: String) -> Result<RHash, Error> {
+    let handle = block_on(Snapshot::get(&name_or_digest)).map_err(error::to_ruby)?;
+    Ok(handle_to_hash(&handle))
+}
+
+/// All snapshots as metadata hashes.
+fn list() -> Result<RArray, Error> {
+    let handles = block_on(Snapshot::list()).map_err(error::to_ruby)?;
+    let arr = ruby().ary_new();
+    for h in &handles {
+        arr.push(handle_to_hash(h))?;
+    }
+    Ok(arr)
+}
+
+/// Remove a snapshot artifact by name or path.
+fn remove(name_or_path: String, force: bool) -> Result<(), Error> {
+    block_on(Snapshot::remove(&name_or_path, force)).map_err(error::to_ruby)
+}
+
+/// Verify a snapshot's recorded upper-layer integrity. Returns
+/// {digest, path, upper_status, upper_algorithm?, upper_digest?}.
+fn verify(name_or_path: String) -> Result<RHash, Error> {
+    let snap = block_on(Snapshot::open(&name_or_path)).map_err(error::to_ruby)?;
+    let report = block_on(snap.verify()).map_err(error::to_ruby)?;
+    Ok(verify_report_to_hash(&report))
+}
+
+/// Bundle a snapshot into a `.tar.zst` (or plain `.tar`) archive. `opts`:
+/// with_parents, with_image, plain_tar.
+fn export(name_or_path: String, out_path: String, opts: RHash) -> Result<(), Error> {
+    let export_opts = ExportOpts {
+        with_parents: conv::opt_bool(opts, "with_parents")?,
+        with_image: conv::opt_bool(opts, "with_image")?,
+        plain_tar: conv::opt_bool(opts, "plain_tar")?,
+    };
+    block_on(Snapshot::export(
+        &name_or_path,
+        std::path::Path::new(&out_path),
+        export_opts,
+    ))
+    .map_err(error::to_ruby)
+}
+
+/// Unpack a snapshot archive into the snapshots dir. Returns the imported
+/// snapshot's metadata hash. `dest` is an optional explicit directory.
+fn import(archive_path: String, dest: Option<String>) -> Result<RHash, Error> {
+    let dest_path = dest.map(PathBuf::from);
+    let handle = block_on(Snapshot::import(
+        std::path::Path::new(&archive_path),
+        dest_path.as_deref(),
+    ))
+    .map_err(error::to_ruby)?;
+    Ok(handle_to_hash(&handle))
+}
+
+fn handle_to_hash(handle: &SnapshotHandle) -> RHash {
+    let hash = ruby().hash_new();
+    let _ = hash.aset("digest", handle.digest().to_string());
+    let _ = hash.aset("name", handle.name().map(str::to_string));
+    let _ = hash.aset("parent_digest", handle.parent_digest().map(str::to_string));
+    let _ = hash.aset("image_ref", handle.image_ref().to_string());
+    let _ = hash.aset("format", format_str(handle.format()));
+    let _ = hash.aset("size_bytes", handle.size_bytes());
+    let _ = hash.aset("path", handle.path().to_string_lossy().into_owned());
+    let _ = hash.aset(
+        "created_at_ms",
+        handle.created_at().and_utc().timestamp_millis(),
+    );
+    hash
+}
+
+fn verify_report_to_hash(report: &SnapshotVerifyReport) -> RHash {
+    let hash = ruby().hash_new();
+    let _ = hash.aset("digest", report.digest.clone());
+    let _ = hash.aset("path", report.path.to_string_lossy().into_owned());
+    match &report.upper {
+        UpperVerifyStatus::NotRecorded => {
+            let _ = hash.aset("upper_status", "not_recorded");
+        }
+        UpperVerifyStatus::Verified { algorithm, digest } => {
+            let _ = hash.aset("upper_status", "verified");
+            let _ = hash.aset("upper_algorithm", algorithm.clone());
+            let _ = hash.aset("upper_digest", digest.clone());
+        }
+    }
+    hash
+}
+
+pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
+    let class = native.define_class("Snapshot", ruby.class_object())?;
+    class.define_singleton_method("create", function!(create, 2))?;
+    class.define_singleton_method("get", function!(get, 1))?;
+    class.define_singleton_method("list", function!(list, 0))?;
+    class.define_singleton_method("remove", function!(remove, 2))?;
+    class.define_singleton_method("verify", function!(verify, 1))?;
+    class.define_singleton_method("export", function!(export, 3))?;
+    class.define_singleton_method("import", function!(import, 2))?;
+    Ok(())
+}

--- a/ext/microsandbox/src/stream.rs
+++ b/ext/microsandbox/src/stream.rs
@@ -1,0 +1,86 @@
+//! Streaming logs and metrics: `Microsandbox::Native::LogStream` and
+//! `Microsandbox::Native::MetricsStream`.
+//!
+//! Mirrors the `ExecHandle` streaming pattern in `exec.rs`. The core
+//! `log_stream`/`metrics_stream` return `impl Stream`; we box+pin each into an
+//! `Arc<tokio::Mutex<…>>` and expose a synchronous `recv` that drives the next
+//! item to completion with the GVL released, returning a Ruby Hash (or `nil` at
+//! end of stream). The Ruby layer wraps each as an `Enumerable`.
+
+use std::pin::Pin;
+use std::sync::Arc;
+
+use futures::Stream;
+use magnus::{method, prelude::*, Error, RHash, RModule, Ruby};
+use microsandbox::logs::LogEntry;
+use microsandbox::sandbox::SandboxMetrics;
+use microsandbox::MicrosandboxResult;
+use tokio::sync::Mutex;
+
+use crate::error;
+use crate::runtime::block_on;
+use crate::sandbox::{log_entry_to_hash, metrics_to_hash};
+
+type BoxStream<T> = Pin<Box<dyn Stream<Item = MicrosandboxResult<T>> + Send>>;
+
+#[magnus::wrap(class = "Microsandbox::Native::LogStream", free_immediately, size)]
+pub struct LogStream {
+    inner: Arc<Mutex<BoxStream<LogEntry>>>,
+}
+
+impl LogStream {
+    pub fn from_stream(
+        stream: impl Stream<Item = MicrosandboxResult<LogEntry>> + Send + 'static,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Box::pin(stream))),
+        }
+    }
+
+    /// Next log entry as a Hash, or nil when the stream ends.
+    fn recv(&self) -> Result<Option<RHash>, Error> {
+        use futures::StreamExt;
+        let inner = Arc::clone(&self.inner);
+        match block_on(async move { inner.lock().await.next().await }) {
+            Some(Ok(entry)) => Ok(Some(log_entry_to_hash(&entry))),
+            Some(Err(e)) => Err(error::to_ruby(e)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[magnus::wrap(class = "Microsandbox::Native::MetricsStream", free_immediately, size)]
+pub struct MetricsStream {
+    inner: Arc<Mutex<BoxStream<SandboxMetrics>>>,
+}
+
+impl MetricsStream {
+    pub fn from_stream(
+        stream: impl Stream<Item = MicrosandboxResult<SandboxMetrics>> + Send + 'static,
+    ) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Box::pin(stream))),
+        }
+    }
+
+    /// Next metrics snapshot as a Hash, or nil when the stream ends.
+    fn recv(&self) -> Result<Option<RHash>, Error> {
+        use futures::StreamExt;
+        let inner = Arc::clone(&self.inner);
+        match block_on(async move { inner.lock().await.next().await }) {
+            Some(Ok(metrics)) => Ok(Some(metrics_to_hash(&metrics))),
+            Some(Err(e)) => Err(error::to_ruby(e)),
+            None => Ok(None),
+        }
+    }
+}
+
+pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
+    let logs = native.define_class("LogStream", ruby.class_object())?;
+    logs.define_method("recv", method!(LogStream::recv, 0))?;
+
+    let metrics = native.define_class("MetricsStream", ruby.class_object())?;
+    metrics.define_method("recv", method!(MetricsStream::recv, 0))?;
+
+    Ok(())
+}

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -18,8 +18,10 @@ require_relative "microsandbox/exec_handle"
 require_relative "microsandbox/fs"
 require_relative "microsandbox/metrics"
 require_relative "microsandbox/log_entry"
+require_relative "microsandbox/streams"
 require_relative "microsandbox/image"
 require_relative "microsandbox/volume"
+require_relative "microsandbox/snapshot"
 require_relative "microsandbox/sandbox"
 
 # Microsandbox — lightweight microVM sandboxes for Ruby.
@@ -64,6 +66,13 @@ module Microsandbox
     # @return [void]
     def runtime_path=(path)
       Native.set_runtime_msb_path(path.to_s)
+    end
+
+    # Latest resource-usage snapshot for every running sandbox, keyed by name.
+    # Mirrors the official `all_sandbox_metrics`/`allSandboxMetrics` helpers.
+    # @return [Hash{String => Metrics}]
+    def all_sandbox_metrics
+      Native.all_sandbox_metrics.transform_values { |m| Metrics.new(m) }
     end
   end
 end

--- a/lib/microsandbox/errors.rb
+++ b/lib/microsandbox/errors.rb
@@ -46,6 +46,7 @@ module Microsandbox
 
   # Volume / image errors ---------------------------------------------------
   define_error(:VolumeNotFoundError, "volume-not-found")
+  define_error(:VolumeAlreadyExistsError, "volume-already-exists")
   define_error(:ImageNotFoundError, "image-not-found")
   define_error(:ImageInUseError, "image-in-use")
   define_error(:ImagePullFailedError, "image-pull-failed")

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -34,6 +34,43 @@ module Microsandbox
     end
   end
 
+  # The terminal observation of a stopped sandbox, returned by
+  # {Sandbox#wait_until_stopped}. Mirrors the official SDKs' `SandboxStopResult`.
+  class SandboxStopResult
+    # @return [String]
+    attr_reader :name
+    # @return [Symbol] :running, :draining, :paused, :stopped, or :crashed
+    attr_reader :status
+    # @return [Integer, nil] process exit code, when observed from an owned child
+    attr_reader :exit_code
+    # @return [Integer, nil] terminating signal, when observed from an owned child
+    attr_reader :signal
+    # @return [String, nil] human description of the observation source
+    attr_reader :source
+
+    def initialize(data)
+      @name = data["name"]
+      @status = data["status"].to_sym
+      @exit_code = data["exit_code"]
+      @signal = data["signal"]
+      @source = data["source"]
+      @observed_at_ms = data["observed_at_ms"]
+    end
+
+    def stopped? = @status == :stopped
+    def crashed? = @status == :crashed
+
+    # @return [Time] when the stopped state was observed
+    def observed_at
+      Time.at(@observed_at_ms / 1000.0)
+    end
+
+    def inspect
+      "#<Microsandbox::SandboxStopResult name=#{@name.inspect} status=#{@status}" \
+        "#{@exit_code ? " exit_code=#{@exit_code}" : ""}#{@signal ? " signal=#{@signal}" : ""}>"
+    end
+  end
+
   # A running sandbox (microVM) — the primary entry point of the SDK.
   #
   # @example Block form (auto-stops on exit)
@@ -70,7 +107,21 @@ module Microsandbox
       # @param scripts [Hash, nil] named scripts to install
       # @param entrypoint [Array<String>, nil] image entrypoint override
       # @param ports [Hash, nil] host_port => guest_port TCP publications
-      # @param network ["public_only", "none", nil] network mode (default public_only)
+      # @param ports_udp [Hash, nil] host_port => guest_port UDP publications
+      # @param network ["public_only", "none", "allow_all", "non_local", nil] network
+      #   policy preset (default public_only)
+      # @param log_level ["error","warn","info","debug","trace", nil] guest log verbosity
+      # @param quiet_logs [Boolean] suppress sandbox process logs
+      # @param security ["default", "restricted", nil] exec security profile
+      # @param oci_upper_size [Integer, nil] writable upper-layer size cap, in MiB
+      # @param max_duration [Integer, nil] hard wall-clock lifetime, in seconds
+      # @param idle_timeout [Integer, nil] stop after this many idle seconds
+      # @param rlimits [Hash, nil] resource limits: { resource => limit } or
+      #   { resource => [soft, hard] } (e.g. { nofile: 65_535 })
+      # @param pull_policy ["always","if-missing","never", nil] image pull behavior
+      # @param secrets [Array<Hash>, nil] placeholder-protected secrets, each
+      #   { env:, value:, host: } — the value is substituted by the TLS proxy only
+      #   for the allowed host (auto-enables TLS interception)
       # @param detached [Boolean] keep running after this process exits
       # @param replace [Boolean] replace an existing sandbox with the same name
       # @param replace_with_timeout [Numeric, nil] replace, waiting up to N seconds
@@ -79,9 +130,11 @@ module Microsandbox
       def create(name,
                  image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
                  shell: nil, user: nil, hostname: nil, labels: nil, scripts: nil,
-                 entrypoint: nil, ports: nil, volumes: nil, network: nil,
-                 from_snapshot: nil, detached: false, replace: false,
-                 replace_with_timeout: nil)
+                 entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
+                 from_snapshot: nil, log_level: nil, quiet_logs: false, security: nil,
+                 oci_upper_size: nil, max_duration: nil, idle_timeout: nil, rlimits: nil,
+                 pull_policy: nil, secrets: nil,
+                 detached: false, replace: false, replace_with_timeout: nil)
         opts = {}
         opts["image"] = image.to_s if image
         opts["from_snapshot"] = from_snapshot.to_s if from_snapshot
@@ -96,8 +149,18 @@ module Microsandbox
         opts["scripts"] = stringify(scripts) if scripts
         opts["entrypoint"] = Array(entrypoint).map(&:to_s) if entrypoint
         opts["ports"] = intify_ports(ports) if ports
+        opts["ports_udp"] = intify_ports(ports_udp) if ports_udp
         opts["volumes"] = normalize_volumes(volumes) if volumes
         opts["network"] = network.to_s if network
+        opts["log_level"] = log_level.to_s if log_level
+        opts["quiet_logs"] = true if quiet_logs
+        opts["security"] = security.to_s if security
+        opts["oci_upper_size"] = Integer(oci_upper_size) if oci_upper_size
+        opts["max_duration"] = Integer(max_duration) if max_duration
+        opts["idle_timeout"] = Integer(idle_timeout) if idle_timeout
+        opts["rlimits"] = normalize_rlimits(rlimits) if rlimits
+        opts["pull_policy"] = pull_policy.to_s if pull_policy
+        opts["secrets"] = normalize_secrets(secrets) if secrets
         opts["detached"] = true if detached
         if replace_with_timeout
           opts["replace_with_timeout"] = Float(replace_with_timeout)
@@ -137,6 +200,14 @@ module Microsandbox
         Native::Sandbox.list.map { |info| SandboxInfo.new(info) }
       end
 
+      # List sandboxes carrying all of the given labels (AND-matched).
+      # @param labels [Hash] required key => value labels
+      # @return [Array<SandboxInfo>]
+      def list_with(labels: {})
+        opts = { "labels" => stringify(labels) }
+        Native::Sandbox.list_with(opts).map { |info| SandboxInfo.new(info) }
+      end
+
       # Remove a (stopped) sandbox by name.
       # @return [nil]
       def remove(name)
@@ -152,6 +223,30 @@ module Microsandbox
 
       def intify_ports(ports)
         ports.each_with_object({}) { |(k, v), acc| acc[Integer(k)] = Integer(v) }
+      end
+
+      # Normalize secrets into [env, value, host] triples for the native layer.
+      # Each entry is a Hash { env:, value:, host: } (string or symbol keys).
+      def normalize_secrets(secrets)
+        Array(secrets).map do |spec|
+          env = spec[:env] || spec["env"]
+          value = spec[:value] || spec["value"]
+          host = spec[:host] || spec["host"]
+          unless env && value && host
+            raise ArgumentError, "secret spec needs :env, :value, and :host (got #{spec.inspect})"
+          end
+          [env.to_s, value.to_s, host.to_s]
+        end
+      end
+
+      # Normalize an rlimits Hash into [resource, soft, hard] triples for the
+      # native layer. Each value is either a single limit (soft == hard) or a
+      # [soft, hard] pair. Shared by {Sandbox.create} and {Sandbox#exec}.
+      def normalize_rlimits(rlimits)
+        rlimits.map do |resource, limit|
+          soft, hard = limit.is_a?(Array) ? [limit[0], limit[1]] : [limit, limit]
+          [resource.to_s, Integer(soft), Integer(hard)]
+        end
       end
 
       # Normalize volumes (Hash of guest_path => spec) into [guest, kind, source]
@@ -198,31 +293,31 @@ module Microsandbox
     # @param tty [Boolean] allocate a pseudo-terminal
     # @param stdin [String, nil] data to feed to stdin
     # @return [ExecOutput]
-    def exec(command, args = [], cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil)
+    def exec(command, args = [], cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecOutput.new(@native.exec(command.to_s, Array(args).map(&:to_s),
-                                  exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:)))
+                                  exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
     end
 
     # Run a shell script (pipes, redirects, etc. allowed) and collect output.
     # @return [ExecOutput]
-    def shell(script, cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil)
+    def shell(script, cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecOutput.new(@native.shell(script.to_s,
-                                   exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:)))
+                                   exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
     end
 
     # Run a command and stream its output as it arrives.
     # @return [ExecHandle]
     # @see ExecHandle
-    def exec_stream(command, args = [], cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil)
+    def exec_stream(command, args = [], cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecHandle.new(@native.exec_stream(command.to_s, Array(args).map(&:to_s),
-                                         exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:)))
+                                         exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
     end
 
     # Run a shell script and stream its output as it arrives.
     # @return [ExecHandle]
-    def shell_stream(script, cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil)
+    def shell_stream(script, cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecHandle.new(@native.shell_stream(script.to_s,
-                                          exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:)))
+                                          exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
     end
 
     # Guest filesystem operations.
@@ -254,6 +349,34 @@ module Microsandbox
       @native.logs(opts).map { |entry| LogEntry.new(entry) }
     end
 
+    # Stream resource-usage snapshots, one per interval tick, until the sandbox
+    # stops. Requires metrics to be enabled for the sandbox.
+    # @param interval [Numeric] seconds between snapshots
+    # @return [MetricsStream] an {Enumerable} of {Metrics}
+    def metrics_stream(interval: 1.0)
+      MetricsStream.new(@native.metrics_stream(Float(interval)))
+    end
+
+    # Stream captured logs as they appear.
+    #
+    # @param sources [Array<String,Symbol>, nil] filter by source
+    #   ("stdout"/"stderr"/"output"/"system")
+    # @param since_ms [Numeric, nil] start at the first entry at/after this Unix ms
+    # @param from_cursor [String, nil] resume exactly after a prior {LogEntry#cursor}
+    #   (mutually exclusive with since_ms; takes precedence if both given)
+    # @param until_ms [Numeric, nil] stop before any entry at/after this Unix ms
+    # @param follow [Boolean] keep the stream open for new entries past current EOF
+    # @return [LogStream] an {Enumerable} of {LogEntry}
+    def log_stream(sources: nil, since_ms: nil, from_cursor: nil, until_ms: nil, follow: false)
+      opts = {}
+      opts["sources"] = Array(sources).map(&:to_s) if sources
+      opts["since_ms"] = Float(since_ms) if since_ms
+      opts["from_cursor"] = from_cursor.to_s if from_cursor
+      opts["until_ms"] = Float(until_ms) if until_ms
+      opts["follow"] = true if follow
+      LogStream.new(@native.log_stream(opts))
+    end
+
     # Gracefully stop the sandbox (and wait for it to terminate).
     # @param timeout [Numeric, nil] seconds to wait before SIGKILL
     # @return [nil]
@@ -270,13 +393,55 @@ module Microsandbox
       nil
     end
 
+    # Send the graceful-shutdown request and return immediately, without waiting
+    # for the sandbox to terminate. Pair with {#wait_until_stopped}.
+    # @return [nil]
+    def request_stop
+      @native.request_stop
+      nil
+    end
+
+    # Send the force-kill request and return immediately, without waiting.
+    # @return [nil]
+    def request_kill
+      @native.request_kill
+      nil
+    end
+
+    # Request a graceful drain and return immediately, without waiting.
+    # @return [nil]
+    def request_drain
+      @native.request_drain
+      nil
+    end
+
+    # Block until the sandbox is observed in a terminal (non-running) state.
+    # @return [SandboxStopResult]
+    def wait_until_stopped
+      SandboxStopResult.new(@native.wait_until_stopped)
+    end
+
+    # @return [Boolean] whether this handle owns the sandbox process lifecycle
+    #   (i.e. stopping it or dropping the handle terminates the sandbox)
+    def owns_lifecycle?
+      @native.owns_lifecycle
+    end
+
+    # Detach this handle: disarm the stop-on-drop safety net so the sandbox
+    # keeps running after this handle is gone (and after this process exits).
+    # @return [nil]
+    def detach
+      @native.detach
+      nil
+    end
+
     def inspect
       "#<Microsandbox::Sandbox name=#{name.inspect}>"
     end
 
     private
 
-    def exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:)
+    def exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)
       opts = {}
       opts["cwd"] = cwd.to_s if cwd
       opts["user"] = user.to_s if user
@@ -284,6 +449,12 @@ module Microsandbox
       opts["timeout"] = Float(timeout) if timeout
       opts["tty"] = true if tty
       opts["stdin"] = stdin.to_s if stdin
+      if rlimits
+        opts["rlimits"] = rlimits.map do |resource, limit|
+          soft, hard = limit.is_a?(Array) ? [limit[0], limit[1]] : [limit, limit]
+          [resource.to_s, Integer(soft), Integer(hard)]
+        end
+      end
       opts
     end
   end

--- a/lib/microsandbox/snapshot.rb
+++ b/lib/microsandbox/snapshot.rb
@@ -1,0 +1,155 @@
+# frozen_string_literal: true
+
+module Microsandbox
+  # Metadata for a snapshot artifact, returned by {Snapshot.create}/{Snapshot.get}/
+  # {Snapshot.list}/{Snapshot.import}.
+  #
+  # `digest` and `path` are always present. `create` additionally populates
+  # `size_bytes`; `get`/`list`/`import` additionally populate `name`,
+  # `parent_digest`, `image_ref`, `format`, and `created_at`.
+  class SnapshotInfo
+    # @return [String] manifest digest ("sha256:…") — the canonical identity
+    attr_reader :digest
+    # @return [String] artifact directory path
+    attr_reader :path
+    # @return [String, nil] name alias (nil for digest-only entries)
+    attr_reader :name
+    # @return [String, nil] parent snapshot digest
+    attr_reader :parent_digest
+    # @return [String, nil] source OCI image reference
+    attr_reader :image_ref
+    # @return [Integer, nil] artifact size in bytes
+    attr_reader :size_bytes
+
+    def initialize(data)
+      @digest = data["digest"]
+      @path = data["path"]
+      @name = data["name"]
+      @parent_digest = data["parent_digest"]
+      @image_ref = data["image_ref"]
+      @format = data["format"]
+      @size_bytes = data["size_bytes"]
+      @created_at_ms = data["created_at_ms"]
+    end
+
+    # @return [Symbol, nil] disk format (:raw or :qcow2)
+    def format
+      @format&.to_sym
+    end
+
+    # @return [Time, nil]
+    def created_at
+      @created_at_ms && Time.at(@created_at_ms / 1000.0)
+    end
+
+    def inspect
+      "#<Microsandbox::SnapshotInfo digest=#{@digest.inspect}#{@name ? " name=#{@name.inspect}" : ""}>"
+    end
+  end
+
+  # The result of {Snapshot.verify}.
+  class SnapshotVerifyReport
+    # @return [String] manifest digest
+    attr_reader :digest
+    # @return [String] artifact directory path
+    attr_reader :path
+    # @return [Symbol] :not_recorded or :verified
+    attr_reader :status
+    # @return [String, nil] digest algorithm (when :verified)
+    attr_reader :algorithm
+    # @return [String, nil] matched content digest (when :verified)
+    attr_reader :content_digest
+
+    def initialize(data)
+      @digest = data["digest"]
+      @path = data["path"]
+      @status = data["upper_status"].to_sym
+      @algorithm = data["upper_algorithm"]
+      @content_digest = data["upper_digest"]
+    end
+
+    # @return [Boolean] whether content integrity was recorded and matched
+    def verified? = @status == :verified
+    # @return [Boolean] whether no integrity descriptor was recorded
+    def not_recorded? = @status == :not_recorded
+  end
+
+  # Creation and management of sandbox snapshots. A snapshot captures a stopped
+  # sandbox's upper layer into a portable artifact; boot from it with
+  # `Sandbox.create(from_snapshot: "name-or-digest")`.
+  class Snapshot
+    class << self
+      # Create a snapshot of a stopped sandbox.
+      #
+      # @param source_sandbox [String] name of the (stopped) source sandbox
+      # @param name [String, nil] destination name under the snapshots dir
+      # @param path [String, nil] explicit destination directory (alternative to name)
+      # @param labels [Hash, nil] user labels
+      # @param force [Boolean] overwrite an existing artifact at the destination
+      # @param record_integrity [Boolean] compute + record upper-layer integrity
+      # @return [SnapshotInfo]
+      def create(source_sandbox, name: nil, path: nil, labels: nil, force: false, record_integrity: false)
+        opts = {}
+        opts["name"] = name.to_s if name
+        opts["path"] = path.to_s if path
+        opts["labels"] = stringify(labels) if labels
+        opts["force"] = true if force
+        opts["record_integrity"] = true if record_integrity
+        SnapshotInfo.new(Native::Snapshot.create(source_sandbox.to_s, opts))
+      end
+
+      # Metadata for a snapshot by name or digest.
+      # @return [SnapshotInfo]
+      def get(name_or_digest)
+        SnapshotInfo.new(Native::Snapshot.get(name_or_digest.to_s))
+      end
+
+      # All snapshots.
+      # @return [Array<SnapshotInfo>]
+      def list
+        Native::Snapshot.list.map { |info| SnapshotInfo.new(info) }
+      end
+
+      # Remove a snapshot artifact by name or path.
+      # @param force [Boolean] remove even if referenced
+      # @return [nil]
+      def remove(name_or_path, force: false)
+        Native::Snapshot.remove(name_or_path.to_s, force)
+        nil
+      end
+
+      # Verify a snapshot's recorded upper-layer integrity.
+      # @return [SnapshotVerifyReport]
+      def verify(name_or_path)
+        SnapshotVerifyReport.new(Native::Snapshot.verify(name_or_path.to_s))
+      end
+
+      # Bundle a snapshot into a `.tar.zst` (or plain `.tar`) archive.
+      # @param with_parents [Boolean] include ancestor snapshots
+      # @param with_image [Boolean] include OCI image artifacts (boots offline)
+      # @param plain_tar [Boolean] write an uncompressed `.tar`
+      # @return [nil]
+      def export(name_or_path, out_path, with_parents: false, with_image: false, plain_tar: false)
+        opts = {}
+        opts["with_parents"] = true if with_parents
+        opts["with_image"] = true if with_image
+        opts["plain_tar"] = true if plain_tar
+        Native::Snapshot.export(name_or_path.to_s, out_path.to_s, opts)
+        nil
+      end
+
+      # Unpack a snapshot archive into the snapshots dir.
+      # @param dest [String, nil] explicit destination directory
+      # @return [SnapshotInfo]
+      def import(archive_path, dest: nil)
+        SnapshotInfo.new(Native::Snapshot.import(archive_path.to_s, dest && dest.to_s))
+      end
+
+      private
+
+      def stringify(hash)
+        hash.each_with_object({}) { |(k, v), acc| acc[k.to_s] = v.to_s }
+      end
+    end
+  end
+end

--- a/lib/microsandbox/streams.rb
+++ b/lib/microsandbox/streams.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Microsandbox
+  # A live stream of {LogEntry}s, returned by {Sandbox#log_stream}. Enumerable:
+  # iterate to consume entries as they are appended. With `follow: true` the
+  # iteration blocks for new entries until the sandbox stops; otherwise it ends
+  # once the historical log is drained.
+  #
+  # @example
+  #   sb.log_stream(follow: true).each { |entry| print entry.text }
+  class LogStream
+    include Enumerable
+
+    def initialize(native)
+      @native = native
+    end
+
+    # @yieldparam entry [LogEntry]
+    # @return [self, Enumerator]
+    def each
+      return enum_for(:each) unless block_given?
+
+      while (entry = @native.recv)
+        yield LogEntry.new(entry)
+      end
+      self
+    end
+  end
+
+  # A live stream of {Metrics} snapshots, returned by {Sandbox#metrics_stream}.
+  # Enumerable: iteration yields one snapshot per interval tick until the
+  # sandbox stops.
+  #
+  # @example
+  #   sb.metrics_stream(interval: 0.5).each { |m| puts m.cpu_percent }
+  class MetricsStream
+    include Enumerable
+
+    def initialize(native)
+      @native = native
+    end
+
+    # @yieldparam metrics [Metrics]
+    # @return [self, Enumerator]
+    def each
+      return enum_for(:each) unless block_given?
+
+      while (snapshot = @native.recv)
+        yield Metrics.new(snapshot)
+      end
+      self
+    end
+  end
+end

--- a/microsandbox-rb.gemspec
+++ b/microsandbox-rb.gemspec
@@ -3,14 +3,17 @@
 require_relative "lib/microsandbox/version"
 
 Gem::Specification.new do |spec|
-  spec.name = "microsandbox"
+  # Gem name is "microsandbox-rb" ("microsandbox" is taken on RubyGems). The
+  # require path and Ruby module stay `microsandbox` / `Microsandbox`, so users
+  # `gem install microsandbox-rb` then `require "microsandbox"`.
+  spec.name = "microsandbox-rb"
   spec.version = Microsandbox::VERSION
-  spec.authors = ["Super Rad Company"]
-  spec.email = ["development@superrad.company"]
+  spec.authors = ["ya-luotao"]
+  spec.email = ["luotao@hey.com"]
 
   spec.summary = "Lightweight microVM sandboxes for Ruby — run AI agents and untrusted code with hardware-level isolation."
   spec.description = <<~DESC
-    The microsandbox gem provides native bindings to the microsandbox runtime via
+    The microsandbox-rb gem provides native bindings to the microsandbox runtime via
     a Rust extension (magnus). It spins up real microVMs (not containers) in under
     100ms, runs standard OCI (Docker) images, and gives you full control over
     command execution, the guest filesystem, networking, volumes, snapshots, SSH,
@@ -18,16 +21,19 @@ Gem::Specification.new do |spec|
     to connect to: the runtime is embedded directly in your process.
   DESC
 
-  spec.homepage = "https://github.com/superradcompany/microsandbox"
+  # This community gem lives in the maintainer's own repository; the upstream
+  # microsandbox runtime/engine it wraps is credited in the description and the
+  # Cargo dependency (superradcompany/microsandbox).
+  spec.homepage = "https://github.com/ya-luotao/microsandbox-rb"
   spec.license = "Apache-2.0"
   spec.required_ruby_version = ">= 3.1.0"
   # Per-platform precompiled gems (built with rb-sys) require a recent RubyGems.
   spec.required_rubygems_version = ">= 3.3.11"
 
   spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/superradcompany/microsandbox/tree/main/sdk"
-  spec.metadata["documentation_uri"] = "https://docs.microsandbox.dev/sdk/overview"
-  spec.metadata["changelog_uri"] = "https://github.com/superradcompany/microsandbox/blob/main/CHANGELOG.md"
+  spec.metadata["source_code_uri"] = "https://github.com/ya-luotao/microsandbox-rb"
+  spec.metadata["documentation_uri"] = "https://github.com/ya-luotao/microsandbox-rb#readme"
+  spec.metadata["changelog_uri"] = "https://github.com/ya-luotao/microsandbox-rb/blob/main/CHANGELOG.md"
   spec.metadata["rubygems_mfa_required"] = "true"
   spec.metadata["cargo_crate_name"] = "microsandbox_rb"
 

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -8,6 +8,7 @@ module Microsandbox
   def self.installed?: () -> bool
   def self.runtime_path: () -> String
   def self.runtime_path=: (String path) -> void
+  def self.all_sandbox_metrics: () -> Hash[String, Metrics]
 
   class Error < StandardError
     def self.code: () -> String
@@ -24,6 +25,7 @@ module Microsandbox
   class FilesystemError < Error end
   class PathNotFoundError < Error end
   class VolumeNotFoundError < Error end
+  class VolumeAlreadyExistsError < Error end
   class ImageNotFoundError < Error end
   class ImageInUseError < Error end
   class ImagePullFailedError < Error end
@@ -120,35 +122,74 @@ module Microsandbox
     def updated_at: () -> Time?
   end
 
+  class SandboxStopResult
+    def name: () -> String
+    def status: () -> Symbol
+    def exit_code: () -> Integer?
+    def signal: () -> Integer?
+    def source: () -> String?
+    def stopped?: () -> bool
+    def crashed?: () -> bool
+    def observed_at: () -> Time
+  end
+
   class Sandbox
     def self.create: (String name, ?image: String?, ?cpus: Integer?, ?memory: Integer?,
                       ?env: Hash[untyped, untyped]?, ?workdir: String?, ?shell: String?,
                       ?user: String?, ?hostname: String?, ?labels: Hash[untyped, untyped]?,
                       ?scripts: Hash[untyped, untyped]?, ?entrypoint: Array[String]?,
-                      ?ports: Hash[untyped, untyped]?, ?volumes: Hash[untyped, untyped]?,
-                      ?network: untyped?, ?from_snapshot: String?, ?detached: bool,
+                      ?ports: Hash[untyped, untyped]?, ?ports_udp: Hash[untyped, untyped]?,
+                      ?volumes: Hash[untyped, untyped]?, ?network: untyped?, ?from_snapshot: String?,
+                      ?log_level: (String | Symbol)?, ?quiet_logs: bool, ?security: (String | Symbol)?,
+                      ?oci_upper_size: Integer?, ?max_duration: Integer?, ?idle_timeout: Integer?,
+                      ?rlimits: Hash[untyped, untyped]?, ?pull_policy: (String | Symbol)?,
+                      ?secrets: Array[Hash[untyped, untyped]]?, ?detached: bool,
                       ?replace: bool, ?replace_with_timeout: Numeric?)
                       ?{ (Sandbox) -> untyped } -> untyped
     def self.start: (String name, ?detached: bool) -> Sandbox
     def self.get: (String name) -> SandboxInfo
     def self.list: () -> Array[SandboxInfo]
+    def self.list_with: (?labels: Hash[untyped, untyped]) -> Array[SandboxInfo]
     def self.remove: (String name) -> nil
 
     def name: () -> String
     def exec: (String command, ?Array[String] args, ?cwd: String?, ?user: String?,
-               ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: String?) -> ExecOutput
+               ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: String?,
+               ?rlimits: Hash[untyped, untyped]?) -> ExecOutput
     def shell: (String script, ?cwd: String?, ?user: String?, ?env: Hash[untyped, untyped]?,
-                ?timeout: Numeric?, ?tty: bool, ?stdin: String?) -> ExecOutput
+                ?timeout: Numeric?, ?tty: bool, ?stdin: String?, ?rlimits: Hash[untyped, untyped]?) -> ExecOutput
     def exec_stream: (String command, ?Array[String] args, ?cwd: String?, ?user: String?,
-                      ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: String?) -> ExecHandle
+                      ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: String?,
+                      ?rlimits: Hash[untyped, untyped]?) -> ExecHandle
     def shell_stream: (String script, ?cwd: String?, ?user: String?, ?env: Hash[untyped, untyped]?,
-                       ?timeout: Numeric?, ?tty: bool, ?stdin: String?) -> ExecHandle
+                       ?timeout: Numeric?, ?tty: bool, ?stdin: String?, ?rlimits: Hash[untyped, untyped]?) -> ExecHandle
     def fs: () -> FS
     def metrics: () -> Metrics
     def logs: (?tail: Integer?, ?since_ms: Numeric?, ?until_ms: Numeric?,
                ?sources: Array[String | Symbol]?) -> Array[LogEntry]
+    def metrics_stream: (?interval: Numeric) -> MetricsStream
+    def log_stream: (?sources: Array[String | Symbol]?, ?since_ms: Numeric?,
+                     ?from_cursor: String?, ?until_ms: Numeric?, ?follow: bool) -> LogStream
     def stop: (?timeout: Numeric?) -> nil
     def kill: (?timeout: Numeric?) -> nil
+    def request_stop: () -> nil
+    def request_kill: () -> nil
+    def request_drain: () -> nil
+    def wait_until_stopped: () -> SandboxStopResult
+    def owns_lifecycle?: () -> bool
+    def detach: () -> nil
+  end
+
+  class LogStream
+    include Enumerable[LogEntry]
+    def each: () { (LogEntry) -> void } -> self
+            | () -> Enumerator[LogEntry, self]
+  end
+
+  class MetricsStream
+    include Enumerable[Metrics]
+    def each: () { (Metrics) -> void } -> self
+            | () -> Enumerator[Metrics, self]
   end
 
   class ExecEvent
@@ -243,5 +284,38 @@ module Microsandbox
     def self.get: (String name) -> VolumeInfo
     def self.list: () -> Array[VolumeInfo]
     def self.remove: (String name) -> nil
+  end
+
+  class SnapshotInfo
+    def digest: () -> String
+    def path: () -> String
+    def name: () -> String?
+    def parent_digest: () -> String?
+    def image_ref: () -> String?
+    def size_bytes: () -> Integer?
+    def format: () -> Symbol?
+    def created_at: () -> Time?
+  end
+
+  class SnapshotVerifyReport
+    def digest: () -> String
+    def path: () -> String
+    def status: () -> Symbol
+    def algorithm: () -> String?
+    def content_digest: () -> String?
+    def verified?: () -> bool
+    def not_recorded?: () -> bool
+  end
+
+  class Snapshot
+    def self.create: (String source_sandbox, ?name: String?, ?path: String?,
+                      ?labels: Hash[untyped, untyped]?, ?force: bool, ?record_integrity: bool) -> SnapshotInfo
+    def self.get: (String name_or_digest) -> SnapshotInfo
+    def self.list: () -> Array[SnapshotInfo]
+    def self.remove: (String name_or_path, ?force: bool) -> nil
+    def self.verify: (String name_or_path) -> SnapshotVerifyReport
+    def self.export: (String name_or_path, String out_path, ?with_parents: bool,
+                      ?with_image: bool, ?plain_tar: bool) -> nil
+    def self.import: (String archive_path, ?dest: String?) -> SnapshotInfo
   end
 end

--- a/spec/integration/lifecycle_spec.rb
+++ b/spec/integration/lifecycle_spec.rb
@@ -5,7 +5,7 @@
 # MICROSANDBOX_TEST_IMAGE), so they require a working runtime and network access
 # for the first image pull.
 RSpec.describe "Sandbox lifecycle", :integration do
-  let(:image) { ENV.fetch("MICROSANDBOX_TEST_IMAGE", "alpine") }
+  let(:image) { default_test_image }
 
   it "creates, execs, and stops via the block form" do
     captured = nil

--- a/spec/integration/roadmap_spec.rb
+++ b/spec/integration/roadmap_spec.rb
@@ -3,7 +3,7 @@
 # Real microVM integration coverage for streaming exec, images, and volumes.
 # Opt-in via MICROSANDBOX_INTEGRATION=1.
 RSpec.describe "streaming, images, volumes", :integration do
-  let(:image) { ENV.fetch("MICROSANDBOX_TEST_IMAGE", "alpine") }
+  let(:image) { default_test_image }
 
   describe "streaming exec" do
     it "streams stdout events and a terminal exit" do

--- a/spec/integration/snapshot_spec.rb
+++ b/spec/integration/snapshot_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# Real microVM integration coverage for snapshots and pull policy.
+# Opt-in via MICROSANDBOX_INTEGRATION=1.
+RSpec.describe "snapshots + pull policy", :integration do
+  let(:image) { default_test_image }
+
+  it "snapshots a stopped sandbox and boots a new one from it" do
+    src = unique_sandbox_name("rb-snapsrc")
+    snap = "rb-snap-#{Process.pid}-#{rand(100_000)}"
+    marker = "snap-data-#{rand(1_000_000)}"
+    begin
+      sb = Microsandbox::Sandbox.create(src, image: image)
+      sb.fs.write("/root/marker.txt", marker)
+      sb.stop
+
+      info = Microsandbox::Snapshot.create(src, name: snap)
+      expect(info).to be_a(Microsandbox::SnapshotInfo)
+      expect(info.digest).to start_with("sha256:")
+      expect(Microsandbox::Snapshot.list.map(&:name)).to include(snap)
+
+      report = Microsandbox::Snapshot.verify(snap)
+      expect(report).to be_a(Microsandbox::SnapshotVerifyReport)
+
+      Microsandbox::Sandbox.create(unique_sandbox_name("rb-snapboot"), from_snapshot: snap) do |sb2|
+        expect(sb2.fs.read_text("/root/marker.txt")).to eq(marker)
+      end
+    ensure
+      Microsandbox::Snapshot.remove(snap, force: true) rescue Microsandbox::Error
+      Microsandbox::Sandbox.remove(src) rescue Microsandbox::Error
+    end
+  end
+
+  it "boots with pull_policy: never from the local cache" do
+    # The image is already cached by earlier specs; never must not hit a registry.
+    Microsandbox::Sandbox.create(unique_sandbox_name, image: image, pull_policy: "never") do |sb|
+      expect(sb.exec("true")).to be_success
+    end
+  end
+end

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+# Real microVM integration coverage for the lifecycle-control and streaming
+# surface added on top of the initial release. Opt-in via MICROSANDBOX_INTEGRATION=1.
+RSpec.describe "lifecycle controls + streaming", :integration do
+  let(:image) { default_test_image }
+
+  describe "async lifecycle" do
+    it "owns_lifecycle? is true and wait_until_stopped reports a terminal result" do
+      sb = Microsandbox::Sandbox.create(unique_sandbox_name, image: image)
+      begin
+        expect(sb.owns_lifecycle?).to be(true)
+        sb.request_stop
+        result = sb.wait_until_stopped
+        expect(result).to be_a(Microsandbox::SandboxStopResult)
+        expect(result.status).to be_a(Symbol)
+        expect(result.observed_at).to be_a(Time)
+      ensure
+        # The sandbox is already stopped by wait_until_stopped; a best-effort
+        # kill here just guards against an early failure leaving it running.
+        sb.kill rescue Microsandbox::Error
+      end
+    end
+
+    it "filters sandboxes by label via list_with" do
+      name = unique_sandbox_name
+      sb = Microsandbox::Sandbox.create(name, image: image, labels: { role: "rb-itest" })
+      begin
+        names = Microsandbox::Sandbox.list_with(labels: { role: "rb-itest" }).map(&:name)
+        expect(names).to include(name)
+        # A non-matching filter must exclude it.
+        other = Microsandbox::Sandbox.list_with(labels: { role: "nope" }).map(&:name)
+        expect(other).not_to include(name)
+      ensure
+        sb.stop
+      end
+    end
+  end
+
+  describe "metrics" do
+    it "exposes all_sandbox_metrics keyed by name" do
+      name = unique_sandbox_name
+      Microsandbox::Sandbox.create(name, image: image) do |sb|
+        sb.exec("true")
+        all = Microsandbox.all_sandbox_metrics
+        expect(all).to be_a(Hash)
+        # The running sandbox should appear with a Metrics snapshot.
+        expect(all[name]).to be_a(Microsandbox::Metrics) if all.key?(name)
+      end
+    end
+
+    it "streams metrics snapshots" do
+      Microsandbox::Sandbox.create(unique_sandbox_name, image: image) do |sb|
+        snapshot = sb.metrics_stream(interval: 0.2).first
+        expect(snapshot).to be_a(Microsandbox::Metrics)
+        expect(snapshot.uptime_secs).to be >= 0
+      end
+    end
+  end
+
+  describe "log streaming" do
+    it "streams historical log entries without follow" do
+      Microsandbox::Sandbox.create(unique_sandbox_name, image: image) do |sb|
+        sb.exec("sh", ["-c", "echo log-line-marker"])
+        entries = sb.log_stream(sources: %i[stdout output], follow: false).first(50)
+        text = entries.map(&:text).join
+        expect(text).to include("log-line-marker")
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,3 +27,11 @@ end
 def unique_sandbox_name(prefix = "rb-spec")
   "#{prefix}-#{Process.pid}-#{rand(1_000_000)}"
 end
+
+# Default OCI image for integration specs. Defaults to AWS's public ECR mirror
+# of the Docker library: anonymous docker.io pulls are rate-limited (and fail
+# with "Not authorized" in CI / unauthenticated environments), while the ECR
+# mirror needs no auth and isn't throttled. Override with MICROSANDBOX_TEST_IMAGE.
+def default_test_image
+  ENV.fetch("MICROSANDBOX_TEST_IMAGE", "public.ecr.aws/docker/library/alpine:latest")
+end

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Microsandbox error hierarchy" do
     "FilesystemError" => "filesystem-error",
     "PathNotFoundError" => "path-not-found",
     "VolumeNotFoundError" => "volume-not-found",
+    "VolumeAlreadyExistsError" => "volume-already-exists",
     "ImageNotFoundError" => "image-not-found",
     "ImageInUseError" => "image-in-use",
     "ImagePullFailedError" => "image-pull-failed",

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -43,6 +43,50 @@ RSpec.describe Microsandbox::Sandbox do
       )
     end
 
+    it "maps pull_policy and normalizes secrets into [env, value, host] triples" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x", pull_policy: "never",
+        secrets: [{ env: "OPENAI_API_KEY", value: "sk-123", host: "api.openai.com" }]
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "pull_policy" => "never",
+          "secrets" => [["OPENAI_API_KEY", "sk-123", "api.openai.com"]]
+        )
+      )
+    end
+
+    it "raises on a malformed secret spec" do
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", secrets: [{ env: "X" }])
+      end.to raise_error(ArgumentError, /:env, :value, and :host/)
+    end
+
+    it "passes the network policy preset string through" do
+      Microsandbox::Sandbox.create("box", image: "x", network: :allow_all)
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box", hash_including("network" => "allow_all")
+      )
+    end
+
+    it "normalizes the resource/limit scalar options" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x", log_level: :debug, quiet_logs: true, security: "restricted",
+        oci_upper_size: 2048, max_duration: 600, idle_timeout: 120,
+        ports_udp: { "53" => 53 }, rlimits: { nofile: 1024, cpu: [10, 20] }
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "log_level" => "debug", "quiet_logs" => true, "security" => "restricted",
+          "oci_upper_size" => 2048, "max_duration" => 600, "idle_timeout" => 120,
+          "ports_udp" => { 53 => 53 },
+          "rlimits" => [["nofile", 1024, 1024], ["cpu", 10, 20]]
+        )
+      )
+    end
+
     it "prefers replace_with_timeout over replace" do
       Microsandbox::Sandbox.create("box", image: "x", replace: true, replace_with_timeout: 5)
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
@@ -99,6 +143,14 @@ RSpec.describe Microsandbox::Sandbox do
       sb.exec("whoami")
       expect(native).to have_received(:exec).with("whoami", [], {})
     end
+
+    it "normalizes per-exec rlimits into [resource, soft, hard] triples" do
+      sb = Microsandbox::Sandbox.create("box", image: "x")
+      sb.exec("ls", [], rlimits: { nofile: 256, as: [1000, 2000] })
+      expect(native).to have_received(:exec).with(
+        "ls", [], hash_including("rlimits" => [["nofile", 256, 256], ["as", 1000, 2000]])
+      )
+    end
   end
 
   describe "#shell option mapping" do
@@ -124,5 +176,128 @@ RSpec.describe Microsandbox::Sandbox do
       expect(native).to have_received(:stop).with(3.0)
       expect(native).to have_received(:kill).with(nil)
     end
+  end
+
+  describe "async lifecycle controls" do
+    subject(:sb) { Microsandbox::Sandbox.create("box", image: "x") }
+
+    it "forwards request_stop/request_kill/request_drain and detach, returning nil" do
+      allow(native).to receive(:request_stop)
+      allow(native).to receive(:request_kill)
+      allow(native).to receive(:request_drain)
+      allow(native).to receive(:detach)
+
+      expect(sb.request_stop).to be_nil
+      expect(sb.request_kill).to be_nil
+      expect(sb.request_drain).to be_nil
+      expect(sb.detach).to be_nil
+
+      expect(native).to have_received(:request_stop)
+      expect(native).to have_received(:request_kill)
+      expect(native).to have_received(:request_drain)
+      expect(native).to have_received(:detach)
+    end
+
+    it "exposes owns_lifecycle? as a boolean predicate" do
+      allow(native).to receive(:owns_lifecycle).and_return(true)
+      expect(sb.owns_lifecycle?).to be(true)
+    end
+
+    it "wraps wait_until_stopped in a SandboxStopResult" do
+      allow(native).to receive(:wait_until_stopped).and_return(
+        "name" => "box", "status" => "stopped", "exit_code" => 0,
+        "signal" => nil, "observed_at_ms" => 1_700_000_000_000, "source" => "owned process handle"
+      )
+      result = sb.wait_until_stopped
+      expect(result).to be_a(Microsandbox::SandboxStopResult)
+      expect(result).to be_stopped
+      expect(result.exit_code).to eq(0)
+      expect(result.name).to eq("box")
+    end
+  end
+
+  describe "streaming logs/metrics" do
+    subject(:sb) { Microsandbox::Sandbox.create("box", image: "x") }
+
+    it "maps metrics_stream interval and wraps recv in Metrics" do
+      native_stream = instance_double(Microsandbox::Native::MetricsStream)
+      allow(native).to receive(:metrics_stream).and_return(native_stream)
+      allow(native_stream).to receive(:recv).and_return(
+        {
+          "cpu_percent" => 5.0, "vcpu_time_ns" => 1, "memory_bytes" => 2,
+          "memory_available_bytes" => nil, "memory_host_resident_bytes" => nil,
+          "memory_limit_bytes" => 4, "disk_read_bytes" => 0, "disk_write_bytes" => 0,
+          "net_rx_bytes" => 0, "net_tx_bytes" => 0, "uptime_secs" => 1.0,
+          "timestamp_ms" => 1_700_000_000_000
+        },
+        nil
+      )
+      stream = sb.metrics_stream(interval: 0.5)
+      expect(native).to have_received(:metrics_stream).with(0.5)
+      snapshots = stream.to_a
+      expect(snapshots.size).to eq(1)
+      expect(snapshots.first).to be_a(Microsandbox::Metrics)
+      expect(snapshots.first.cpu_percent).to eq(5.0)
+    end
+
+    it "normalizes log_stream options and wraps recv in LogEntry" do
+      native_stream = instance_double(Microsandbox::Native::LogStream)
+      allow(native).to receive(:log_stream).and_return(native_stream)
+      allow(native_stream).to receive(:recv).and_return(
+        { "timestamp_ms" => 1_700_000_000_000, "source" => "stdout",
+          "session_id" => 1, "cursor" => "abc", "data" => "hi".b },
+        nil
+      )
+      stream = sb.log_stream(sources: [:stdout, "stderr"], since_ms: 1000, until_ms: 2000, follow: true)
+      expect(native).to have_received(:log_stream).with(
+        hash_including("sources" => %w[stdout stderr], "since_ms" => 1000.0,
+                       "until_ms" => 2000.0, "follow" => true)
+      )
+      entries = stream.to_a
+      expect(entries.first).to be_a(Microsandbox::LogEntry)
+      expect(entries.first.text).to eq("hi")
+    end
+
+    it "prefers from_cursor and returns an Enumerator without a block" do
+      native_stream = instance_double(Microsandbox::Native::LogStream)
+      allow(native).to receive(:log_stream).and_return(native_stream)
+      sb.log_stream(from_cursor: "cursor-token")
+      expect(native).to have_received(:log_stream).with(
+        hash_including("from_cursor" => "cursor-token")
+      )
+      expect(Microsandbox::LogStream.new(native_stream).each).to be_a(Enumerator)
+    end
+  end
+
+  describe ".list_with" do
+    it "normalizes label filters into a string-keyed labels hash" do
+      allow(Microsandbox::Native::Sandbox).to receive(:list_with).and_return(
+        [{ "name" => "box", "status" => "running" }]
+      )
+      infos = Microsandbox::Sandbox.list_with(labels: { team: :core })
+      expect(Microsandbox::Native::Sandbox).to have_received(:list_with).with(
+        "labels" => { "team" => "core" }
+      )
+      expect(infos.first).to be_a(Microsandbox::SandboxInfo)
+      expect(infos.first.name).to eq("box")
+    end
+  end
+end
+
+RSpec.describe "Microsandbox.all_sandbox_metrics" do
+  it "wraps each per-sandbox metrics hash in a Metrics object" do
+    allow(Microsandbox::Native).to receive(:all_sandbox_metrics).and_return(
+      "box" => {
+        "cpu_percent" => 12.5, "vcpu_time_ns" => 1, "memory_bytes" => 2,
+        "memory_available_bytes" => nil, "memory_host_resident_bytes" => nil,
+        "memory_limit_bytes" => 4, "disk_read_bytes" => 0, "disk_write_bytes" => 0,
+        "net_rx_bytes" => 0, "net_tx_bytes" => 0, "uptime_secs" => 1.0,
+        "timestamp_ms" => 1_700_000_000_000
+      }
+    )
+    metrics = Microsandbox.all_sandbox_metrics
+    expect(metrics.keys).to eq(["box"])
+    expect(metrics["box"]).to be_a(Microsandbox::Metrics)
+    expect(metrics["box"].cpu_percent).to eq(12.5)
   end
 end

--- a/spec/unit/snapshot_spec.rb
+++ b/spec/unit/snapshot_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+# Pure-Ruby option-normalization + value-object coverage for Microsandbox::Snapshot.
+# The native layer is stubbed; real behaviour is exercised by the integration specs.
+RSpec.describe Microsandbox::Snapshot do
+  describe ".create" do
+    it "normalizes destination/labels/flags into a string-keyed options hash" do
+      allow(Microsandbox::Native::Snapshot).to receive(:create).and_return(
+        "digest" => "sha256:abc", "path" => "/snaps/x", "size_bytes" => 2048
+      )
+      info = described_class.create("box", name: "snap1", labels: { kind: :base },
+                                    force: true, record_integrity: true)
+      expect(Microsandbox::Native::Snapshot).to have_received(:create).with(
+        "box",
+        hash_including("name" => "snap1", "labels" => { "kind" => "base" },
+                       "force" => true, "record_integrity" => true)
+      )
+      expect(info).to be_a(Microsandbox::SnapshotInfo)
+      expect(info.digest).to eq("sha256:abc")
+      expect(info.size_bytes).to eq(2048)
+    end
+
+    it "passes path when given instead of name" do
+      allow(Microsandbox::Native::Snapshot).to receive(:create).and_return(
+        "digest" => "sha256:abc", "path" => "/tmp/snap"
+      )
+      described_class.create("box", path: "/tmp/snap")
+      expect(Microsandbox::Native::Snapshot).to have_received(:create).with(
+        "box", hash_including("path" => "/tmp/snap")
+      )
+    end
+  end
+
+  describe ".list / .get" do
+    it "wraps handles in SnapshotInfo with parsed format and timestamp" do
+      allow(Microsandbox::Native::Snapshot).to receive(:list).and_return(
+        [{ "digest" => "sha256:d", "path" => "/p", "name" => "s", "image_ref" => "alpine",
+           "format" => "qcow2", "size_bytes" => 10, "created_at_ms" => 1_700_000_000_000 }]
+      )
+      info = described_class.list.first
+      expect(info.name).to eq("s")
+      expect(info.format).to eq(:qcow2)
+      expect(info.created_at).to be_a(Time)
+    end
+  end
+
+  describe ".verify" do
+    it "maps a verified report" do
+      allow(Microsandbox::Native::Snapshot).to receive(:verify).and_return(
+        "digest" => "sha256:d", "path" => "/p", "upper_status" => "verified",
+        "upper_algorithm" => "sha256", "upper_digest" => "deadbeef"
+      )
+      report = described_class.verify("snap1")
+      expect(report).to be_verified
+      expect(report.algorithm).to eq("sha256")
+      expect(report.content_digest).to eq("deadbeef")
+    end
+
+    it "maps a not-recorded report" do
+      allow(Microsandbox::Native::Snapshot).to receive(:verify).and_return(
+        "digest" => "sha256:d", "path" => "/p", "upper_status" => "not_recorded"
+      )
+      expect(described_class.verify("snap1")).to be_not_recorded
+    end
+  end
+
+  describe ".remove / .export / .import" do
+    it "forwards remove with the force flag" do
+      allow(Microsandbox::Native::Snapshot).to receive(:remove)
+      described_class.remove("snap1", force: true)
+      expect(Microsandbox::Native::Snapshot).to have_received(:remove).with("snap1", true)
+    end
+
+    it "normalizes export flags" do
+      allow(Microsandbox::Native::Snapshot).to receive(:export)
+      described_class.export("snap1", "/tmp/out.tar.zst", with_parents: true, with_image: true)
+      expect(Microsandbox::Native::Snapshot).to have_received(:export).with(
+        "snap1", "/tmp/out.tar.zst", hash_including("with_parents" => true, "with_image" => true)
+      )
+    end
+
+    it "passes an optional dest to import" do
+      allow(Microsandbox::Native::Snapshot).to receive(:import).and_return(
+        "digest" => "sha256:d", "path" => "/p"
+      )
+      described_class.import("/tmp/a.tar.zst", dest: "/snaps")
+      expect(Microsandbox::Native::Snapshot).to have_received(:import).with("/tmp/a.tar.zst", "/snaps")
+    end
+  end
+end

--- a/spec/unit/value_objects_spec.rb
+++ b/spec/unit/value_objects_spec.rb
@@ -128,4 +128,21 @@ RSpec.describe "value objects" do
       expect(info.updated_at).to be_nil
     end
   end
+
+  describe Microsandbox::SandboxStopResult do
+    it "parses status/exit_code/signal and the observation timestamp" do
+      result = described_class.new(
+        "name" => "box", "status" => "crashed", "exit_code" => nil,
+        "signal" => 9, "observed_at_ms" => 1_700_000_000_000, "source" => "owned process handle"
+      )
+      expect(result.name).to eq("box")
+      expect(result.status).to eq(:crashed)
+      expect(result).to be_crashed
+      expect(result).not_to be_stopped
+      expect(result.exit_code).to be_nil
+      expect(result.signal).to eq(9)
+      expect(result.source).to eq("owned process handle")
+      expect(result.observed_at).to be_a(Time)
+    end
+  end
 end


### PR DESCRIPTION
First release of the gem as **`microsandbox-rb`** (the `microsandbox` name is taken on RubyGems; require path/module stay `microsandbox`/`Microsandbox`).

## Alignment (binds the same v0.5.7 core as the official Python/Node/Go SDKs)
- **Lifecycle**: `request_stop`/`request_kill`/`request_drain`, `wait_until_stopped` (→ `SandboxStopResult`), `detach`, `owns_lifecycle?`, `Sandbox.list_with(labels:)`, `Microsandbox.all_sandbox_metrics`
- **Streaming**: `metrics_stream` / `log_stream` (`LogStream`/`MetricsStream`, `Enumerable`)
- **Snapshots**: `Snapshot.create/get/list/remove/verify/export/import` (+ `from_snapshot:` boot)
- **Create options**: `log_level`, `quiet_logs`, `security`, `oci_upper_size`, `max_duration`, `idle_timeout`, `ports_udp`, `rlimits`, `pull_policy`, `secrets`, network presets (`allow_all`/`non_local`); per-exec `rlimits`
- **Errors**: `VolumeAlreadyExistsError`; fixed a real `metrics_stream` "no reactor running" panic (caught by live runtime testing)
- RBS signatures + unit tests for all new surface (130 unit examples)

## Verification
- **Real-microVM integration** (`spec/integration`) — exec/shell/fs/metrics/logs/streaming/snapshots round-trip on actual VMs; wired into CI on a KVM runner
- **Cross-SDK behavioral parity** — an identical-operations harness through this gem and the **official Go SDK** against the same runtime yields byte-identical results
- **Packaged-gem install** — `gem install` compiles the shipped Rust source and the installed gem boots a real microVM

## Packaging / release
- Author/email/repo URLs set to the maintainer; upstream credited in the description + Cargo dep only
- `release.yml`: fixed the OIDC publish action to `rubygems/configure-rubygems-credentials` (SHA-pinned); CI integration defaults to the AWS ECR alpine mirror to avoid docker.io rate limits

🤖 Generated with [Claude Code](https://claude.com/claude-code)