### PR TITLE
feat: registry auth + runtime auto-provision for precompiled gems

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,11 +13,30 @@ name: Release
 # Publishing uses RubyGems Trusted Publishing (OIDC); configure the gem's trusted
 # publisher to this repo + workflow in the RubyGems UI before the first release.
 #
-# NOTE: the core crate is heavy (a platform-specific build.rs that downloads the
-# msb runtime, plus native deps and Apple-native keyring on macOS). Whether the
-# `arm64-darwin` target cross-builds under osxcross in rake-compiler-dock is to be
-# confirmed on the first run; if it can't, move that platform to a native macos-14
-# runner job that builds all 3.1–3.4 ABIs into one gem.
+# What a precompiled gem ships (and what it does NOT): the gem carries the
+# compiled Rust extension with the guest-side `agentd` baked in (the core's
+# filesystem build.rs downloads agentd by *target* arch via CARGO_CFG_TARGET_ARCH
+# and embeds it with include_bytes!, so it cross-compiles correctly). The gem
+# does NOT carry the host-side `msb` runtime + `libkrunfw`: those are downloaded
+# into ~/.microsandbox on first use by `Microsandbox.ensure_runtime!` (called
+# automatically by Sandbox.create/start). That is the piece that makes precompiled
+# gems usable at all — a precompiled-gem user never ran the source build, so the
+# runtime is provisioned lazily at runtime (by the *running* host's arch) instead.
+#
+# Cross-compile reality check (corrects an earlier, pessimistic note here):
+#   - microsandbox/build.rs downloads msb + libkrunfw keyed on the *host* arch
+#     into the build container's ~/.microsandbox. That is self-consistent on the
+#     x86_64 dock host and never enters the gem, so it does NOT block the cross
+#     build — it's just wasted work. (libkrunfw is dlopen'd by msb at runtime; it
+#     is never *linked* into the extension.)
+#   - The genuine cross blockers are the *target* native libraries the extension
+#     links: libcap-ng on Linux (via the capng crate → msb_krun_devices) and the
+#     Hypervisor + Security system frameworks on macOS (HVF + Apple-native keyring).
+#     aarch64-linux therefore needs libcap-ng:arm64 (handled below via Debian
+#     multiarch); arm64-darwin needs osxcross to resolve those frameworks from the
+#     macOS SDK — that's the one platform still to confirm on first dispatch. If it
+#     can't link, move arm64-darwin to a native macos-14 runner job (which builds
+#     all 3.1–3.4 ABIs into one fat gem with no osxcross involved).
 
 on:
   push:
@@ -34,15 +53,19 @@ permissions:
 
 jobs:
   # Precompiled per-platform gems — a UX optimization (users skip the Rust
-  # compile). EXPERIMENTAL / not on the release path yet: this gem wraps a heavy
-  # core crate whose build.rs downloads platform-specific msb + libkrunfw and
-  # links libkrunfw/keyring, which doesn't cross-compile cleanly through the
-  # generic rake-compiler-dock/osxcross flow. So this job is gated to manual
-  # `workflow_dispatch` only — tag releases ship the source gem (which installs
-  # everywhere by compiling via rb_sys). Iterate on it with a manual dispatch;
-  # when it produces working gems on all platforms, re-add it to `publish.needs`
-  # and drop the workflow_dispatch gate. The `bundle install` below fixes the
-  # first blocker (Bundler::GemNotFound inside the dock container).
+  # compile). Gated to manual `workflow_dispatch`: tag releases ship the source
+  # gem (which installs everywhere by compiling via rb_sys), while precompiled
+  # gems are built best-effort here for validation. They are NOT auto-published
+  # on tags yet, because a gem that *compiles but doesn't boot a microVM* would
+  # be served to users in preference to the source gem — and CI cannot boot a VM
+  # to prove it works (no nested virt). Validate a dispatched build by installing
+  # the artifact on each real platform, then promote it (see `publish` below).
+  #
+  # cross-compile prerequisites handled below:
+  #   - bundle install: rake/rb_sys/rake-compiler inside the dock container
+  #     (else Bundler::GemNotFound).
+  #   - libcap-ng: host package for x86_64-linux; the arm64 multiarch variant for
+  #     aarch64-linux (the extension links -lcap-ng for the *target* arch).
   cross-gems:
     name: gem (${{ matrix.platform }})
     if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -67,18 +90,28 @@ jobs:
         with:
           platform: ${{ matrix.platform }}
           ruby-versions: "3.1,3.2,3.3,3.4"
-          # The core crate links libcap-ng on Linux targets, so the rake-compiler-dock
-          # container needs the dev package before the cross-build (same failure mode
-          # as CI: `cannot find -lcap-ng`). The containers are Debian-based (apt); the
-          # guard keeps the darwin container — which needs nothing — from erroring.
-          # NOTE (validate on first real release): aarch64-linux is cross-compiled, so
-          # the linker resolves libs from the target sysroot, not the host arch. The
-          # host-arch package below covers x86_64-linux; if aarch64 still fails to find
-          # -lcap-ng, enable arm64 multiarch (dpkg --add-architecture arm64) and
-          # install libcap-ng-dev:arm64 here.
+          # The extension links libcap-ng on Linux targets (capng crate →
+          # msb_krun_devices), so the rake-compiler-dock container needs the dev
+          # package before the cross-build (else `cannot find -lcap-ng`). The
+          # Linux containers are Debian-based (apt); darwin needs nothing here
+          # (its frameworks come from the osxcross macOS SDK), so the apt guard
+          # keeps it from erroring.
+          #
+          # aarch64-linux is cross-compiled from an x86_64 container: the target
+          # linker (aarch64-linux-gnu) resolves -lcap-ng from the *arm64* sysroot,
+          # not the host package — so add the arch and install libcap-ng-dev:arm64.
+          # Debian's main mirror carries every arch, so multiarch fetches work
+          # without switching to ports.ubuntu.com.
           setup: |
             if command -v apt-get >/dev/null 2>&1; then
               apt-get update && apt-get install -y libcap-ng-dev
+              case "${{ matrix.platform }}" in
+                aarch64-linux*)
+                  dpkg --add-architecture arm64
+                  apt-get update
+                  apt-get install -y libcap-ng-dev:arm64
+                  ;;
+              esac
             fi
             # The dock container runs `bundle exec rake native:<plat> gem`; install
             # the bundle (rb_sys/rake/rake-compiler) first or it fails with
@@ -107,9 +140,12 @@ jobs:
 
   publish:
     name: publish to RubyGems
-    # Only the source gem is required to publish; precompiled cross-gems are
-    # best-effort (see cross-gems above) and pushed too if they happened to
-    # build (the gem push loop globs whatever artifacts are present).
+    # On a tag push, only `source-gem` runs (cross-gems is workflow_dispatch-only),
+    # so this publishes the source gem alone — the safe default. The push loop
+    # globs every gem under dist/, so once precompiled gems are validated they can
+    # be promoted by either (a) re-adding `cross-gems` to `needs` and dropping its
+    # workflow_dispatch gate, or (b) attaching the validated artifacts to the
+    # release run. Until then, tag releases stay source-only on purpose.
     needs: [source-gem]
     runs-on: ubuntu-latest
     # Real tag pushes only — never on a manual dry run.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,25 @@ Closes the `Sandbox`-class lifecycle gap with the official Python/Node/Go SDKs.
 - CI now runs the real-microVM integration suite (`spec/integration`) on a
   KVM-enabled runner, so the Rust↔core round-trip is exercised in automation —
   not just compilation and unit tests.
+- Registry authentication for `Sandbox.create`: `registry_auth: { username:,
+  password: }` (the password may be a token) for private/authenticated
+  registries and to lift Docker Hub's anonymous rate limit, plus
+  `registry_insecure:` (plain HTTP) and `registry_ca_certs:` (a PEM String or
+  Array) for self-hosted registries. Mirrors the Python/Node `registry_auth`
+  surface; without it the core's default resolution (OS keyring, global config,
+  `~/.docker/config.json`) still applies.
+- `Microsandbox.ensure_runtime!` — provisions the `msb` runtime + `libkrunfw` on
+  first use, called automatically by `Sandbox.create`/`start`. This makes
+  **precompiled platform gems** usable without a manual `install` step (a
+  precompiled-gem user never ran the source build, so the runtime is fetched
+  lazily by the running host's arch). Opt out with `MICROSANDBOX_NO_AUTO_INSTALL`.
+
+### Changed
+
+- The `cross-gems` release job now installs `libcap-ng-dev:arm64` via Debian
+  multiarch for the `aarch64-linux` cross-build (the extension links `-lcap-ng`
+  for the target arch). Precompiled gems remain `workflow_dispatch`-only and are
+  promoted to the publish path manually after per-platform validation.
 
 ## [0.5.7] - 2026-06-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
-Closes the `Sandbox`-class lifecycle gap with the official Python/Node/Go SDKs.
+## [0.5.8] - 2026-06-17
+
+Closes the `Sandbox`-class lifecycle gap with the official Python/Node/Go SDKs
+and adds private/authenticated registry support plus first-use runtime
+auto-provisioning (the keystone for precompiled gems). Wraps the same upstream
+core (`v0.5.7`); this is a gem-only revision atop it.
 
 ### Added
 
@@ -110,4 +115,6 @@ microsandbox runtime, aligned with the official Python/Node/Go SDKs.
   core crate has Apple-native deps). Until precompiled gems are published,
   installing from source requires a Rust toolchain (stable >= 1.91).
 
+[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.8...HEAD
+[0.5.8]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.7"
+version = "0.5.8"
 dependencies = [
  "chrono",
  "futures",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -76,6 +76,15 @@ SDK-set path (`Microsandbox.runtime_path=`) → config file → workspace build 
 expose the core `setup::install`/`is_installed` for explicit, idempotent
 provisioning (mirrors the Python `install()`/`is_installed()`).
 
+Build-time provisioning only helps the **source gem**, where `build.rs` runs on
+the user's own machine. A **precompiled gem** is built in CI, so its build-time
+download lands on the CI host, not the user's — the user's `~/.microsandbox` is
+empty. `Microsandbox.ensure_runtime!` closes that gap: `Sandbox.create`/`start`
+call it to fetch the runtime on first use (by the *running* host's arch, which is
+always correct), at most once per process. `MICROSANDBOX_NO_AUTO_INSTALL` opts
+out (air-gapped hosts that provision out of band). libkrunfw is `dlopen`'d by
+`msb` at runtime and is never linked into the extension.
+
 ## Core-crate dependency (self-contained)
 
 `ext/microsandbox/Cargo.toml` depends on the core crate via a **pinned git tag**
@@ -90,14 +99,22 @@ git. The override must never be committed — it would break container builds.
 
 * **Source gem**: compiles the extension via `extconf.rb` (rb-sys
   `create_rust_makefile`); requires a Rust toolchain (MSRV below).
-* **Precompiled platform gems**: built in CI on a `vX.Y.Z` tag
+* **Precompiled platform gems**: built best-effort by the `cross-gems` job
   (`.github/workflows/release.yml`) with `oxidize-rb/cross-gem-action`
   (`rake-compiler-dock`) per `Gem::Platform`, shipping multi-ABI
   `lib/microsandbox/<ruby_abi>/` native artifacts — the same model Node uses with
-  per-platform packages. End users then install with no Rust toolchain. Published
+  per-platform packages. End users then install with no Rust toolchain, and the
+  runtime is fetched on first use (see above). The guest `agentd` is baked into
+  the extension by *target* arch (`filesystem/build.rs` uses
+  `CARGO_CFG_TARGET_ARCH` + `include_bytes!`), so it cross-compiles correctly;
+  the real cross work is linking the *target* native libs — `libcap-ng` on Linux
+  (via Debian multiarch for `aarch64-linux`) and the Hypervisor + Security
+  frameworks on macOS (via osxcross; `arm64-darwin` is the platform still to
+  confirm — if osxcross can't link them, move it to a native `macos-14` runner).
+  The job is gated to `workflow_dispatch` and **not** auto-published on tags:
+  since CI can't boot a microVM to prove a built gem actually works, gems are
+  promoted to the publish path manually after per-platform validation. Published
   to RubyGems via Trusted Publishing (OIDC). See [Releasing](README.md#releasing).
-  Whether the heavy core cross-builds for `arm64-darwin` under osxcross is
-  confirmed on first run; if not, that platform moves to a native macOS runner.
 
 ## Build requirements
 
@@ -120,14 +137,16 @@ API (`fs.read`/`write`/`list`/`mkdir`/`remove`/`stat`/…), `metrics`,
 **OCI image-cache management** (`Image.get`/`list`/`inspect`/`remove`/`prune`),
 **named volumes** (`Volume.create`/`get`/`list`/`remove` + `volumes:` mounts),
 **snapshots** (`Snapshot.create`/`get`/`list`/`remove`/`verify`/`export`/`import`
-+ `from_snapshot:` boot), `version`/`install`/`installed?`, and
-the typed error hierarchy.
++ `from_snapshot:` boot), `version`/`install`/`installed?`/`ensure_runtime!`,
+**registry auth** (`registry_auth`/`registry_insecure`/`registry_ca_certs` on
+`create`, for private/authenticated registries), and the typed error hierarchy.
 
 Create options now cover `image`, `cpus`, `memory`, `oci_upper_size`, `env`,
 `workdir`, `shell`, `user`, `hostname`, `labels`, `scripts`, `entrypoint`,
 `ports`/`ports_udp`, `volumes`, `network` policy presets
 (`public_only`/`none`/`allow_all`/`non_local`), `log_level`, `quiet_logs`,
-`security`, `max_duration`, `idle_timeout`, `rlimits`, `pull_policy`, `secrets`,
+`security`, `max_duration`, `idle_timeout`, `rlimits`, `pull_policy`,
+`registry_auth`/`registry_insecure`/`registry_ca_certs`, `secrets`,
 `from_snapshot`, `detached`, and `replace`/`replace_with_timeout`. `exec`/`shell`
 add per-call `rlimits`.
 
@@ -135,7 +154,7 @@ add per-call `rlimits`.
 
 The binding is verified at four levels:
 
-1. **Unit** (130 examples) — the Ruby layer's option normalization and value
+1. **Unit** (140 examples) — the Ruby layer's option normalization and value
    objects, with the native layer stubbed.
 2. **Real-microVM integration** (`spec/integration`, opt-in via
    `MICROSANDBOX_INTEGRATION=1`) — boots actual sandboxes and round-trips
@@ -153,7 +172,7 @@ The binding is verified at four levels:
 
 **Roadmap:** custom per-rule network policies (CIDR/domain/group allow-deny
 rules — the presets and secret-host allowances are covered), file patches,
-registry auth, interactive `attach`/`attach_shell` (host-TTY coupled — raw mode,
+interactive `attach`/`attach_shell` (host-TTY coupled — raw mode,
 SIGWINCH), SSH (`SshClient`/`SftpClient`/`SshServer`), and the raw agent client.
 The native layer is structured so these slot in module-by-module, exactly as in
 the Python binding.

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This is an **unofficial, community-maintained** Ruby implementation — not part
 
 - **Ruby** >= 3.1
 - **Linux** with KVM enabled, or **macOS** on Apple Silicon (M-series)
-- A **Rust** toolchain (stable >= 1.91) — the gem currently installs as a source
-  gem and compiles the native extension on install (precompiled per-platform
-  gems are planned; see [Releasing](#releasing))
+- A **Rust** toolchain (stable >= 1.91) — needed only when installing the source
+  gem (it compiles the native extension on install). Precompiled per-platform
+  gems, where available, require no Rust toolchain; see [Releasing](#releasing)
 
 ## Installation
 
@@ -41,15 +41,22 @@ bundle install
 gem install microsandbox-rb
 ```
 
-Installing compiles the Rust extension, so the first install takes a few minutes
-and needs a Rust toolchain on `PATH`.
+Installing the **source gem** compiles the Rust extension, so the first install
+takes a few minutes and needs a Rust toolchain (`rustc >= 1.91`) on `PATH`. When
+a **precompiled platform gem** is available for your OS/architecture, RubyGems
+picks it automatically and no Rust toolchain is required.
 
-The first build downloads the `msb` runtime and `libkrunfw` firmware into
-`~/.microsandbox`. You can (re)provision them explicitly at any time:
+Either way the `msb` runtime and `libkrunfw` firmware are provisioned into
+`~/.microsandbox` automatically on first use (the first `Sandbox.create`/`start`
+downloads them if missing). To provision ahead of time — e.g. while baking a
+container image, or to avoid the first-call latency — call `install` explicitly:
 
 ```ruby
 Microsandbox.install unless Microsandbox.installed?
 ```
+
+Set `MICROSANDBOX_NO_AUTO_INSTALL` to disable the automatic first-use download
+(e.g. on air-gapped hosts that provision the runtime out of band).
 
 ## Quick start
 
@@ -67,9 +74,9 @@ end
 > **Why `public.ecr.aws/docker/library/...`?** The examples pull from AWS's
 > public mirror of the Docker Library because anonymous **Docker Hub** pulls are
 > rate-limited and often fail with `registry error: Not authorized`. Plain short
-> names like `image: "python"` work too if you aren't rate-limited; registry
-> auth for private registries isn't exposed by the gem yet (on the roadmap), so
-> until then use a public mirror or a pre-pulled image.
+> names like `image: "python"` work too if you aren't rate-limited. For private
+> or authenticated registries (including authenticated Docker Hub), pass
+> `registry_auth:` — see [Private & authenticated registries](#private--authenticated-registries).
 
 ## Usage
 
@@ -205,6 +212,38 @@ report = Microsandbox::Image.prune
 report.bytes_reclaimed
 ```
 
+### Private & authenticated registries
+
+Images are pulled automatically on `create`. For a private registry — or to lift
+Docker Hub's anonymous rate limit — pass `registry_auth:` with a username and a
+password or token:
+
+```ruby
+Microsandbox::Sandbox.create(
+  "private",
+  image: "registry.example.com/team/app:latest",
+  registry_auth: { username: "ci-bot", password: ENV.fetch("REGISTRY_TOKEN") }
+) do |sb|
+  # ...
+end
+```
+
+For self-hosted registries you can also reach the registry over plain HTTP and
+trust a private CA:
+
+```ruby
+Microsandbox::Sandbox.create(
+  "internal",
+  image: "registry.internal:5000/app:latest",
+  registry_insecure: true,                                  # plain HTTP instead of HTTPS
+  registry_ca_certs: File.read("/etc/pki/internal-ca.pem")  # String or Array of PEMs
+)
+```
+
+Without `registry_auth:`, the core's default credential resolution still applies
+(OS keyring, global config, and `~/.docker/config.json`), so an existing
+`docker login` is honored automatically.
+
 ### Named volumes
 
 Persistent storage that outlives individual sandboxes:
@@ -317,15 +356,20 @@ one bound to the gem.
    via `rubygems/configure-rubygems-credentials` (OIDC, `id-token: write`) — no
    `RUBYGEMS_API_KEY` secret required.
 
-> **Precompiled per-platform gems** are not on the release path yet — this gem
-> wraps a heavy core crate whose `build.rs` downloads platform-specific `msb` +
-> `libkrunfw` binaries and links `libkrunfw`/keyring, which doesn't
-> cross-compile cleanly through the generic `rake-compiler-dock`/osxcross flow.
-> The `cross-gems` job is gated to manual `workflow_dispatch` so you can iterate
-> on it (`gh workflow run release.yml`) without failing tag releases. Once it
-> produces working gems on all platforms, re-add it to `publish.needs` and drop
-> the `workflow_dispatch` gate. Until then, users install the source gem (which
-> compiles via `rb_sys`).
+> **Precompiled per-platform gems** are built best-effort by the `cross-gems`
+> job, gated to manual `workflow_dispatch` so you can iterate
+> (`gh workflow run release.yml`) without failing tag releases. They are not
+> auto-published on tags yet: a gem that *compiles but can't boot a microVM*
+> would be served to users ahead of the source gem, and CI can't boot a VM to
+> prove otherwise — so promotion is manual after validating the artifact on each
+> platform. A precompiled gem ships the compiled extension (with the guest
+> `agentd` baked in by *target* arch); the host-side `msb` + `libkrunfw` runtime
+> is fetched into `~/.microsandbox` on first use by `Microsandbox.ensure_runtime!`
+> (libkrunfw is `dlopen`'d by `msb` at runtime, never linked into the gem). The
+> real cross-compile work is linking the *target* native libraries — `libcap-ng`
+> on Linux (handled via Debian multiarch in the workflow) and the Hypervisor +
+> Security frameworks on macOS (via osxcross; the one platform left to confirm).
+> Until promoted, users install the source gem (which compiles via `rb_sys`).
 
 See [DESIGN.md](DESIGN.md) for the architecture and the implemented-surface
 section for what's covered today vs. on the roadmap. Covered: full sandbox
@@ -337,8 +381,10 @@ streaming `metrics_stream`/`log_stream`), logs, OCI image-cache management,
 named volumes, and snapshots (create/list/verify/export/import +
 boot-from-snapshot). Create options span resources, network policy presets,
 `log_level`/`security`/`rlimits`/`pull_policy`/`secrets` and more; `exec`/`shell`
-take per-call `rlimits`. Still on the roadmap: custom per-rule network policies,
-file patches, registry auth, interactive `attach`, SSH, and the raw agent client.
+take per-call `rlimits`, and `create` accepts `registry_auth`/`registry_insecure`/
+`registry_ca_certs` for private and authenticated registries. Still on the
+roadmap: custom per-rule network policies, file patches, interactive `attach`,
+SSH, and the raw agent client.
 
 ## License
 

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -4,7 +4,10 @@
 # `microsandbox/microsandbox_rb` and stays hidden behind `require "microsandbox"`.
 name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
-version = "0.5.7"
+# Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
+# returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
+# The core-crate dependency below stays pinned at its own tag (v0.5.7).
+version = "0.5.8"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -19,6 +19,7 @@ use microsandbox::sandbox::{
     SandboxMetrics, SandboxStatus, SandboxStopResult, SecurityProfile,
 };
 use microsandbox::LogLevel;
+use microsandbox::RegistryAuth;
 use microsandbox_network::policy::NetworkPolicy;
 
 use crate::conv;
@@ -136,6 +137,14 @@ impl Sandbox {
         }
         if let Some(mib) = conv::opt_u32(opts, "oci_upper_size")? {
             b = b.oci_upper_size(mib);
+        }
+        // Registry connection settings, for private / non-default registries:
+        // Basic auth (username + password/token), plain-HTTP `insecure`, and
+        // extra PEM CA roots. The Ruby layer flattens `registry_auth: {...}`
+        // into these keys; mirrors the Python `registry_auth=` and Node
+        // `.registry(r => r.auth(...))` surfaces.
+        if let Some(rc) = parse_registry_config(opts)? {
+            b = b.registry(move |r| rc.apply(r));
         }
         if let Some(secs) = conv::opt::<u64>(opts, "max_duration")? {
             b = b.max_duration(secs);
@@ -500,6 +509,65 @@ fn parse_rlimits(opts: RHash) -> Result<Vec<(RlimitResource, u64, u64)>, Error> 
         out.push((rlimit_resource_from_str(&triple.0)?, triple.1, triple.2));
     }
     Ok(out)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Registry option parsing
+//--------------------------------------------------------------------------------------------------
+
+/// Parsed registry connection settings (auth + transport). Built from the flat
+/// `registry_*` option keys the Ruby layer normalizes `registry_auth:` into.
+struct RegistryConfig {
+    auth: Option<RegistryAuth>,
+    insecure: bool,
+    ca_certs: Vec<String>,
+}
+
+impl RegistryConfig {
+    fn apply(
+        self,
+        mut r: microsandbox::sandbox::RegistryConfigBuilder,
+    ) -> microsandbox::sandbox::RegistryConfigBuilder {
+        if let Some(auth) = self.auth {
+            r = r.auth(auth);
+        }
+        if self.insecure {
+            r = r.insecure();
+        }
+        for pem in self.ca_certs {
+            r = r.ca_certs(pem.into_bytes());
+        }
+        r
+    }
+}
+
+/// Read the `registry_*` options, returning `None` when none are set (so the
+/// default credential-resolution chain in the core is left untouched).
+fn parse_registry_config(opts: RHash) -> Result<Option<RegistryConfig>, Error> {
+    let username = conv::opt_string(opts, "registry_username")?;
+    let password = conv::opt_string(opts, "registry_password")?;
+    let insecure = conv::opt_bool(opts, "registry_insecure")?;
+    let ca_certs = conv::opt_string_vec(opts, "registry_ca_certs")?;
+
+    let auth = match (username, password) {
+        (Some(username), Some(password)) => Some(RegistryAuth::Basic { username, password }),
+        (None, None) => None,
+        // A half-specified credential is a caller bug, not a silent anonymous pull.
+        _ => {
+            return Err(error::base_error(
+                "registry_auth requires both :username and :password",
+            ))
+        }
+    };
+
+    if auth.is_none() && !insecure && ca_certs.is_empty() {
+        return Ok(None);
+    }
+    Ok(Some(RegistryConfig {
+        auth,
+        insecure,
+        ca_certs,
+    }))
 }
 
 //--------------------------------------------------------------------------------------------------

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -42,8 +42,14 @@ module Microsandbox
     end
 
     # Download and install the `msb` runtime + `libkrunfw` into
-    # `~/.microsandbox` (idempotent). Usually unnecessary: the native
-    # extension provisions the runtime at build time.
+    # `~/.microsandbox` (idempotent).
+    #
+    # When the gem is built from source, the native extension provisions the
+    # runtime at build time, so this is usually a no-op. Precompiled platform
+    # gems (which skip the local Rust build) do NOT provision it that way, so the
+    # runtime is fetched on first use — see {ensure_runtime!}. Call this
+    # explicitly to provision ahead of time (e.g. while baking a container
+    # image) so the first {Sandbox.create} doesn't pay the download.
     # @return [nil]
     def install
       Native.install
@@ -53,6 +59,32 @@ module Microsandbox
     # @return [Boolean] whether the runtime is installed and resolvable
     def installed?
       Native.installed?
+    end
+
+    # Ensure the `msb` runtime + `libkrunfw` are present, provisioning them on
+    # first use if not. Called automatically by {Sandbox.create}/{Sandbox.start}
+    # so precompiled-gem users (who never ran the source build) get a working
+    # runtime without a manual {install} step.
+    #
+    # The download is attempted at most once per process. Opt out by setting
+    # `MICROSANDBOX_NO_AUTO_INSTALL` (e.g. air-gapped hosts that provision the
+    # runtime out of band); the subsequent operation then surfaces the missing
+    # runtime itself. Already-installed runtimes (e.g. source builds) skip
+    # straight through with only a cheap presence check.
+    # @return [nil]
+    def ensure_runtime!
+      return if @runtime_ready
+      if installed?
+        @runtime_ready = true
+        return
+      end
+      return if auto_install_disabled?
+
+      warn "[microsandbox] runtime (msb + libkrunfw) not found; " \
+           "downloading to ~/.microsandbox (set MICROSANDBOX_NO_AUTO_INSTALL to skip)..."
+      install
+      @runtime_ready = true
+      nil
     end
 
     # @return [String] the resolved path to the `msb` runtime binary
@@ -73,6 +105,15 @@ module Microsandbox
     # @return [Hash{String => Metrics}]
     def all_sandbox_metrics
       Native.all_sandbox_metrics.transform_values { |m| Metrics.new(m) }
+    end
+
+    private
+
+    # Auto-provisioning is on by default; any non-empty, non-"0"/"false" value
+    # of MICROSANDBOX_NO_AUTO_INSTALL disables it.
+    def auto_install_disabled?
+      v = ENV["MICROSANDBOX_NO_AUTO_INSTALL"]
+      !v.nil? && !v.empty? && !%w[0 false no].include?(v.downcase)
     end
   end
 end

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -119,6 +119,14 @@ module Microsandbox
       # @param rlimits [Hash, nil] resource limits: { resource => limit } or
       #   { resource => [soft, hard] } (e.g. { nofile: 65_535 })
       # @param pull_policy ["always","if-missing","never", nil] image pull behavior
+      # @param registry_auth [Hash, nil] credentials for a private/authenticated
+      #   registry: { username:, password: } (the password may be a token).
+      #   Without this the core's default resolution chain still applies (OS
+      #   keyring, global config, `~/.docker/config.json`).
+      # @param registry_insecure [Boolean] reach the registry over plain HTTP
+      #   instead of HTTPS (for local/self-hosted registries)
+      # @param registry_ca_certs [String, Array<String>, nil] extra PEM-encoded CA
+      #   root certificate(s) to trust (for a registry with a private CA)
       # @param secrets [Array<Hash>, nil] placeholder-protected secrets, each
       #   { env:, value:, host: } — the value is substituted by the TLS proxy only
       #   for the allowed host (auto-enables TLS interception)
@@ -133,8 +141,10 @@ module Microsandbox
                  entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
                  from_snapshot: nil, log_level: nil, quiet_logs: false, security: nil,
                  oci_upper_size: nil, max_duration: nil, idle_timeout: nil, rlimits: nil,
-                 pull_policy: nil, secrets: nil,
+                 pull_policy: nil, registry_auth: nil, registry_insecure: false,
+                 registry_ca_certs: nil, secrets: nil,
                  detached: false, replace: false, replace_with_timeout: nil)
+        Microsandbox.ensure_runtime!
         opts = {}
         opts["image"] = image.to_s if image
         opts["from_snapshot"] = from_snapshot.to_s if from_snapshot
@@ -160,6 +170,7 @@ module Microsandbox
         opts["idle_timeout"] = Integer(idle_timeout) if idle_timeout
         opts["rlimits"] = normalize_rlimits(rlimits) if rlimits
         opts["pull_policy"] = pull_policy.to_s if pull_policy
+        apply_registry_opts(opts, registry_auth, registry_insecure, registry_ca_certs)
         opts["secrets"] = normalize_secrets(secrets) if secrets
         opts["detached"] = true if detached
         if replace_with_timeout
@@ -185,6 +196,7 @@ module Microsandbox
       # Restart a previously-defined sandbox by name.
       # @return [Sandbox]
       def start(name, detached: false)
+        Microsandbox.ensure_runtime!
         new(Native::Sandbox.start(name.to_s, { "detached" => detached }))
       end
 
@@ -223,6 +235,25 @@ module Microsandbox
 
       def intify_ports(ports)
         ports.each_with_object({}) { |(k, v), acc| acc[Integer(k)] = Integer(v) }
+      end
+
+      # Flatten the registry options into the native layer's `registry_*` keys.
+      # `auth` is a Hash { username:, password: } (string or symbol keys); both
+      # are required when given. `ca_certs` accepts one PEM string or an Array.
+      def apply_registry_opts(opts, auth, insecure, ca_certs)
+        if auth
+          username = auth[:username] || auth["username"]
+          password = auth[:password] || auth["password"]
+          unless username && password
+            # Report only the keys given, never the values — auth carries secrets.
+            raise ArgumentError,
+                  "registry_auth needs :username and :password (got keys: #{auth.keys.inspect})"
+          end
+          opts["registry_username"] = username.to_s
+          opts["registry_password"] = password.to_s
+        end
+        opts["registry_insecure"] = true if insecure
+        opts["registry_ca_certs"] = Array(ca_certs).map(&:to_s) if ca_certs
       end
 
       # Normalize secrets into [env, value, host] triples for the native layer.

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  # Gem version. Kept in lock-step with the upstream microsandbox runtime and
-  # the official Python/Node/Go SDKs (workspace version in the microsandbox repo).
-  VERSION = "0.5.7"
+  # Gem version. Tracks the upstream microsandbox runtime (currently `v0.5.7`,
+  # the pinned core-crate tag); the patch segment advances for gem-only revisions
+  # that add bindings atop the same core. Must equal the native ext's Cargo crate
+  # version (`Native.version`), enforced by spec/unit/version_spec.rb.
+  VERSION = "0.5.8"
 end

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -6,6 +6,7 @@ module Microsandbox
   def self.version: () -> String
   def self.install: () -> nil
   def self.installed?: () -> bool
+  def self.ensure_runtime!: () -> nil
   def self.runtime_path: () -> String
   def self.runtime_path=: (String path) -> void
   def self.all_sandbox_metrics: () -> Hash[String, Metrics]
@@ -143,6 +144,8 @@ module Microsandbox
                       ?log_level: (String | Symbol)?, ?quiet_logs: bool, ?security: (String | Symbol)?,
                       ?oci_upper_size: Integer?, ?max_duration: Integer?, ?idle_timeout: Integer?,
                       ?rlimits: Hash[untyped, untyped]?, ?pull_policy: (String | Symbol)?,
+                      ?registry_auth: Hash[untyped, untyped]?, ?registry_insecure: bool,
+                      ?registry_ca_certs: (String | Array[String])?,
                       ?secrets: Array[Hash[untyped, untyped]]?, ?detached: bool,
                       ?replace: bool, ?replace_with_timeout: Numeric?)
                       ?{ (Sandbox) -> untyped } -> untyped

--- a/spec/unit/runtime_spec.rb
+++ b/spec/unit/runtime_spec.rb
@@ -40,4 +40,47 @@ RSpec.describe "Microsandbox runtime helpers" do
       end
     end
   end
+
+  describe ".ensure_runtime!" do
+    # The memoized "ready" flag would leak across examples (and from a real
+    # source-built runtime on the dev box), so reset it around each one.
+    around do |example|
+      Microsandbox.instance_variable_set(:@runtime_ready, nil)
+      example.run
+      Microsandbox.instance_variable_set(:@runtime_ready, nil)
+    end
+
+    it "is a no-op (no install) when the runtime is already present" do
+      allow(Microsandbox).to receive(:installed?).and_return(true)
+      allow(Microsandbox).to receive(:install)
+      Microsandbox.ensure_runtime!
+      expect(Microsandbox).not_to have_received(:install)
+    end
+
+    it "auto-installs once when the runtime is missing" do
+      allow(Microsandbox).to receive(:installed?).and_return(false)
+      allow(Microsandbox).to receive(:install)
+      allow(Microsandbox).to receive(:warn)
+      Microsandbox.ensure_runtime!
+      Microsandbox.ensure_runtime! # second call should be memoized, not re-install
+      expect(Microsandbox).to have_received(:install).once
+    end
+
+    it "does not auto-install when MICROSANDBOX_NO_AUTO_INSTALL is set" do
+      allow(Microsandbox).to receive(:installed?).and_return(false)
+      allow(Microsandbox).to receive(:install)
+      stub_const("ENV", ENV.to_h.merge("MICROSANDBOX_NO_AUTO_INSTALL" => "1"))
+      Microsandbox.ensure_runtime!
+      expect(Microsandbox).not_to have_received(:install)
+    end
+
+    it "treats MICROSANDBOX_NO_AUTO_INSTALL=0/false as 'not disabled'" do
+      allow(Microsandbox).to receive(:installed?).and_return(false)
+      allow(Microsandbox).to receive(:install)
+      allow(Microsandbox).to receive(:warn)
+      stub_const("ENV", ENV.to_h.merge("MICROSANDBOX_NO_AUTO_INSTALL" => "false"))
+      Microsandbox.ensure_runtime!
+      expect(Microsandbox).to have_received(:install)
+    end
+  end
 end

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -8,6 +8,9 @@ RSpec.describe Microsandbox::Sandbox do
 
   before do
     allow(Microsandbox::Native::Sandbox).to receive(:create).and_return(native)
+    # Don't let the auto-provision hook touch the filesystem / network in unit
+    # tests; runtime provisioning is covered separately in runtime_spec.
+    allow(Microsandbox).to receive(:ensure_runtime!)
   end
 
   describe ".create option mapping" do
@@ -41,6 +44,61 @@ RSpec.describe Microsandbox::Sandbox do
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box", { "image" => "alpine" }
       )
+    end
+
+    it "ensures the runtime is provisioned before creating" do
+      Microsandbox::Sandbox.create("box", image: "x")
+      expect(Microsandbox).to have_received(:ensure_runtime!)
+    end
+
+    it "flattens registry_auth into registry_username/registry_password" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        registry_auth: { username: "alice", password: "s3cr3t" }
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("registry_username" => "alice", "registry_password" => "s3cr3t")
+      )
+    end
+
+    it "accepts string-keyed registry_auth and passes insecure + ca_certs through" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        registry_auth: { "username" => "bob", "password" => "tok" },
+        registry_insecure: true,
+        registry_ca_certs: "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "registry_username" => "bob", "registry_password" => "tok",
+          "registry_insecure" => true,
+          "registry_ca_certs" => ["-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"]
+        )
+      )
+    end
+
+    it "wraps a single ca_cert and an array of ca_certs the same way" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x", registry_ca_certs: %w[pem-a pem-b]
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box", hash_including("registry_ca_certs" => %w[pem-a pem-b])
+      )
+    end
+
+    it "omits registry keys entirely when no registry options are given" do
+      Microsandbox::Sandbox.create("box", image: "x")
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box", hash_excluding("registry_username", "registry_insecure", "registry_ca_certs")
+      )
+    end
+
+    it "raises on a half-specified registry_auth (missing password)" do
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", registry_auth: { username: "alice" })
+      end.to raise_error(ArgumentError, /:username and :password/)
     end
 
     it "maps pull_policy and normalizes secrets into [env, value, host] triples" do


### PR DESCRIPTION
Closes two documented, previously non-blocking follow-ups.

## ① Registry auth (private / authenticated registries, docker.io rate-limit)

A binding gap, not a core gap — the core supports `RegistryAuth::Basic` and Python/Node already expose it. `Sandbox.create` now accepts:

- `registry_auth: { username:, password: }` (password may be a token)
- `registry_insecure: true` (plain HTTP, for self-hosted registries)
- `registry_ca_certs: <PEM String | Array>` (trust a private CA)

The ext (`parse_registry_config`) wires these to `b.registry(|r| r.auth(RegistryAuth::Basic{..}).insecure().ca_certs(..))`. Without them, the core's default resolution (OS keyring, global config, `~/.docker/config.json`) still applies. A half-specified `registry_auth` raises `ArgumentError` reporting only the keys given — never the secret values.

```ruby
Microsandbox::Sandbox.create("private",
  image: "registry.example.com/team/app:latest",
  registry_auth: { username: "ci-bot", password: ENV["REGISTRY_TOKEN"] })
```

## ② Precompiled per-platform gems (users don't need Rust)

**Corrected the stale analysis of why this is hard:**
- `agentd` is the only thing baked into the gem — `filesystem/build.rs` downloads it by **target** arch and `include_bytes!`-embeds it → cross-compiles fine (and means `prebuilt` can't be disabled).
- `microsandbox/build.rs` downloads msb/libkrunfw by **host** arch into the build machine and never enters the gem → not a cross blocker. libkrunfw is `dlopen`'d at runtime, never linked.
- Real blockers are **target** native libs: `libcap-ng` (Linux) and Hypervisor/Security frameworks (macOS).

**The missing keystone — runtime delivery:** a precompiled gem is built in CI, so build-time `prebuilt` provisions the CI host, not the user. Added `Microsandbox.ensure_runtime!` — `Sandbox.create`/`start` fetch msb+libkrunfw on first use (by the running host's arch), once per process, opt-out via `MICROSANDBOX_NO_AUTO_INSTALL`.

**`release.yml`:** install `libcap-ng-dev:arm64` via Debian multiarch for the `aarch64-linux` cross-build; corrected docs. Still `workflow_dispatch`-gated and **not** auto-published on tags (CI can't boot a microVM to prove a built gem works → promote manually after per-platform validation). `arm64-darwin` via osxcross remains the one platform to confirm on first dispatch.

## Verification

- `rake compile` + `cargo clippy -- -D warnings` + `cargo fmt --check` clean
- 140 unit examples green (9 new: registry-auth option mapping, `ensure_runtime!` behavior)
- ⚠️ The CI cross-build and microVM boot are **not** validated in this environment (no GH Actions / nested virt here) — hence the precompiled-gem path stays gated + best-effort.

Docs (README / DESIGN / CHANGELOG) and rbs signatures updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)