### PR TITLE
chore: adopt StandardRB + add Claude Code project config

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath // empty' | { read -r f; case \"$f\" in *.rs) cargo fmt --manifest-path ext/microsandbox/Cargo.toml;; esac; } 2>/dev/null || true",
+            "statusMessage": "Formatting Rust (cargo fmt)..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: release
+description: Cut a release of the microsandbox-rb gem — walk the version lock-step SOP and tag vX.Y.Z to trigger the OIDC publish. Usage: /release <version> (e.g. /release 0.5.10). User-triggered only.
+disable-model-invocation: true
+---
+
+Cut a release for version `$ARGUMENTS` (e.g. `0.5.10`). If no version was given, ask for it before
+doing anything. This has side effects (commits, tags, triggers publishing) — confirm the target
+version with the user before pushing the tag.
+
+## Steps
+
+1. **Confirm a clean tree on `main`** (or the intended release branch) and that CI is green.
+
+2. **Bump the gem version in BOTH files (they must match — `version_spec.rb` enforces it):**
+   - `lib/microsandbox/version.rb` → `VERSION = "$ARGUMENTS"`
+   - `ext/microsandbox/Cargo.toml` `[package]` → `version = "$ARGUMENTS"`
+
+3. **Upstream runtime tag — only if this release adopts a new upstream runtime.** This is a
+   SEPARATE axis from the gem version. If adopting a new runtime, update the `tag = "vX.Y.Z"` for
+   BOTH `microsandbox` and `microsandbox-network` git deps in `ext/microsandbox/Cargo.toml` to the
+   same tag, then `bundle exec rake compile` to refresh `Cargo.lock`. Otherwise leave the deps
+   untouched.
+
+4. **Update `CHANGELOG.md`** (Keep-a-Changelog) — move Unreleased items under a new
+   `## [$ARGUMENTS] - <date>` heading.
+
+5. **Verify locally** before tagging: run the `verify-local` skill (cargo fmt --check, clippy
+   -D warnings, rake spec). Do not proceed if anything fails.
+
+6. **Commit** the version + changelog bump with a conventional message, e.g.
+   `chore(release): v$ARGUMENTS`.
+
+7. **Tag and push** — this is what triggers the publish, so confirm with the user first:
+   ```sh
+   git tag v$ARGUMENTS && git push origin main v$ARGUMENTS
+   ```
+
+8. **Publishing happens in CI.** `.github/workflows/release.yml` builds the source gem and pushes
+   to RubyGems via Trusted Publishing (OIDC) on the `v*` tag. There is no API key to handle.
+   Precompiled platform gems are NOT published by this tag flow — they require manual
+   `workflow_dispatch` and per-platform validation. Mention this if the user expected fat gems.
+
+Report what you changed and the tag you pushed, and link the user to the Actions run if `gh` is
+available (`gh run list --workflow=release.yml`).

--- a/.claude/skills/verify-local/SKILL.md
+++ b/.claude/skills/verify-local/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: verify-local
+description: Run the full local check gate for this gem — cargo fmt --check, cargo clippy -D warnings, standardrb, and the unit specs (optionally integration). Use before pushing, opening a PR, or claiming a change is done. (The bundled /verify skill — run the app and observe behavior — still exists and is separate.)
+---
+
+Run the same checks CI gates on, in this order, and report a concise pass/fail summary. Do NOT
+stop at the first failure unless a step can't run — collect results from all steps so the user
+sees everything at once.
+
+## 1. Rust format check
+
+```sh
+cargo fmt --check --manifest-path ext/microsandbox/Cargo.toml
+```
+
+If it fails, the fix is `cargo fmt --manifest-path ext/microsandbox/Cargo.toml` (offer to run it).
+
+## 2. Rust lint (clippy, warnings = errors)
+
+```sh
+cargo clippy --manifest-path ext/microsandbox/Cargo.toml -- -D warnings
+```
+
+## 3. Ruby lint/format (StandardRB)
+
+```sh
+bundle exec standardrb
+```
+
+If it fails, autocorrect with `bundle exec standardrb --fix` (offer to run it).
+
+## 4. Unit specs (auto-compiles the native ext first)
+
+```sh
+bundle exec rake spec
+```
+
+This compiles before running, so a stale `.bundle`/`.so` is rebuilt automatically. Requires stable
+Rust ≥ 1.91 on PATH.
+
+## 5. Integration specs — only if asked, or `$ARGUMENTS` contains `integration`
+
+These boot real microVMs and need Linux+KVM or macOS Apple Silicon. They auto-skip without the env
+var, so skipping them silently is a false "all green". Run only on request:
+
+```sh
+MICROSANDBOX_INTEGRATION=1 bundle exec rspec spec/integration
+```
+
+## Report
+
+Summarize each step as ✅/❌ with the failing output excerpted. If you changed the public Ruby API,
+remind the user to update `sig/microsandbox.rbs` and `CHANGELOG.md` if they haven't.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
         run: bundle exec rspec spec/integration
 
   lint:
-    name: rustfmt + clippy
+    name: lint (rustfmt + clippy + standardrb)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -132,3 +132,6 @@ jobs:
         run: cargo fmt --check --manifest-path ext/microsandbox/Cargo.toml
       - name: clippy
         run: cargo clippy --manifest-path ext/microsandbox/Cargo.toml -- -D warnings
+      # Ruby lint/format for the lib/ + spec/ layer (StandardRB, zero-config).
+      - name: standardrb
+        run: bundle exec standardrb

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,68 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A Ruby gem wrapping the upstream `microsandbox` Rust crate (secure microVM sandboxing) through a
+magnus + rb-sys native extension. Two layers:
+
+- `lib/microsandbox/` — idiomatic, **synchronous** Ruby API (the public surface).
+- `ext/microsandbox/src/` — magnus bindings over the async (tokio) core crate. The async core is
+  bridged to sync Ruby via a shared blocking tokio runtime; the GVL is released
+  (`rb_thread_call_without_gvl`) during blocking calls. Built as `microsandbox_rb.{bundle,so}`.
+
+Deeper architecture is in `DESIGN.md`; usage in `README.md`.
+
+## Build / test / lint
+
+- Compile the native ext: `bundle exec rake compile` (release: `rake compile:release`). Requires
+  **stable Rust ≥ 1.91** on PATH — the core crate is edition 2024 / pulls smoltcp; an older rustc
+  fails the `extconf.rb` preflight. `rust-toolchain.toml` pins `stable`.
+- Unit specs (no runtime needed): `bundle exec rake spec` (the default task; auto-compiles first).
+- Integration specs (boot real microVMs, **Linux+KVM or macOS Apple Silicon**):
+  `MICROSANDBOX_INTEGRATION=1 bundle exec rspec spec/integration`. They auto-skip without that env
+  var or a missing runtime — never assume a green unit run exercised them.
+- Lint:
+  - Rust: `cargo fmt --check --manifest-path ext/microsandbox/Cargo.toml` and
+    `cargo clippy --manifest-path ext/microsandbox/Cargo.toml -- -D warnings`. Always pass
+    `--manifest-path ext/microsandbox/Cargo.toml` — the workspace root has no buildable crate.
+  - Ruby (`lib/`, `spec/`): `bundle exec standardrb` (zero-config StandardRB; autocorrect with
+    `bundle exec standardrb --fix`).
+
+  CI gates on all three — run them before claiming a change is done. The `verify-local` skill runs
+  the Rust + spec gate in one shot.
+
+## Version lock-step (two independent axes)
+
+1. **Gem version** — `Microsandbox::VERSION` in `lib/microsandbox/version.rb` MUST equal `version`
+   in `ext/microsandbox/Cargo.toml` `[package]`. `spec/unit/version_spec.rb` asserts equality via
+   `Native.version`. Bump both together, or specs fail.
+2. **Upstream runtime tag** — the `microsandbox` and `microsandbox-network` git deps in
+   `ext/microsandbox/Cargo.toml` are pinned to a `tag` (currently `v0.5.7`). This tracks the
+   upstream runtime, NOT the gem version. Bump it only when adopting a new upstream release, and
+   keep both deps on the same tag.
+
+## Conventions
+
+- When the public Ruby API changes, update `sig/microsandbox.rbs` (hand-maintained RBS) and
+  `CHANGELOG.md` (Keep-a-Changelog) in the same change.
+- Commits: conventional style, e.g. `fix(exec): ...`, `docs(readme): ...`. Branches:
+  `feature/<desc>`, `fix/<desc>`. PRs target `main`.
+
+## Env vars & gotchas
+
+- `MICROSANDBOX_INTEGRATION=1` — opt in to integration specs. `MICROSANDBOX_TEST_IMAGE` — override
+  the test image (default `public.ecr.aws/docker/library/alpine:latest`, an ECR mirror to dodge
+  docker.io rate limits). `MSB_PATH` — override the resolved `msb` runtime binary.
+  `MICROSANDBOX_NO_AUTO_INSTALL` — opt out of first-use runtime download.
+- Local dev against a sibling `../microsandbox` checkout: `cp .cargo/config.toml.example
+  .cargo/config.toml` (gitignored). **Never commit `.cargo/config.toml`** — it breaks CI/container
+  builds, which rely on the pinned git dep.
+
+## Release
+
+Push a `vX.Y.Z` tag → `.github/workflows/release.yml` builds the source gem and publishes to
+RubyGems via Trusted Publishing (OIDC — no API key). Precompiled platform gems are built only via
+manual `workflow_dispatch` and require per-platform validation before promotion; they do not
+auto-publish on tags.

--- a/Gemfile
+++ b/Gemfile
@@ -9,4 +9,5 @@ group :development do
   gem "rake", "~> 13.0"
   gem "rake-compiler", "~> 1.2"
   gem "rspec", "~> 3.13"
+  gem "standard", "~> 1.0"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -24,5 +24,13 @@ rescue LoadError
   # rspec not installed (e.g. production install); skip test tasks.
 end
 
+begin
+  require "standard/rake"
+  # Adds `rake standard` (lint) and `rake standard:fix` (autocorrect) for the
+  # Ruby layer (lib/, spec/). Rust formatting/linting stays with cargo fmt/clippy.
+rescue LoadError
+  # standard not installed (e.g. production install); skip lint task.
+end
+
 task spec: :compile
 task default: %i[compile spec]

--- a/ext/microsandbox/extconf.rb
+++ b/ext/microsandbox/extconf.rb
@@ -13,12 +13,16 @@ MSRV = Gem::Version.new("1.91")
 rustc_version = begin
   out = `rustc --version 2>/dev/null`
   out[/\d+\.\d+(\.\d+)?/] && Gem::Version.new(out[/\d+\.\d+(\.\d+)?/])
-rescue StandardError
+rescue
   nil
 end
 
 if rustc_version && rustc_version < MSRV
-  which_rustc = (`which rustc 2>/dev/null`.strip rescue "")
+  which_rustc = begin
+    `which rustc 2>/dev/null`.strip
+  rescue
+    ""
+  end
   abort(<<~MSG)
 
     [microsandbox-rb] Rust #{rustc_version} is too old — the embedded core requires rustc >= #{MSRV}.

--- a/lib/microsandbox/exec_handle.rb
+++ b/lib/microsandbox/exec_handle.rb
@@ -22,19 +22,19 @@ module Microsandbox
 
     # @return [String, nil] {#data} decoded as UTF-8 (lenient)
     def text
-      @data && @data.dup.force_encoding(Encoding::UTF_8)
+      @data&.dup&.force_encoding(Encoding::UTF_8)
     end
 
-    def started?      = @type == :started
-    def stdout?       = @type == :stdout
-    def stderr?       = @type == :stderr
-    def exited?       = @type == :exited
-    def failed?       = @type == :failed
-    def stdin_error?  = @type == :stdin_error
+    def started? = @type == :started
+    def stdout? = @type == :stdout
+    def stderr? = @type == :stderr
+    def exited? = @type == :exited
+    def failed? = @type == :failed
+    def stdin_error? = @type == :stdin_error
 
     def inspect
-      "#<Microsandbox::ExecEvent type=#{@type}#{@pid ? " pid=#{@pid}" : ""}" \
-        "#{@code ? " code=#{@code}" : ""}#{@data ? " data=#{@data.bytesize}B" : ""}>"
+      "#<Microsandbox::ExecEvent type=#{@type}#{" pid=#{@pid}" if @pid}" \
+        "#{" code=#{@code}" if @code}#{" data=#{@data.bytesize}B" if @data}>"
     end
   end
 

--- a/lib/microsandbox/fs.rb
+++ b/lib/microsandbox/fs.rb
@@ -30,9 +30,9 @@ module Microsandbox
       @modified_ms && Time.at(@modified_ms / 1000.0)
     end
 
-    def file?       = @type == :file
-    def directory?  = @type == :directory
-    def symlink?    = @type == :symlink
+    def file? = @type == :file
+    def directory? = @type == :directory
+    def symlink? = @type == :symlink
 
     def inspect
       "#<Microsandbox::FsEntry path=#{@path.inspect} type=#{@type} size=#{@size}>"
@@ -57,10 +57,10 @@ module Microsandbox
       @created_ms = data["created_ms"]
     end
 
-    def readonly?   = @readonly
-    def file?       = @type == :file
-    def directory?  = @type == :directory
-    def symlink?    = @type == :symlink
+    def readonly? = @readonly
+    def file? = @type == :file
+    def directory? = @type == :directory
+    def symlink? = @type == :symlink
 
     # @return [Time, nil] last-modified time, if known
     def modified

--- a/lib/microsandbox/image.rb
+++ b/lib/microsandbox/image.rb
@@ -56,7 +56,7 @@ module Microsandbox
   # The result of {Image.prune}.
   class ImagePruneReport
     attr_reader :image_refs_removed, :manifests_removed, :layers_removed,
-                :fsmeta_removed, :vmdk_removed, :bytes_reclaimed
+      :fsmeta_removed, :vmdk_removed, :bytes_reclaimed
 
     def initialize(data)
       @image_refs_removed = data["image_refs_removed"]

--- a/lib/microsandbox/network.rb
+++ b/lib/microsandbox/network.rb
@@ -16,23 +16,23 @@ module Microsandbox
     module_function
 
     # Match any destination.
-    def any = { "destination_kind" => "any" }
+    def any = {"destination_kind" => "any"}
 
     # A single IP address (stored as a /32 or /128).
-    def ip(value) = { "destination_kind" => "ip", "destination" => value.to_s }
+    def ip(value) = {"destination_kind" => "ip", "destination" => value.to_s}
 
     # An IP network in CIDR notation (e.g. "10.0.0.0/8").
-    def cidr(value) = { "destination_kind" => "cidr", "destination" => value.to_s }
+    def cidr(value) = {"destination_kind" => "cidr", "destination" => value.to_s}
 
     # An exact domain name (matched against the resolved-hostname cache / SNI).
-    def domain(value) = { "destination_kind" => "domain", "destination" => value.to_s }
+    def domain(value) = {"destination_kind" => "domain", "destination" => value.to_s}
 
     # A domain suffix — matches the apex and any subdomain (e.g. ".internal").
-    def domain_suffix(value) = { "destination_kind" => "domain_suffix", "destination" => value.to_s }
+    def domain_suffix(value) = {"destination_kind" => "domain_suffix", "destination" => value.to_s}
 
     # A predefined group: :public, :loopback, :private, :link_local, :metadata,
     # :multicast, or :host.
-    def group(value) = { "destination_kind" => "group", "destination" => value.to_s.tr("_", "-") }
+    def group(value) = {"destination_kind" => "group", "destination" => value.to_s.tr("_", "-")}
   end
 
   # Factory for a single network-policy **rule**. A rule pairs an action
@@ -64,7 +64,7 @@ module Microsandbox
 
     # @api private
     def build(action, destination, direction, protocol, protocols, port, ports)
-      rule = { "action" => action, "direction" => direction.to_s }
+      rule = {"action" => action, "direction" => direction.to_s}
       rule.merge!(normalize_destination(destination))
       protos = (Array(protocols) + Array(protocol)).compact.map(&:to_s)
       rule["protocols"] = protos unless protos.empty?
@@ -78,7 +78,7 @@ module Microsandbox
       case dest
       when nil then {}
       when Hash then dest.each_with_object({}) { |(k, v), a| a[k.to_s] = v }
-      when String, Symbol then { "destination" => dest.to_s }
+      when String, Symbol then {"destination" => dest.to_s}
       else raise ArgumentError, "invalid rule destination: #{dest.inspect}"
       end
     end
@@ -149,7 +149,7 @@ module Microsandbox
       # @param deny_domain_suffixes [Array<String>] domain suffixes to deny
       # @return [NetworkPolicy]
       def custom(default_egress: :deny, default_ingress: :allow, rules: [],
-                 deny_domains: [], deny_domain_suffixes: [])
+        deny_domains: [], deny_domain_suffixes: [])
         h = {}
         h["default_egress"] = action_str(default_egress) unless default_egress.nil?
         h["default_ingress"] = action_str(default_ingress) unless default_ingress.nil?
@@ -163,12 +163,12 @@ module Microsandbox
       def coerce(network)
         case network
         when NetworkPolicy then network.to_h
-        when String, Symbol then { "preset" => canonical_preset(network) }
+        when String, Symbol then {"preset" => canonical_preset(network)}
         when Hash then from_hash(network)
         else
           raise ArgumentError,
-                "network: expects a preset name, a Microsandbox::NetworkPolicy, or a Hash " \
-                "(got #{network.class})"
+            "network: expects a preset name, a Microsandbox::NetworkPolicy, or a Hash " \
+            "(got #{network.class})"
         end
       end
 
@@ -186,11 +186,11 @@ module Microsandbox
         if sym.key?(:preset)
           if sym.key?(:rules) || sym.key?(:default_egress) || sym.key?(:default_ingress)
             raise ArgumentError,
-                  "network preset: cannot be combined with rules:/default_egress:/" \
-                  "default_ingress: (the preset already defines its rules and defaults); " \
-                  "only deny_domains:/deny_domain_suffixes: may be layered on a preset"
+              "network preset: cannot be combined with rules:/default_egress:/" \
+              "default_ingress: (the preset already defines its rules and defaults); " \
+              "only deny_domains:/deny_domain_suffixes: may be layered on a preset"
           end
-          h = { "preset" => canonical_preset(sym[:preset]) }
+          h = {"preset" => canonical_preset(sym[:preset])}
           add_deny_lists(h, sym[:deny_domains], sym[:deny_domain_suffixes])
           h
         elsif sym.key?(:rules) || sym.key?(:default_egress) || sym.key?(:default_ingress)
@@ -213,7 +213,7 @@ module Microsandbox
           ds = Array(sym[:deny_domain_suffixes]).map(&:to_s)
           return {} if dd.empty? && ds.empty?
 
-          h = { "default_egress" => "allow", "default_ingress" => "allow" }
+          h = {"default_egress" => "allow", "default_ingress" => "allow"}
           add_deny_lists(h, dd, ds)
           h
         end
@@ -233,8 +233,8 @@ module Microsandbox
         key = name.to_s.downcase
         PRESET_ALIASES[key] ||
           raise(ArgumentError,
-                "unknown network preset #{name.inspect} " \
-                "(expected one of public_only/none/allow_all/non_local)")
+            "unknown network preset #{name.inspect} " \
+            "(expected one of public_only/none/allow_all/non_local)")
       end
 
       def action_str(action)

--- a/lib/microsandbox/patch.rb
+++ b/lib/microsandbox/patch.rb
@@ -31,7 +31,7 @@ module Microsandbox
     # @param replace [Boolean] allow shadowing a path already in the rootfs
     # @return [Hash]
     def text(path, content, mode: nil, replace: false)
-      h = { "kind" => "text", "path" => path.to_s, "content" => content.to_s, "replace" => replace ? true : false }
+      h = {"kind" => "text", "path" => path.to_s, "content" => content.to_s, "replace" => replace ? true : false}
       h["mode"] = Integer(mode) unless mode.nil?
       h
     end
@@ -43,7 +43,7 @@ module Microsandbox
     # @param replace [Boolean]
     # @return [Hash]
     def file(path, content, mode: nil, replace: false)
-      h = { "kind" => "file", "path" => path.to_s, "content" => content.to_s, "replace" => replace ? true : false }
+      h = {"kind" => "file", "path" => path.to_s, "content" => content.to_s, "replace" => replace ? true : false}
       h["mode"] = Integer(mode) unless mode.nil?
       h
     end
@@ -52,7 +52,7 @@ module Microsandbox
     # lower image layer is copied up first, then appended.
     # @return [Hash]
     def append(path, content)
-      { "kind" => "append", "path" => path.to_s, "content" => content.to_s }
+      {"kind" => "append", "path" => path.to_s, "content" => content.to_s}
     end
 
     # Copy a host file into the rootfs.
@@ -62,7 +62,7 @@ module Microsandbox
     # @param replace [Boolean]
     # @return [Hash]
     def copy_file(src, dst, mode: nil, replace: false)
-      h = { "kind" => "copy_file", "src" => src.to_s, "dst" => dst.to_s, "replace" => replace ? true : false }
+      h = {"kind" => "copy_file", "src" => src.to_s, "dst" => dst.to_s, "replace" => replace ? true : false}
       h["mode"] = Integer(mode) unless mode.nil?
       h
     end
@@ -70,13 +70,13 @@ module Microsandbox
     # Copy a host directory (recursively) into the rootfs.
     # @return [Hash]
     def copy_dir(src, dst, replace: false)
-      { "kind" => "copy_dir", "src" => src.to_s, "dst" => dst.to_s, "replace" => replace ? true : false }
+      {"kind" => "copy_dir", "src" => src.to_s, "dst" => dst.to_s, "replace" => replace ? true : false}
     end
 
     # Create a symlink at +link+ pointing to +target+.
     # @return [Hash]
     def symlink(target, link, replace: false)
-      { "kind" => "symlink", "target" => target.to_s, "link" => link.to_s, "replace" => replace ? true : false }
+      {"kind" => "symlink", "target" => target.to_s, "link" => link.to_s, "replace" => replace ? true : false}
     end
 
     # Create a directory (idempotent — no error if it already exists).
@@ -84,7 +84,7 @@ module Microsandbox
     # @param mode [Integer, nil] directory mode (e.g. 0o755)
     # @return [Hash]
     def mkdir(path, mode: nil)
-      h = { "kind" => "mkdir", "path" => path.to_s }
+      h = {"kind" => "mkdir", "path" => path.to_s}
       h["mode"] = Integer(mode) unless mode.nil?
       h
     end
@@ -92,7 +92,7 @@ module Microsandbox
     # Remove a file or directory (idempotent — no error if absent).
     # @return [Hash]
     def remove(path)
-      { "kind" => "remove", "path" => path.to_s }
+      {"kind" => "remove", "path" => path.to_s}
     end
   end
 end

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -67,7 +67,7 @@ module Microsandbox
 
     def inspect
       "#<Microsandbox::SandboxStopResult name=#{@name.inspect} status=#{@status}" \
-        "#{@exit_code ? " exit_code=#{@exit_code}" : ""}#{@signal ? " signal=#{@signal}" : ""}>"
+        "#{" exit_code=#{@exit_code}" if @exit_code}#{" signal=#{@signal}" if @signal}>"
     end
   end
 
@@ -143,15 +143,15 @@ module Microsandbox
       # @yieldparam sandbox [Sandbox]
       # @return [Sandbox, Object] the sandbox, or the block's return value
       def create(name,
-                 image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
-                 shell: nil, user: nil, hostname: nil, labels: nil, scripts: nil,
-                 entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
-                 patches: nil,
-                 from_snapshot: nil, log_level: nil, quiet_logs: false, security: nil,
-                 oci_upper_size: nil, max_duration: nil, idle_timeout: nil, rlimits: nil,
-                 pull_policy: nil, registry_auth: nil, registry_insecure: false,
-                 registry_ca_certs: nil, secrets: nil,
-                 detached: false, replace: false, replace_with_timeout: nil)
+        image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
+        shell: nil, user: nil, hostname: nil, labels: nil, scripts: nil,
+        entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
+        patches: nil,
+        from_snapshot: nil, log_level: nil, quiet_logs: false, security: nil,
+        oci_upper_size: nil, max_duration: nil, idle_timeout: nil, rlimits: nil,
+        pull_policy: nil, registry_auth: nil, registry_insecure: false,
+        registry_ca_certs: nil, secrets: nil,
+        detached: false, replace: false, replace_with_timeout: nil)
         Microsandbox.ensure_runtime!
         opts = {}
         opts["image"] = image.to_s if image
@@ -206,7 +206,7 @@ module Microsandbox
       # @return [Sandbox]
       def start(name, detached: false)
         Microsandbox.ensure_runtime!
-        new(Native::Sandbox.start(name.to_s, { "detached" => detached }))
+        new(Native::Sandbox.start(name.to_s, {"detached" => detached}))
       end
 
       # Fetch metadata for a sandbox by name.
@@ -225,7 +225,7 @@ module Microsandbox
       # @param labels [Hash] required key => value labels
       # @return [Array<SandboxInfo>]
       def list_with(labels: {})
-        opts = { "labels" => stringify(labels) }
+        opts = {"labels" => stringify(labels)}
         Native::Sandbox.list_with(opts).map { |info| SandboxInfo.new(info) }
       end
 
@@ -256,7 +256,7 @@ module Microsandbox
           unless username && password
             # Report only the keys given, never the values — auth carries secrets.
             raise ArgumentError,
-                  "registry_auth needs :username and :password (got keys: #{auth.keys.inspect})"
+              "registry_auth needs :username and :password (got keys: #{auth.keys.inspect})"
           end
           opts["registry_username"] = username.to_s
           opts["registry_password"] = password.to_s
@@ -364,14 +364,14 @@ module Microsandbox
     # @return [ExecOutput]
     def exec(command, args = [], cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecOutput.new(@native.exec(command.to_s, Array(args).map(&:to_s),
-                                  exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
+        exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
     end
 
     # Run a shell script (pipes, redirects, etc. allowed) and collect output.
     # @return [ExecOutput]
     def shell(script, cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecOutput.new(@native.shell(script.to_s,
-                                   exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
+        exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:)))
     end
 
     # Run a command and stream its output as it arrives.
@@ -383,14 +383,14 @@ module Microsandbox
     # @see ExecHandle
     def exec_stream(command, args = [], cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecHandle.new(@native.exec_stream(command.to_s, Array(args).map(&:to_s),
-                                         exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:, pipe_ok: true)))
+        exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:, pipe_ok: true)))
     end
 
     # Run a shell script and stream its output as it arrives.
     # @return [ExecHandle]
     def shell_stream(script, cwd: nil, user: nil, env: nil, timeout: nil, tty: false, stdin: nil, rlimits: nil)
       ExecHandle.new(@native.shell_stream(script.to_s,
-                                          exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:, pipe_ok: true)))
+        exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:, pipe_ok: true)))
     end
 
     # Attach an interactive terminal to a command in the sandbox.
@@ -581,8 +581,8 @@ module Microsandbox
       when :pipe
         unless pipe_ok
           raise ArgumentError,
-                "stdin: :pipe is only valid for exec_stream/shell_stream — a blocking " \
-                "exec/shell cannot expose a writable stdin sink; pass a String to feed bytes"
+            "stdin: :pipe is only valid for exec_stream/shell_stream — a blocking " \
+            "exec/shell cannot expose a writable stdin sink; pass a String to feed bytes"
         end
         opts["stdin_pipe"] = true
       else opts["stdin"] = stdin.to_s

--- a/lib/microsandbox/snapshot.rb
+++ b/lib/microsandbox/snapshot.rb
@@ -43,7 +43,7 @@ module Microsandbox
     end
 
     def inspect
-      "#<Microsandbox::SnapshotInfo digest=#{@digest.inspect}#{@name ? " name=#{@name.inspect}" : ""}>"
+      "#<Microsandbox::SnapshotInfo digest=#{@digest.inspect}#{" name=#{@name.inspect}" if @name}>"
     end
   end
 
@@ -142,7 +142,7 @@ module Microsandbox
       # @param dest [String, nil] explicit destination directory
       # @return [SnapshotInfo]
       def import(archive_path, dest: nil)
-        SnapshotInfo.new(Native::Snapshot.import(archive_path.to_s, dest && dest.to_s))
+        SnapshotInfo.new(Native::Snapshot.import(archive_path.to_s, dest&.to_s))
       end
 
       private

--- a/lib/microsandbox/ssh.rb
+++ b/lib/microsandbox/ssh.rb
@@ -218,7 +218,7 @@ module Microsandbox
     # @yieldparam client [SshClient]
     # @return [SshClient, Object]
     def open_client(user: "root", term: nil, sftp: true)
-      opts = { "user" => user.to_s, "sftp" => sftp ? true : false }
+      opts = {"user" => user.to_s, "sftp" => sftp ? true : false}
       opts["term"] = term.to_s if term
       client = SshClient.new(@native.ssh_open_client(opts))
       return client unless block_given?
@@ -237,7 +237,7 @@ module Microsandbox
     # @param sftp [Boolean] enable the SFTP subsystem (default true)
     # @return [SshServer]
     def prepare_server(host_key_path: nil, authorized_keys_path: nil, user: nil, sftp: true)
-      opts = { "sftp" => sftp ? true : false }
+      opts = {"sftp" => sftp ? true : false}
       opts["host_key_path"] = host_key_path.to_s if host_key_path
       opts["authorized_keys_path"] = authorized_keys_path.to_s if authorized_keys_path
       opts["user"] = user.to_s if user

--- a/lib/microsandbox/volume.rb
+++ b/lib/microsandbox/volume.rb
@@ -7,7 +7,7 @@ module Microsandbox
   # (`kind`, `used_bytes`, …) are populated when returned from {Volume.get}/{Volume.list}.
   class VolumeInfo
     attr_reader :name, :path, :quota_mib, :used_bytes, :capacity_bytes,
-                :disk_format, :disk_fstype, :labels
+      :disk_format, :disk_fstype, :labels
 
     def initialize(data)
       @name = data["name"]
@@ -33,7 +33,7 @@ module Microsandbox
     end
 
     def inspect
-      "#<Microsandbox::VolumeInfo name=#{@name.inspect}#{@kind ? " kind=#{@kind}" : ""}>"
+      "#<Microsandbox::VolumeInfo name=#{@name.inspect}#{" kind=#{@kind}" if @kind}>"
     end
   end
 
@@ -49,7 +49,7 @@ module Microsandbox
       # @param labels [Hash, nil]
       # @return [VolumeInfo]
       def create(name, kind: "dir", size_mib: nil, quota_mib: nil, labels: nil)
-        opts = { "kind" => kind.to_s }
+        opts = {"kind" => kind.to_s}
         opts["size_mib"] = Integer(size_mib) if size_mib
         opts["quota_mib"] = Integer(quota_mib) if quota_mib
         opts["labels"] = labels.each_with_object({}) { |(k, v), a| a[k.to_s] = v.to_s } if labels

--- a/spec/integration/lifecycle_spec.rb
+++ b/spec/integration/lifecycle_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe "Sandbox lifecycle", :integration do
 
   it "passes environment variables and honors cwd" do
     Microsandbox::Sandbox.create(unique_sandbox_name, image: image) do |sb|
-      out = sb.exec("sh", ["-c", "echo $GREETING"], env: { "GREETING" => "hi-env" })
+      out = sb.exec("sh", ["-c", "echo $GREETING"], env: {"GREETING" => "hi-env"})
       expect(out.stdout.strip).to eq("hi-env")
 
       out2 = sb.exec("pwd", [], cwd: "/tmp")

--- a/spec/integration/patches_network_spec.rb
+++ b/spec/integration/patches_network_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "patches and network", :integration do
           Microsandbox::Patch.mkdir("/opt/app"),
           Microsandbox::Patch.text("/opt/app/config.txt", "base\n"),
           Microsandbox::Patch.append("/opt/app/config.txt", "appended\n"),
-          Microsandbox::Patch.symlink("/opt/app/config.txt", "/opt/app/link.txt"),
+          Microsandbox::Patch.symlink("/opt/app/config.txt", "/opt/app/link.txt")
         ]
       ) do |sb|
         out = sb.shell("test -d /opt/app && cat /opt/app/config.txt && cat /opt/app/link.txt")
@@ -32,7 +32,7 @@ RSpec.describe "patches and network", :integration do
           unique_sandbox_name, image: image,
           patches: [
             Microsandbox::Patch.copy_file(host_file, "/etc/staged.toml", mode: 0o644),
-            Microsandbox::Patch.remove("/etc/motd"),
+            Microsandbox::Patch.remove("/etc/motd")
           ]
         ) do |sb|
           expect(sb.fs.read_text("/etc/staged.toml")).to eq("staged = true\n")
@@ -74,7 +74,7 @@ RSpec.describe "patches and network", :integration do
     it "accepts a preset base plus a bulk domain denial" do
       Microsandbox::Sandbox.create(
         unique_sandbox_name, image: image,
-        network: { preset: :public_only, deny_domains: ["example.com"] }
+        network: {preset: :public_only, deny_domains: ["example.com"]}
       ) do |sb|
         # The sandbox still boots and runs; the deny rule is enforced by the proxy.
         expect(sb.shell("echo ok").stdout).to include("ok")

--- a/spec/integration/roadmap_spec.rb
+++ b/spec/integration/roadmap_spec.rb
@@ -71,11 +71,11 @@ RSpec.describe "streaming, images, volumes", :integration do
       Microsandbox::Volume.create(vol)
       begin
         Microsandbox::Sandbox.create(unique_sandbox_name, image: image,
-                                     volumes: { "/data" => { named: vol } }) do |sb|
+          volumes: {"/data" => {named: vol}}) do |sb|
           sb.fs.write("/data/persisted.txt", "across-boots")
         end
         Microsandbox::Sandbox.create(unique_sandbox_name, image: image,
-                                     volumes: { "/data" => { named: vol } }) do |sb|
+          volumes: {"/data" => {named: vol}}) do |sb|
           expect(sb.fs.read_text("/data/persisted.txt")).to eq("across-boots")
         end
       ensure

--- a/spec/integration/snapshot_spec.rb
+++ b/spec/integration/snapshot_spec.rb
@@ -26,8 +26,16 @@ RSpec.describe "snapshots + pull policy", :integration do
         expect(sb2.fs.read_text("/root/marker.txt")).to eq(marker)
       end
     ensure
-      Microsandbox::Snapshot.remove(snap, force: true) rescue Microsandbox::Error
-      Microsandbox::Sandbox.remove(src) rescue Microsandbox::Error
+      begin
+        Microsandbox::Snapshot.remove(snap, force: true)
+      rescue
+        Microsandbox::Error
+      end
+      begin
+        Microsandbox::Sandbox.remove(src)
+      rescue
+        Microsandbox::Error
+      end
     end
   end
 

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -18,18 +18,22 @@ RSpec.describe "lifecycle controls + streaming", :integration do
       ensure
         # The sandbox is already stopped by wait_until_stopped; a best-effort
         # kill here just guards against an early failure leaving it running.
-        sb.kill rescue Microsandbox::Error
+        begin
+          sb.kill
+        rescue
+          Microsandbox::Error
+        end
       end
     end
 
     it "filters sandboxes by label via list_with" do
       name = unique_sandbox_name
-      sb = Microsandbox::Sandbox.create(name, image: image, labels: { role: "rb-itest" })
+      sb = Microsandbox::Sandbox.create(name, image: image, labels: {role: "rb-itest"})
       begin
-        names = Microsandbox::Sandbox.list_with(labels: { role: "rb-itest" }).map(&:name)
+        names = Microsandbox::Sandbox.list_with(labels: {role: "rb-itest"}).map(&:name)
         expect(names).to include(name)
         # A non-matching filter must exclude it.
-        other = Microsandbox::Sandbox.list_with(labels: { role: "nope" }).map(&:name)
+        other = Microsandbox::Sandbox.list_with(labels: {role: "nope"}).map(&:name)
         expect(other).not_to include(name)
       ensure
         sb.stop

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe "raw agent client" do
 
     it "is Enumerable and yields frames until recv returns nil" do
       allow(native).to receive(:stream_next).and_return(
-        { "id" => 1, "flags" => 0, "body" => "a".b },
-        { "id" => 1, "flags" => 1, "body" => "b".b },
+        {"id" => 1, "flags" => 0, "body" => "a".b},
+        {"id" => 1, "flags" => 1, "body" => "b".b},
         nil
       )
       bodies = stream.map(&:body)

--- a/spec/unit/attach_spec.rb
+++ b/spec/unit/attach_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe "Sandbox#attach" do
       allow(native).to receive(:attach).and_return(0)
       code = sandbox.attach(
         "bash", ["-l"],
-        cwd: "/app", user: "app", env: { FOO: 1 },
-        detach_keys: "ctrl-p,ctrl-q", rlimits: { nofile: [1024, 2048] }
+        cwd: "/app", user: "app", env: {FOO: 1},
+        detach_keys: "ctrl-p,ctrl-q", rlimits: {nofile: [1024, 2048]}
       )
       expect(code).to eq(0)
       expect(native).to have_received(:attach).with(
         "bash", ["-l"],
         {
-          "cwd" => "/app", "user" => "app", "env" => { "FOO" => "1" },
+          "cwd" => "/app", "user" => "app", "env" => {"FOO" => "1"},
           "detach_keys" => "ctrl-p,ctrl-q", "rlimits" => [["nofile", 1024, 2048]]
         }
       )

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe "Microsandbox error hierarchy" do
     expect(Microsandbox::Error.ancestors).to include(StandardError)
   end
 
-  # Mirrors sdk/python/microsandbox/errors.py
-  EXPECTED_CODES = {
+  # Mirrors sdk/python/microsandbox/errors.py. A local (not a constant) so it can
+  # drive example-group generation below without leaking a constant from the block.
+  expected_codes = {
     "Error" => "microsandbox-error",
     "InvalidConfigError" => "invalid-config",
     "SandboxNotFoundError" => "sandbox-not-found",
@@ -29,9 +30,9 @@ RSpec.describe "Microsandbox error hierarchy" do
     "MetricsDisabledError" => "metrics-disabled",
     "MetricsUnavailableError" => "metrics-unavailable",
     "UnsupportedOperationError" => "unsupported-operation"
-  }.freeze
+  }
 
-  EXPECTED_CODES.each do |name, code|
+  expected_codes.each do |name, code|
     describe "Microsandbox::#{name}" do
       let(:klass) { Microsandbox.const_get(name) }
 
@@ -52,7 +53,7 @@ RSpec.describe "Microsandbox error hierarchy" do
 
   it "defines exactly the expected error classes" do
     defined = Microsandbox.constants.grep(/Error\z/).map(&:to_s).sort
-    expect(defined).to match_array(EXPECTED_CODES.keys.sort)
+    expect(defined).to match_array(expected_codes.keys.sort)
   end
 
   it "carries the message like a normal exception" do

--- a/spec/unit/network_spec.rb
+++ b/spec/unit/network_spec.rb
@@ -70,8 +70,8 @@ RSpec.describe "network policy" do
         "default_egress" => "deny",
         "default_ingress" => "allow",
         "rules" => [
-          { "action" => "allow", "direction" => "egress",
-            "destination" => "api.openai.com", "protocols" => ["tcp"], "ports" => ["443"] },
+          {"action" => "allow", "direction" => "egress",
+           "destination" => "api.openai.com", "protocols" => ["tcp"], "ports" => ["443"]}
         ],
         "deny_domain_suffixes" => [".ads.example"]
       )
@@ -91,19 +91,19 @@ RSpec.describe "network policy" do
       # spelling Go/Python's PolicyRule use) must not be dropped — that would widen
       # an `allow tcp/443` rule into an all-protocol/all-port allow.
       policy = described_class.custom(
-        rules: [{ action: "allow", destination: "1.1.1.1", protocol: "tcp", port: "443" }]
+        rules: [{action: "allow", destination: "1.1.1.1", protocol: "tcp", port: "443"}]
       )
       expect(policy.to_h["rules"]).to eq(
-        [{ "action" => "allow", "destination" => "1.1.1.1", "protocols" => ["tcp"], "ports" => ["443"] }]
+        [{"action" => "allow", "destination" => "1.1.1.1", "protocols" => ["tcp"], "ports" => ["443"]}]
       )
     end
 
     it "accepts a typed Destination hash inside a hand-written rule" do
       policy = described_class.custom(
-        rules: [{ action: "deny", destination: Microsandbox::Destination.group(:metadata) }]
+        rules: [{action: "deny", destination: Microsandbox::Destination.group(:metadata)}]
       )
       expect(policy.to_h["rules"]).to eq(
-        [{ "action" => "deny", "destination_kind" => "group", "destination" => "metadata" }]
+        [{"action" => "deny", "destination_kind" => "group", "destination" => "metadata"}]
       )
     end
   end
@@ -135,7 +135,7 @@ RSpec.describe "network policy" do
         hash_including(
           "network_policy" => hash_including(
             "default_egress" => "deny",
-            "rules" => [{ "action" => "deny", "direction" => "egress", "destination" => "evil.com" }]
+            "rules" => [{"action" => "deny", "direction" => "egress", "destination" => "evil.com"}]
           )
         )
       )
@@ -144,14 +144,14 @@ RSpec.describe "network policy" do
     it "routes a plain Hash to network_policy" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
-        network: { default_egress: :deny, rules: [{ action: "allow", destination: "1.1.1.1" }] }
+        network: {default_egress: :deny, rules: [{action: "allow", destination: "1.1.1.1"}]}
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
         hash_including(
           "network_policy" => hash_including(
             "default_egress" => "deny",
-            "rules" => [{ "action" => "allow", "destination" => "1.1.1.1" }]
+            "rules" => [{"action" => "allow", "destination" => "1.1.1.1"}]
           )
         )
       )
@@ -160,19 +160,19 @@ RSpec.describe "network policy" do
     it "routes a preset-plus-deny-domains hash to network_policy without injecting defaults" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
-        network: { preset: :public_only, deny_domains: ["evil.com"] }
+        network: {preset: :public_only, deny_domains: ["evil.com"]}
       )
       # Crucially: no default_egress/default_ingress is injected, so the native
       # layer applies the preset's own defaults (regression: injected defaults
       # used to clobber the preset, turning allow_all into deny-all egress).
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
-        hash_including("network_policy" => { "preset" => "public_only", "deny_domains" => ["evil.com"] })
+        hash_including("network_policy" => {"preset" => "public_only", "deny_domains" => ["evil.com"]})
       )
     end
 
     it "routes a bare preset Hash to the legacy network key (preset defaults preserved)" do
-      Microsandbox::Sandbox.create("box", image: "x", network: { preset: :allow_all })
+      Microsandbox::Sandbox.create("box", image: "x", network: {preset: :allow_all})
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box", hash_including("network" => "allow_all")
       )
@@ -183,17 +183,17 @@ RSpec.describe "network policy" do
 
     it "rejects combining a preset with custom rules or defaults" do
       expect do
-        Microsandbox::Sandbox.create("box", image: "x", network: { preset: :public_only, rules: [] })
+        Microsandbox::Sandbox.create("box", image: "x", network: {preset: :public_only, rules: []})
       end.to raise_error(ArgumentError, /preset:.*cannot be combined/)
       expect do
-        Microsandbox::Sandbox.create("box", image: "x", network: { preset: :none, default_ingress: :deny })
+        Microsandbox::Sandbox.create("box", image: "x", network: {preset: :none, default_ingress: :deny})
       end.to raise_error(ArgumentError, /preset:.*cannot be combined/)
     end
 
     it "treats a deny-list-only hash as permissive (block listed domains, allow the rest)" do
       # Regression: { deny_domains: [...] } with no preset/defaults must keep the
       # rest of the network reachable, not deny all unmatched egress.
-      Microsandbox::Sandbox.create("box", image: "x", network: { deny_domains: ["evil.com"] })
+      Microsandbox::Sandbox.create("box", image: "x", network: {deny_domains: ["evil.com"]})
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
         hash_including(
@@ -213,7 +213,7 @@ RSpec.describe "network policy" do
 
     it "still omits network entirely when not given" do
       Microsandbox::Sandbox.create("box", image: "x")
-      expect(Microsandbox::Native::Sandbox).to have_received(:create).with("box", { "image" => "x" })
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with("box", {"image" => "x"})
     end
   end
 end

--- a/spec/unit/patch_spec.rb
+++ b/spec/unit/patch_spec.rb
@@ -60,15 +60,15 @@ RSpec.describe Microsandbox::Patch do
         "box", image: "alpine",
         patches: [
           Microsandbox::Patch.mkdir("/opt/app"),
-          Microsandbox::Patch.text("/opt/app/c.txt", "hi", mode: 0o600),
+          Microsandbox::Patch.text("/opt/app/c.txt", "hi", mode: 0o600)
         ]
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
         hash_including(
           "patches" => [
-            { "kind" => "mkdir", "path" => "/opt/app" },
-            { "kind" => "text", "path" => "/opt/app/c.txt", "content" => "hi", "replace" => false, "mode" => 0o600 },
+            {"kind" => "mkdir", "path" => "/opt/app"},
+            {"kind" => "text", "path" => "/opt/app/c.txt", "content" => "hi", "replace" => false, "mode" => 0o600}
           ]
         )
       )
@@ -77,10 +77,10 @@ RSpec.describe Microsandbox::Patch do
     it "stringifies keys of a hand-written symbol-keyed patch hash" do
       Microsandbox::Sandbox.create(
         "box", image: "alpine",
-        patches: [{ kind: "remove", path: "/etc/motd" }]
+        patches: [{kind: "remove", path: "/etc/motd"}]
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
-        "box", hash_including("patches" => [{ "kind" => "remove", "path" => "/etc/motd" }])
+        "box", hash_including("patches" => [{"kind" => "remove", "path" => "/etc/motd"}])
       )
     end
 
@@ -93,7 +93,7 @@ RSpec.describe Microsandbox::Patch do
     it "omits patches when none are given" do
       Microsandbox::Sandbox.create("box", image: "alpine")
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
-        "box", { "image" => "alpine" }
+        "box", {"image" => "alpine"}
       )
     end
   end

--- a/spec/unit/roadmap_spec.rb
+++ b/spec/unit/roadmap_spec.rb
@@ -34,9 +34,9 @@ RSpec.describe "streaming exec, images, volumes" do
 
     it "is Enumerable and yields events until recv returns nil" do
       allow(native).to receive(:recv).and_return(
-        { "type" => "started", "pid" => 1 },
-        { "type" => "stdout", "data" => "hi".b },
-        { "type" => "exited", "code" => 0 },
+        {"type" => "started", "pid" => 1},
+        {"type" => "stdout", "data" => "hi".b},
+        {"type" => "exited", "code" => 0},
         nil
       )
       types = handle.map(&:type)
@@ -79,7 +79,7 @@ RSpec.describe "streaming exec, images, volumes" do
   describe Microsandbox::Image do
     it "maps list/get/remove/prune through the native layer" do
       allow(Microsandbox::Native::Image).to receive(:list).and_return(
-        [{ "reference" => "alpine", "layer_count" => 1 }]
+        [{"reference" => "alpine", "layer_count" => 1}]
       )
       allow(Microsandbox::Native::Image).to receive(:remove)
       allow(Microsandbox::Native::Image).to receive(:prune).and_return(
@@ -107,9 +107,9 @@ RSpec.describe "streaming exec, images, volumes" do
     end
 
     it "normalizes create options" do
-      info = Microsandbox::Volume.create("v", kind: :disk, size_mib: 256, quota_mib: 512, labels: { a: 1 })
+      info = Microsandbox::Volume.create("v", kind: :disk, size_mib: 256, quota_mib: 512, labels: {a: 1})
       expect(Microsandbox::Native::Volume).to have_received(:create).with(
-        "v", hash_including("kind" => "disk", "size_mib" => 256, "quota_mib" => 512, "labels" => { "a" => "1" })
+        "v", hash_including("kind" => "disk", "size_mib" => 256, "quota_mib" => 512, "labels" => {"a" => "1"})
       )
       expect(info).to be_a(Microsandbox::VolumeInfo)
       expect(info.name).to eq("v")
@@ -130,7 +130,7 @@ RSpec.describe "streaming exec, images, volumes" do
       Microsandbox::Sandbox.create(
         "box",
         from_snapshot: "snap-1",
-        volumes: { "/data" => "/host/data", "/cache" => { named: "cache-vol" } }
+        volumes: {"/data" => "/host/data", "/cache" => {named: "cache-vol"}}
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
@@ -143,7 +143,7 @@ RSpec.describe "streaming exec, images, volumes" do
 
     it "raises on a malformed volume spec" do
       expect do
-        Microsandbox::Sandbox.create("box", image: "x", volumes: { "/data" => { wrong: 1 } })
+        Microsandbox::Sandbox.create("box", image: "x", volumes: {"/data" => {wrong: 1}})
       end.to raise_error(ArgumentError, /:bind or :named/)
     end
 

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Microsandbox::Sandbox do
       Microsandbox::Sandbox.create(
         "box",
         image: "python", cpus: 2, memory: 1024,
-        env: { FOO: 1, "BAR" => :baz }, workdir: "/app",
-        labels: { team: "core" }, ports: { "8080" => 80 },
+        env: {:FOO => 1, "BAR" => :baz}, workdir: "/app",
+        labels: {team: "core"}, ports: {"8080" => 80},
         network: :public_only, entrypoint: %w[/bin/sh -c]
       )
 
@@ -30,9 +30,9 @@ RSpec.describe Microsandbox::Sandbox do
           "cpus" => 2,
           "memory" => 1024,
           "workdir" => "/app",
-          "env" => { "FOO" => "1", "BAR" => "baz" },
-          "labels" => { "team" => "core" },
-          "ports" => { 8080 => 80 },
+          "env" => {"FOO" => "1", "BAR" => "baz"},
+          "labels" => {"team" => "core"},
+          "ports" => {8080 => 80},
           "network" => "public_only",
           "entrypoint" => ["/bin/sh", "-c"]
         )
@@ -42,7 +42,7 @@ RSpec.describe Microsandbox::Sandbox do
     it "omits unspecified options" do
       Microsandbox::Sandbox.create("box", image: "alpine")
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
-        "box", { "image" => "alpine" }
+        "box", {"image" => "alpine"}
       )
     end
 
@@ -54,7 +54,7 @@ RSpec.describe Microsandbox::Sandbox do
     it "flattens registry_auth into registry_username/registry_password" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
-        registry_auth: { username: "alice", password: "s3cr3t" }
+        registry_auth: {username: "alice", password: "s3cr3t"}
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
@@ -65,7 +65,7 @@ RSpec.describe Microsandbox::Sandbox do
     it "accepts string-keyed registry_auth and passes insecure + ca_certs through" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
-        registry_auth: { "username" => "bob", "password" => "tok" },
+        registry_auth: {"username" => "bob", "password" => "tok"},
         registry_insecure: true,
         registry_ca_certs: "-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----"
       )
@@ -97,14 +97,14 @@ RSpec.describe Microsandbox::Sandbox do
 
     it "raises on a half-specified registry_auth (missing password)" do
       expect do
-        Microsandbox::Sandbox.create("box", image: "x", registry_auth: { username: "alice" })
+        Microsandbox::Sandbox.create("box", image: "x", registry_auth: {username: "alice"})
       end.to raise_error(ArgumentError, /:username and :password/)
     end
 
     it "maps pull_policy and normalizes secrets into [env, value, host] triples" do
       Microsandbox::Sandbox.create(
         "box", image: "x", pull_policy: "never",
-        secrets: [{ env: "OPENAI_API_KEY", value: "sk-123", host: "api.openai.com" }]
+        secrets: [{env: "OPENAI_API_KEY", value: "sk-123", host: "api.openai.com"}]
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
@@ -117,7 +117,7 @@ RSpec.describe Microsandbox::Sandbox do
 
     it "raises on a malformed secret spec" do
       expect do
-        Microsandbox::Sandbox.create("box", image: "x", secrets: [{ env: "X" }])
+        Microsandbox::Sandbox.create("box", image: "x", secrets: [{env: "X"}])
       end.to raise_error(ArgumentError, /:env, :value, and :host/)
     end
 
@@ -132,14 +132,14 @@ RSpec.describe Microsandbox::Sandbox do
       Microsandbox::Sandbox.create(
         "box", image: "x", log_level: :debug, quiet_logs: true, security: "restricted",
         oci_upper_size: 2048, max_duration: 600, idle_timeout: 120,
-        ports_udp: { "53" => 53 }, rlimits: { nofile: 1024, cpu: [10, 20] }
+        ports_udp: {"53" => 53}, rlimits: {nofile: 1024, cpu: [10, 20]}
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
         hash_including(
           "log_level" => "debug", "quiet_logs" => true, "security" => "restricted",
           "oci_upper_size" => 2048, "max_duration" => 600, "idle_timeout" => 120,
-          "ports_udp" => { 53 => 53 },
+          "ports_udp" => {53 => 53},
           "rlimits" => [["nofile", 1024, 1024], ["cpu", 10, 20]]
         )
       )
@@ -180,18 +180,18 @@ RSpec.describe Microsandbox::Sandbox do
 
   describe "#exec option mapping" do
     let(:exec_result) do
-      { "exit_code" => 0, "success" => true, "stdout" => "".b, "stderr" => "".b }
+      {"exit_code" => 0, "success" => true, "stdout" => "".b, "stderr" => "".b}
     end
 
     before { allow(native).to receive(:exec).and_return(exec_result) }
 
     it "passes command, args, and a normalized options hash" do
       sb = Microsandbox::Sandbox.create("box", image: "x")
-      out = sb.exec("ls", ["-l", :foo], cwd: "/tmp", env: { A: 1 }, timeout: 5, tty: true, stdin: "in")
+      out = sb.exec("ls", ["-l", :foo], cwd: "/tmp", env: {A: 1}, timeout: 5, tty: true, stdin: "in")
 
       expect(native).to have_received(:exec).with(
         "ls", ["-l", "foo"],
-        hash_including("cwd" => "/tmp", "env" => { "A" => "1" }, "timeout" => 5.0, "tty" => true, "stdin" => "in")
+        hash_including("cwd" => "/tmp", "env" => {"A" => "1"}, "timeout" => 5.0, "tty" => true, "stdin" => "in")
       )
       expect(out).to be_a(Microsandbox::ExecOutput)
     end
@@ -222,7 +222,7 @@ RSpec.describe Microsandbox::Sandbox do
 
     it "normalizes per-exec rlimits into [resource, soft, hard] triples" do
       sb = Microsandbox::Sandbox.create("box", image: "x")
-      sb.exec("ls", [], rlimits: { nofile: 256, as: [1000, 2000] })
+      sb.exec("ls", [], rlimits: {nofile: 256, as: [1000, 2000]})
       expect(native).to have_received(:exec).with(
         "ls", [], hash_including("rlimits" => [["nofile", 256, 256], ["as", 1000, 2000]])
       )
@@ -232,7 +232,7 @@ RSpec.describe Microsandbox::Sandbox do
   describe "#shell option mapping" do
     before do
       allow(native).to receive(:shell).and_return(
-        { "exit_code" => 0, "success" => true, "stdout" => "".b, "stderr" => "".b }
+        {"exit_code" => 0, "success" => true, "stdout" => "".b, "stderr" => "".b}
       )
     end
 
@@ -320,14 +320,14 @@ RSpec.describe Microsandbox::Sandbox do
       native_stream = instance_double(Microsandbox::Native::LogStream)
       allow(native).to receive(:log_stream).and_return(native_stream)
       allow(native_stream).to receive(:recv).and_return(
-        { "timestamp_ms" => 1_700_000_000_000, "source" => "stdout",
-          "session_id" => 1, "cursor" => "abc", "data" => "hi".b },
+        {"timestamp_ms" => 1_700_000_000_000, "source" => "stdout",
+         "session_id" => 1, "cursor" => "abc", "data" => "hi".b},
         nil
       )
       stream = sb.log_stream(sources: [:stdout, "stderr"], since_ms: 1000, until_ms: 2000, follow: true)
       expect(native).to have_received(:log_stream).with(
         hash_including("sources" => %w[stdout stderr], "since_ms" => 1000.0,
-                       "until_ms" => 2000.0, "follow" => true)
+          "until_ms" => 2000.0, "follow" => true)
       )
       entries = stream.to_a
       expect(entries.first).to be_a(Microsandbox::LogEntry)
@@ -348,11 +348,11 @@ RSpec.describe Microsandbox::Sandbox do
   describe ".list_with" do
     it "normalizes label filters into a string-keyed labels hash" do
       allow(Microsandbox::Native::Sandbox).to receive(:list_with).and_return(
-        [{ "name" => "box", "status" => "running" }]
+        [{"name" => "box", "status" => "running"}]
       )
-      infos = Microsandbox::Sandbox.list_with(labels: { team: :core })
+      infos = Microsandbox::Sandbox.list_with(labels: {team: :core})
       expect(Microsandbox::Native::Sandbox).to have_received(:list_with).with(
-        "labels" => { "team" => "core" }
+        "labels" => {"team" => "core"}
       )
       expect(infos.first).to be_a(Microsandbox::SandboxInfo)
       expect(infos.first.name).to eq("box")

--- a/spec/unit/snapshot_spec.rb
+++ b/spec/unit/snapshot_spec.rb
@@ -8,12 +8,12 @@ RSpec.describe Microsandbox::Snapshot do
       allow(Microsandbox::Native::Snapshot).to receive(:create).and_return(
         "digest" => "sha256:abc", "path" => "/snaps/x", "size_bytes" => 2048
       )
-      info = described_class.create("box", name: "snap1", labels: { kind: :base },
-                                    force: true, record_integrity: true)
+      info = described_class.create("box", name: "snap1", labels: {kind: :base},
+        force: true, record_integrity: true)
       expect(Microsandbox::Native::Snapshot).to have_received(:create).with(
         "box",
-        hash_including("name" => "snap1", "labels" => { "kind" => "base" },
-                       "force" => true, "record_integrity" => true)
+        hash_including("name" => "snap1", "labels" => {"kind" => "base"},
+          "force" => true, "record_integrity" => true)
       )
       expect(info).to be_a(Microsandbox::SnapshotInfo)
       expect(info.digest).to eq("sha256:abc")
@@ -34,8 +34,8 @@ RSpec.describe Microsandbox::Snapshot do
   describe ".list / .get" do
     it "wraps handles in SnapshotInfo with parsed format and timestamp" do
       allow(Microsandbox::Native::Snapshot).to receive(:list).and_return(
-        [{ "digest" => "sha256:d", "path" => "/p", "name" => "s", "image_ref" => "alpine",
-           "format" => "qcow2", "size_bytes" => 10, "created_at_ms" => 1_700_000_000_000 }]
+        [{"digest" => "sha256:d", "path" => "/p", "name" => "s", "image_ref" => "alpine",
+          "format" => "qcow2", "size_bytes" => 10, "created_at_ms" => 1_700_000_000_000}]
       )
       info = described_class.list.first
       expect(info.name).to eq("s")


### PR DESCRIPTION
## Summary

Two independent, tooling-only changes (no gem behavior change):

### 1. Adopt StandardRB for the Ruby layer
Brings `lib/` and `spec/` under a zero-config linter/formatter, mirroring the existing `cargo fmt` + `clippy -D warnings` gate on the Rust side.

- Add the `standard` dev gem + `rake standard` / `standard:fix` tasks
- Add a `standardrb` step to the CI lint job (now `rustfmt + clippy + standardrb`)
- Autocorrect the existing Ruby tree to conform — almost entirely mechanical (hash-literal brace spacing, argument alignment, endless-method spacing)

Three changes were **not** pure whitespace and were verified behavior-preserving by hand:
- `exec_handle.rb` / `snapshot.rb`: safe navigation (`a && a.x` → `a&.x`); the receivers are only ever `String`/`nil`, never `false`
- `errors_spec.rb`: the `EXPECTED_CODES` constant (defined inside the `describe` block) became a block-local variable — it drives example-group generation, so it can't be a `let`; example blocks close over it
- `#inspect` ternaries inside string interpolation (`#{cond ? " x" : ""}` → `#{" x" if cond}`) are equivalent because `nil.to_s == ""` in interpolation

### 2. Add Claude Code project config
- **`CLAUDE.md`** — two-layer architecture, build/test/lint commands, the two independent version axes (gem version lock-step vs upstream runtime `tag`), KVM-gated integration specs, key env vars, OIDC release flow
- **`.claude/skills/verify-local`** — runs the full local gate in one shot
- **`.claude/skills/release`** — walks the version-bump + tag → OIDC-publish SOP (user-triggered only)
- **`.claude/settings.json`** — PostToolUse hook that `cargo fmt`s edited `.rs` files

## Verification
- `bundle exec standardrb` → clean
- `bundle exec rake spec` → 201 examples, 0 failures
- `cargo fmt --check` → clean
- Rust source is byte-identical to `main` (no `.rs` change), so `clippy` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)