### PR TITLE
fix(sandbox): validate durations and reject contradictory rootfs source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reject invalid durations with a clear `ArgumentError`** — negative, `NaN`,
+  and infinite values passed to `timeout:` (`exec`/`shell`), `stop`/`kill`
+  timeouts, `replace_with_timeout:`, and `metrics_stream(interval:)` are now
+  rejected in Ruby before reaching the native layer, where they would otherwise
+  panic across the FFI boundary (`Duration::from_secs_f64` panics on exactly
+  those inputs).
+- **Reject contradictory `image:` + `from_snapshot:`** — `Sandbox.create` now
+  raises `ArgumentError` when both are given (a sandbox boots from exactly one
+  rootfs source), failing fast instead of after a runtime round-trip.
+
 ## [0.5.9] - 2026-06-18
 
 Closes the remaining roadmap items, bringing the binding surface to parity with

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -152,6 +152,12 @@ module Microsandbox
         pull_policy: nil, registry_auth: nil, registry_insecure: false,
         registry_ca_certs: nil, secrets: nil,
         detached: false, replace: false, replace_with_timeout: nil)
+        # A sandbox boots from exactly one rootfs source. The core would reject a
+        # contradictory pair, but only after a runtime round-trip; fail fast and
+        # clearly here (the Python SDK validates this the same way).
+        if image && from_snapshot
+          raise ArgumentError, "provide either image: or from_snapshot:, not both"
+        end
         Microsandbox.ensure_runtime!
         opts = {}
         opts["image"] = image.to_s if image
@@ -183,7 +189,7 @@ module Microsandbox
         opts["secrets"] = normalize_secrets(secrets) if secrets
         opts["detached"] = true if detached
         if replace_with_timeout
-          opts["replace_with_timeout"] = Float(replace_with_timeout)
+          opts["replace_with_timeout"] = coerce_duration(replace_with_timeout, "replace_with_timeout")
         elsif replace
           opts["replace"] = true
         end
@@ -237,6 +243,19 @@ module Microsandbox
       end
 
       private
+
+      # Coerce a seconds value to a finite, non-negative Float. Rejects negatives,
+      # NaN, and infinities *here* (a clean ArgumentError) rather than letting them
+      # reach the native layer, where `Duration::from_secs_f64` panics across the
+      # FFI boundary on exactly those inputs. Shared by every duration option.
+      def coerce_duration(value, label)
+        seconds = Float(value)
+        unless seconds.finite? && seconds >= 0
+          raise ArgumentError,
+            "#{label} must be a finite, non-negative number of seconds (got #{value.inspect})"
+        end
+        seconds
+      end
 
       def stringify(hash)
         hash.each_with_object({}) { |(k, v), acc| acc[k.to_s] = v.to_s }
@@ -475,7 +494,7 @@ module Microsandbox
     # @param interval [Numeric] seconds between snapshots
     # @return [MetricsStream] an {Enumerable} of {Metrics}
     def metrics_stream(interval: 1.0)
-      MetricsStream.new(@native.metrics_stream(Float(interval)))
+      MetricsStream.new(@native.metrics_stream(coerce_duration(interval, "interval")))
     end
 
     # Stream captured logs as they appear.
@@ -502,7 +521,7 @@ module Microsandbox
     # @param timeout [Numeric, nil] seconds to wait before SIGKILL
     # @return [nil]
     def stop(timeout: nil)
-      @native.stop(timeout && Float(timeout))
+      @native.stop(timeout && coerce_duration(timeout, "timeout"))
       nil
     end
 
@@ -510,7 +529,7 @@ module Microsandbox
     # @param timeout [Numeric, nil] seconds to wait
     # @return [nil]
     def kill(timeout: nil)
-      @native.kill(timeout && Float(timeout))
+      @native.kill(timeout && coerce_duration(timeout, "timeout"))
       nil
     end
 
@@ -562,12 +581,18 @@ module Microsandbox
 
     private
 
+    # Instance-side shim for the shared, class-private duration validator (used
+    # by #exec/#shell timeouts, #stop/#kill, and #metrics_stream).
+    def coerce_duration(value, label)
+      self.class.send(:coerce_duration, value, label)
+    end
+
     def exec_opts(cwd:, user:, env:, timeout:, tty:, stdin:, rlimits:, pipe_ok: false)
       opts = {}
       opts["cwd"] = cwd.to_s if cwd
       opts["user"] = user.to_s if user
       opts["env"] = env.each_with_object({}) { |(k, v), a| a[k.to_s] = v.to_s } if env
-      opts["timeout"] = Float(timeout) if timeout
+      opts["timeout"] = coerce_duration(timeout, "timeout") if timeout
       opts["tty"] = true if tty
       # `stdin: :pipe` opens a streaming stdin pipe — write to it via
       # {ExecHandle#stdin} and close to send EOF. It is only meaningful for the

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -145,6 +145,27 @@ RSpec.describe Microsandbox::Sandbox do
       )
     end
 
+    it "raises when both image: and from_snapshot: are given" do
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", from_snapshot: "snap")
+      end.to raise_error(ArgumentError, /either image: or from_snapshot:/)
+      expect(Microsandbox::Native::Sandbox).not_to have_received(:create)
+    end
+
+    it "accepts from_snapshot: on its own" do
+      Microsandbox::Sandbox.create("box", from_snapshot: "snap")
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box", hash_including("from_snapshot" => "snap")
+      )
+    end
+
+    it "rejects a negative replace_with_timeout before any runtime round-trip" do
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", replace_with_timeout: -1)
+      end.to raise_error(ArgumentError, /replace_with_timeout must be a finite, non-negative/)
+      expect(Microsandbox::Native::Sandbox).not_to have_received(:create)
+    end
+
     it "prefers replace_with_timeout over replace" do
       Microsandbox::Sandbox.create("box", image: "x", replace: true, replace_with_timeout: 5)
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
@@ -251,6 +272,54 @@ RSpec.describe Microsandbox::Sandbox do
       sb.kill
       expect(native).to have_received(:stop).with(3.0)
       expect(native).to have_received(:kill).with(nil)
+    end
+  end
+
+  describe "duration validation" do
+    subject(:sb) { Microsandbox::Sandbox.create("box", image: "x") }
+
+    before do
+      allow(native).to receive(:exec).and_return(
+        {"exit_code" => 0, "success" => true, "stdout" => "".b, "stderr" => "".b}
+      )
+      allow(native).to receive(:kill)
+      allow(native).to receive(:metrics_stream)
+    end
+
+    # The native layer's Duration::from_secs_f64 panics on these; they must be
+    # caught in Ruby as a clean ArgumentError, never reaching the binding.
+    [-1, -0.5, Float::INFINITY, -Float::INFINITY, Float::NAN].each do |bad|
+      it "rejects #{bad.inspect} as an exec timeout without calling the native layer" do
+        expect { sb.exec("sleep", ["1"], timeout: bad) }
+          .to raise_error(ArgumentError, /timeout must be a finite, non-negative/)
+        expect(native).not_to have_received(:exec)
+      end
+
+      it "rejects #{bad.inspect} as a stop timeout" do
+        expect { sb.stop(timeout: bad) }
+          .to raise_error(ArgumentError, /timeout must be a finite, non-negative/)
+      end
+
+      it "rejects #{bad.inspect} as a metrics_stream interval" do
+        expect { sb.metrics_stream(interval: bad) }
+          .to raise_error(ArgumentError, /interval must be a finite, non-negative/)
+        expect(native).not_to have_received(:metrics_stream)
+      end
+    end
+
+    # Valid durations (including 0 and integers) still flow through unchanged.
+    it "accepts 0, integers, and positive floats" do
+      sb.exec("true", [], timeout: 0)
+      sb.exec("true", [], timeout: 5)
+      sb.exec("true", [], timeout: 1.5)
+      expect(native).to have_received(:exec).with("true", [], hash_including("timeout" => 0.0))
+      expect(native).to have_received(:exec).with("true", [], hash_including("timeout" => 5.0))
+      expect(native).to have_received(:exec).with("true", [], hash_including("timeout" => 1.5))
+    end
+
+    it "leaves a nil timeout absent (no coercion)" do
+      sb.exec("true")
+      expect(native).to have_received(:exec).with("true", [], hash_excluding("timeout"))
     end
   end
 


### PR DESCRIPTION
## What

Two version-independent, pure-Ruby robustness fixes to `Microsandbox::Sandbox`, both surfaced by an audit against the official Python SDK binding.

### 1. Reject invalid durations before they panic across FFI
Ruby's `Float(...)` happily accepts `-1`, `Float::INFINITY`, and `Float::NAN`, all of which reach the native layer where `Duration::from_secs_f64` **panics** (it panics on negative, non-finite, or overflowing input). A panic crossing the magnus FFI boundary is at best an opaque error, at worst a process abort.

A shared `coerce_duration(value, label)` helper now validates `finite? && >= 0` and raises a clean `ArgumentError` in Ruby first. Applied at every duration site:
- `exec`/`shell` `timeout:`
- `stop(timeout:)` / `kill(timeout:)`
- `Sandbox.create(replace_with_timeout:)`
- `metrics_stream(interval:)`

This matches the Python SDK, which validates `>= 0` and raises `ValueError`.

### 2. Reject contradictory `image:` + `from_snapshot:`
A sandbox boots from exactly one rootfs source. `Sandbox.create` now raises `ArgumentError` when both are given (fail fast, before `ensure_runtime!` / any runtime round-trip), matching the Python SDK's xor validation.

## Testing
- New unit specs cover adversarial inputs (`-1 / -0.5 / +∞ / -∞ / NaN`) across exec timeout / stop / metrics interval, asserting `ArgumentError` is raised **and the native layer is never called**; plus valid `0` / integer / positive-float / `nil` pass-through, and the `image`/`from_snapshot` xor.
- Verified against the **pinned `v0.5.7`** core dep (override moved aside): `standardrb`, `cargo fmt --check`, `cargo clippy -D warnings`, and `rake spec` (221 examples, 0 failures) all green.

## Notes
A third candidate fix (mapping `CloudHttpError`/`UnsupportedError`) was investigated and **dropped**: adversarial verification (compiling against the pinned `v0.5.7`) proved those `MicrosandboxError` variants do not exist at `v0.5.7` — they are post-tag `#754` backend-routing surface and are tracked separately (issue #7). Only the version-independent fixes ship here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)