### PR TITLE
feat!: align with upstream microsandbox v0.5.8 (backend routing + lifecycle split)

### DIFF
--- a/.cargo/config.toml.example
+++ b/.cargo/config.toml.example
@@ -11,7 +11,11 @@
 # `paths` overrides any dependency whose name + version matches a crate found at
 # the listed path. Paths are relative to this gem's root.
 
+# NOTE: as of upstream v0.5.8 the core `microsandbox` crate moved from
+# `crates/microsandbox` to `sdk/rust` (PR #989); `microsandbox-network` stayed at
+# `crates/network`. Cargo's `paths` override matches by package name, not path, so
+# only the directory below needs to be correct for the override to take effect.
 paths = [
-  "../microsandbox/crates/microsandbox",
+  "../microsandbox/sdk/rust",
   "../microsandbox/crates/network",
 ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,64 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+Adopts the upstream **microsandbox `v0.5.8`** runtime (was `v0.5.7`), whose
+backend-routing rewrite (upstream PR #754) both adds new surface and reshapes the
+sandbox lifecycle.
+
+### Changed
+
+- **BREAKING — sandbox lifecycle split (mirrors the official Python/Node SDKs).**
+  Upstream `v0.5.8` split the lifecycle across a live `Sandbox` and a lightweight
+  `SandboxHandle`. The gem follows suit:
+  - The live `Microsandbox::Sandbox` (from `Sandbox.create`/`Sandbox.start`) now
+    exposes `#stop`, `#stop_and_wait`, `#kill`, `#drain`, `#wait`, `#status`,
+    `#detach`, and `#owns_lifecycle?`. `#stop` and `#kill` **no longer take a
+    `timeout:`** keyword; `#stop` performs the graceful SIGTERM→SIGKILL
+    escalation (10s default) the official SDKs use.
+  - `#request_stop`, `#request_kill`, `#request_drain`, `#wait_until_stopped`,
+    and a custom stop/kill timeout have **moved off** the live `Sandbox` onto the
+    controllable `Microsandbox::SandboxHandle` (see Added).
+- **BREAKING — `Sandbox.get`/`.list`/`.list_with` now return a controllable
+  `Microsandbox::SandboxHandle`** instead of a read-only `SandboxInfo`. The
+  handle keeps the same metadata accessors (`name`, `status`, `created_at`,
+  `updated_at`, `running?`, `stopped?`). `Microsandbox::SandboxInfo` remains as a
+  deprecated constant alias for `SandboxHandle`.
+- `SandboxStatus` gained two values, `:created` and `:starting` (cloud-only
+  today), so `#status` may now return them.
+
+### Added
+
+- **Backend routing** — `Microsandbox.set_default_backend(kind, url:, api_key:,
+  profile:)`, `Microsandbox.with_backend(kind, …) { … }` (a scoped, restoring
+  override), and `Microsandbox.default_backend_kind`. Without configuration the
+  runtime resolves a backend lazily from `MSB_BACKEND`, `MSB_API_URL` +
+  `MSB_API_KEY`, `MSB_PROFILE`, and `~/.microsandbox/config.json` (honoring
+  `MSB_CONFIG_PATH`). The cloud backend supports a documented subset
+  (create/start/stop/remove/get/list, one-shot exec, follow log streaming);
+  unsupported operations raise `UnsupportedError`.
+- **`Microsandbox::SandboxHandle`** — the controllable handle returned by
+  `Sandbox.get`/`.list`/`.list_with`: `#stop`, `#stop_with_timeout(secs)`,
+  `#kill`, `#kill_with_timeout(secs)`, `#request_stop`, `#request_kill`,
+  `#request_drain`, `#wait_until_stopped` (→ `SandboxStopResult`), plus the
+  metadata accessors. Mirrors the official SDKs' `SandboxHandle`.
+- **`Sandbox#stop_and_wait` / `Sandbox#wait`** — return a `Microsandbox::ExitStatus`
+  (`#exit_code`, `#success?`). **`Sandbox#drain`** triggers a graceful drain.
+  **`Sandbox#status`** fetches the live status from the backend.
+- **`Microsandbox.libkrunfw_path=`** — overrides the `libkrunfw` shared-library
+  path (SDK tier of the resolver; `MSB_LIBKRUNFW_PATH` still wins). Mirrors
+  `runtime_path=`.
+- **`Microsandbox::CloudHttpError`** (`cloud-http`) and
+  **`Microsandbox::UnsupportedError`** (`unsupported`) — distinct from the
+  existing `UnsupportedOperationError`.
+
 ### Fixed
 
 - **Reject invalid durations with a clear `ArgumentError`** — negative, `NaN`,
-  and infinite values passed to `timeout:` (`exec`/`shell`), `stop`/`kill`
-  timeouts, `replace_with_timeout:`, and `metrics_stream(interval:)` are now
-  rejected in Ruby before reaching the native layer, where they would otherwise
-  panic across the FFI boundary (`Duration::from_secs_f64` panics on exactly
-  those inputs).
+  and infinite values passed to `timeout:` (`exec`/`shell`),
+  `SandboxHandle#stop_with_timeout`/`#kill_with_timeout`, `replace_with_timeout:`,
+  and `metrics_stream(interval:)` are rejected in Ruby before reaching the native
+  layer, where they would otherwise panic across the FFI boundary
+  (`Duration::from_secs_f64` panics on exactly those inputs).
 - **Reject contradictory `image:` + `from_snapshot:`** — `Sandbox.create` now
   raises `ArgumentError` when both are given (a sandbox boots from exactly one
   rootfs source), failing fast instead of after a runtime round-trip.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ sandbox lifecycle.
   `MSB_API_KEY`, `MSB_PROFILE`, and `~/.microsandbox/config.json` (honoring
   `MSB_CONFIG_PATH`). The cloud backend supports a documented subset
   (create/start/stop/remove/get/list, one-shot exec, follow log streaming);
-  unsupported operations raise `UnsupportedError`.
+  unsupported operations raise `UnsupportedError`. Under a cloud backend,
+  `Sandbox.create`/`.start` skip local `msb`/`libkrunfw` runtime provisioning
+  (it isn't needed), so cloud-only hosts no longer trigger a spurious download.
 - **`Microsandbox::SandboxHandle`** — the controllable handle returned by
   `Sandbox.get`/`.list`/`.list_with`: `#stop`, `#stop_with_timeout(secs)`,
   `#kill`, `#kill_with_timeout(secs)`, `#request_stop`, `#request_kill`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,8 +3003,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3031,6 +3031,7 @@ dependencies = [
  "microsandbox-network",
  "microsandbox-protocol",
  "microsandbox-runtime",
+ "microsandbox-types",
  "microsandbox-utils",
  "nix 0.31.3",
  "notify",
@@ -3047,6 +3048,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tokio-tungstenite",
  "tracing",
  "typed-builder",
  "which",
@@ -3054,8 +3056,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3067,8 +3069,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3079,8 +3081,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3092,8 +3094,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3118,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "chrono",
  "libc",
@@ -3129,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3138,8 +3140,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "base64",
  "bytes",
@@ -3178,11 +3180,12 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "chrono",
  "ciborium",
+ "microsandbox-types",
  "serde",
  "serde_bytes",
  "strum 0.28.0",
@@ -3192,19 +3195,21 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "bytes",
  "chrono",
  "clap",
  "crossbeam-queue",
  "libc",
+ "microsandbox-agent-client",
  "microsandbox-db",
  "microsandbox-filesystem",
  "microsandbox-metrics",
  "microsandbox-network",
  "microsandbox-protocol",
+ "microsandbox-types",
  "microsandbox-utils",
  "msb_krun",
  "nix 0.31.3",
@@ -3219,9 +3224,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "microsandbox-types"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+dependencies = [
+ "chrono",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "microsandbox-utils"
-version = "0.5.7"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.7#4dbb712bfd636f8964939a5317f749ba111e6a6d"
+version = "0.5.8"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "dirs",
  "libc",
@@ -3306,9 +3323,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5df0f4dbc4771ed8df8a7ed584221e48bc3fe1726242378332a02ce27518ca53"
+checksum = "72a554acf513be16b336fbcd4a9bab29a78b06a5ddf94e917481cfeafc1078f5"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3326,9 +3343,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923b2f7ed0d299b37ea9bbc47e9d8fe1a46c44e1ecf1d9ecf306377b20f90762"
+checksum = "9d270d914cee3125cf71734b9a5aa60fe7d9648f09511999199424e0fe1a88c6"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3342,15 +3359,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aff114cab67c406f051985749d7cd4aedab3fd445936f6759fd95de9c0352bb7"
+checksum = "8372d1e4e8c853e20ffb5568a4cc3f930a2bf1ce25bc346812ac7b84e84639d4"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f4a5cf30e814f211c32c43ee88e9a711ed0b17b88396a80baf5360f49ade848"
+checksum = "179542321455c65a8e4b14c09bc8443227a89cd46ef2c9c06f0ee1ab11f510ea"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3359,9 +3376,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80f22c8cd187fc729c7f3b0922ae9e2e078809172f305dd343a6c4c71a219d68"
+checksum = "67350e76fd466e1a089b89fa548ba85a92f237c2d3dab179ba675cfd18eb9a39"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3387,9 +3404,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c816c66f7eb6ccf751cb250a1c7ab0bc261cac6cef36ee68a8b673864ce5800"
+checksum = "13eaca12857149c3552007a18c7f863ccc6b4dddcf2863c0bcc8fbc2aa2d4c6e"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -3399,9 +3416,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "294eaf9998761721183f080866ddca635f3186da8541d2a273f60cf719ee92c3"
+checksum = "514f7493860978b08819fdcc4ef3d1887fd4d2b5e26ad0a0eabcec005410df94"
 dependencies = [
  "msb_krun_utils",
  "vm-memory 0.16.2",
@@ -3409,9 +3426,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778c4a9713517f131ae5b0c3e6c299a7e70ced97edeedd6e469639b9d7390fe2"
+checksum = "08ebbb0336b9cd8dcffa9c47d01a729de4f83c39fc099620f4f9c4d8ef69f460"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3419,18 +3436,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775c50a8ab2688083eaf8636af96bed12974d5be9e5811e4c5665cea4fd06ff8"
+checksum = "f25cb991386c6aca7c74d0bd8b327a807290830e439fbb473c5e1b62a7c66d32"
 dependencies = [
  "vm-memory 0.16.2",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f620c8707cd19f6c67c004c2e80744a0bdab7349e18564ec982f8542712a375"
+checksum = "b7104f87f235ef5cc320ffa760b7cd3635960b58cdc5e1ec89df852fc538f042"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3443,9 +3460,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb70c044c60e011e6f43c2e336687850b0910853a0efe37010e9649eff1395fe"
+checksum = "6742a7fba174849b924a370bfba0fe7be8435253bff26303aec34ac89641ae63"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -6010,6 +6027,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6150,6 +6179,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1 0.10.6",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "typed-builder"

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -126,9 +126,13 @@ git. The override must never be committed — it would break container builds.
 ## Implemented surface (v1) vs roadmap
 
 **Implemented:** sandbox lifecycle (`create`/`start`/`get`/`list`/`list_with`/
-`remove`/`stop`/`kill`, the async `request_stop`/`request_kill`/`request_drain`/
-`wait_until_stopped` (→ `SandboxStopResult`) / `detach` / `owns_lifecycle?`
-controls, block form), `exec`/`shell` with collected `ExecOutput`,
+`remove`; the live `Sandbox` exposes `stop`/`stop_and_wait`/`kill`/`drain`/
+`wait` (→ `ExitStatus`) / `status` / `detach` / `owns_lifecycle?`, while the
+controllable `SandboxHandle` from `get`/`list` carries the fine-grained
+`stop_with_timeout`/`request_stop`/`request_kill`/`request_drain`/
+`wait_until_stopped` (→ `SandboxStopResult`) controls — the v0.5.8 live-vs-handle
+split that mirrors the official SDKs), backend routing (`set_default_backend`/
+`with_backend`/`default_backend_kind`), block form), `exec`/`shell` with collected `ExecOutput`,
 **streaming** `exec_stream`/`shell_stream` (`ExecHandle` is `Enumerable` over
 `ExecEvent`s, with stdin sink + signal/kill/resize), the full guest filesystem
 API (`fs.read`/`write`/`list`/`mkdir`/`remove`/`stat`/…), `metrics`,

--- a/README.md
+++ b/README.md
@@ -121,16 +121,32 @@ sb = Microsandbox::Sandbox.create("box", image: "public.ecr.aws/docker/library/a
 begin
   # ...
 ensure
-  sb.stop          # graceful (sb.stop(timeout: 5) to bound the wait)
-  # sb.kill        # force (SIGKILL)
+  sb.stop          # graceful (SIGTERM→SIGKILL escalation, 10s default)
+  # sb.stop_and_wait # graceful, then wait → ExitStatus(#exit_code, #success?)
+  # sb.kill          # force (SIGKILL); sb.drain for a graceful drain
 end
 
-# Inspect / manage existing sandboxes
-Microsandbox::Sandbox.list            # => [Microsandbox::SandboxInfo, ...]
-Microsandbox::Sandbox.get("box")      # => Microsandbox::SandboxInfo
+# Inspect / manage existing sandboxes. `get`/`list` return a controllable
+# SandboxHandle (the live `stop`/`kill`/`drain`/`wait` live on the object from
+# `create`/`start`; fine-grained control lives on the handle).
+Microsandbox::Sandbox.list            # => [Microsandbox::SandboxHandle, ...]
+h = Microsandbox::Sandbox.get("box")  # => Microsandbox::SandboxHandle
+h.status                              # :running, :stopped, :created, ...
+h.stop_with_timeout(5)                # custom escalation timeout
+h.request_stop                        # fire-and-return; pair with #wait_until_stopped
+h.request_kill
+h.request_drain
+h.wait_until_stopped                  # => Microsandbox::SandboxStopResult
 Microsandbox::Sandbox.start("box")    # restart a stopped sandbox
 Microsandbox::Sandbox.remove("box")   # remove a stopped sandbox
 ```
+
+> **v0.5.8 lifecycle change.** Upstream split the lifecycle into the live
+> `Sandbox` and a controllable `SandboxHandle`, and the gem mirrors it. The live
+> `Sandbox#stop`/`#kill` no longer take a `timeout:`; `#request_stop`/
+> `#request_kill`/`#request_drain`/`#wait_until_stopped` and a custom stop timeout
+> now live on the `SandboxHandle` from `Sandbox.get`. `Sandbox.get`/`.list` return
+> a `SandboxHandle` (was a read-only `SandboxInfo`, kept as a deprecated alias).
 
 ### Configuration
 
@@ -332,7 +348,31 @@ Microsandbox.installed?            # => true/false
 Microsandbox.install               # download + install the runtime (idempotent)
 Microsandbox.runtime_path          # => "/Users/you/.microsandbox/bin/msb"
 Microsandbox.runtime_path = "/opt/microsandbox/bin/msb"  # override
+Microsandbox.libkrunfw_path = "/opt/microsandbox/lib/libkrunfw.dylib"  # override (set-once)
 ```
+
+### Backend routing
+
+As of v0.5.8 every operation runs through a backend. The default is the local
+libkrun backend; without any configuration nothing changes. A backend can be
+selected programmatically or via the environment:
+
+```ruby
+Microsandbox.default_backend_kind          # => :local (or :cloud)
+Microsandbox.set_default_backend(:cloud, url: "https://api.example.com", api_key: ENV["MSB_API_KEY"])
+# or a named profile from ~/.microsandbox/config.json:
+Microsandbox.set_default_backend(:cloud, profile: "prod")
+
+# Scoped override (restored afterward, even on error):
+Microsandbox.with_backend(:local) { Microsandbox::Sandbox.create("box", image: "alpine") { |sb| ... } }
+```
+
+Resolution order when no backend is set programmatically: `MSB_BACKEND`
+(`local`/`cloud`) → `MSB_API_URL` + `MSB_API_KEY` → `MSB_PROFILE` → the
+`active_profile` in `~/.microsandbox/config.json` (path overridable via
+`MSB_CONFIG_PATH`) → local. The cloud backend currently supports a subset of
+operations (create/start/stop/remove/get/list, one-shot exec, follow log
+streaming); unsupported operations raise `Microsandbox::UnsupportedError`.
 
 ## Development
 
@@ -390,9 +430,12 @@ or credential setup is needed.
 
 See [DESIGN.md](DESIGN.md) for the architecture and the implemented-surface
 section. The binding now covers the full official-SDK surface: sandbox
-lifecycle (including the async `request_stop`/`request_kill`/`request_drain`/
-`wait_until_stopped`/`detach`/`owns_lifecycle?` controls and label-filtered
-`list_with`), `exec`/`shell` (collected and streaming), interactive `attach`/
+lifecycle (the live `Sandbox` `stop`/`stop_and_wait`/`kill`/`drain`/`wait`/
+`status`/`detach`/`owns_lifecycle?`, plus the `SandboxHandle` controls
+`stop_with_timeout`/`request_stop`/`request_kill`/`request_drain`/
+`wait_until_stopped` from `Sandbox.get`, and label-filtered `list_with`),
+backend routing (`set_default_backend`/`with_backend`/`default_backend_kind`),
+`exec`/`shell` (collected and streaming), interactive `attach`/
 `attach_shell`, the full guest filesystem, metrics (per-sandbox,
 `Microsandbox.all_sandbox_metrics`, and streaming `metrics_stream`/`log_stream`),
 logs, OCI image-cache management, named volumes, snapshots (create/list/verify/

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,7 +6,7 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.5.7).
+# The core-crate dependency below stays pinned at its own tag (v0.5.8).
 version = "0.5.9"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.7", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.7" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/ext/microsandbox/src/backend.rs
+++ b/ext/microsandbox/src/backend.rs
@@ -23,6 +23,7 @@ use magnus::{function, prelude::*, Error, RModule, Ruby};
 use microsandbox::{Backend, MicrosandboxError};
 
 use crate::error;
+use crate::runtime::block_on;
 
 /// Resolve the ambient default backend, requiring it to be local.
 ///
@@ -44,6 +45,26 @@ pub fn local_backend() -> Result<Arc<dyn Backend>, MicrosandboxError> {
     }
 }
 
+/// Resolve the ambient backend (requiring it to be local), then run `op` with a
+/// borrowed `&LocalBackend` inside the blocking runtime, mapping any core error
+/// to a Ruby exception. Local-only operations (image cache, aggregate metrics)
+/// share this instead of repeating the resolve/downcast dance; the single
+/// `as_local()` unwrap is provably infallible — [`local_backend`] just checked
+/// it and returns the same `Arc` kept alive for the borrow — so it lives here
+/// once rather than at every call site.
+pub fn with_local_backend<T>(
+    op: impl AsyncFnOnce(&microsandbox::LocalBackend) -> Result<T, MicrosandboxError>,
+) -> Result<T, Error> {
+    block_on(async move {
+        let backend = local_backend()?;
+        let local = backend
+            .as_local()
+            .expect("local_backend() guarantees a local backend");
+        op(local).await
+    })
+    .map_err(error::to_ruby)
+}
+
 /// Build an `Arc<dyn Backend>` from the SDK facade. Ported from pyo3
 /// `build_backend` (`sdk/python/src/lib.rs`) / node `build_backend`. Synchronous
 /// (no network I/O): cloud construction only builds the HTTP client. Runs on the
@@ -57,20 +78,16 @@ fn build_backend(
     match kind.trim().to_ascii_lowercase().as_str() {
         "local" => Ok(Arc::new(microsandbox::LocalBackend::lazy())),
         "cloud" => {
-            let cloud = if let Some(profile) = profile {
-                microsandbox::CloudBackend::from_profile(&profile)
-            } else {
-                let url = url.ok_or_else(|| {
-                    error::to_ruby(MicrosandboxError::InvalidConfig(
-                        "cloud backend requires url + api_key or profile".into(),
-                    ))
-                })?;
-                let api_key = api_key.ok_or_else(|| {
-                    error::to_ruby(MicrosandboxError::InvalidConfig(
-                        "cloud backend requires url + api_key or profile".into(),
-                    ))
-                })?;
-                microsandbox::CloudBackend::new(url, api_key)
+            let cloud = match profile {
+                Some(profile) => microsandbox::CloudBackend::from_profile(&profile),
+                None => match (url, api_key) {
+                    (Some(url), Some(api_key)) => microsandbox::CloudBackend::new(url, api_key),
+                    _ => {
+                        return Err(error::to_ruby(MicrosandboxError::InvalidConfig(
+                            "cloud backend requires url + api_key or profile".into(),
+                        )))
+                    }
+                },
             }
             .map_err(error::to_ruby)?;
             Ok(Arc::new(cloud))

--- a/ext/microsandbox/src/backend.rs
+++ b/ext/microsandbox/src/backend.rs
@@ -1,0 +1,153 @@
+//! Backend routing: the ambient process-wide backend and its selection surface.
+//!
+//! Mirrors the official Python (`sdk/python/src/lib.rs`) and Node
+//! (`sdk/node-ts/native/runtime_config.rs`) bindings. As of upstream v0.5.8
+//! (PR #754) every operation routes through a [`microsandbox::Backend`]: the
+//! ambient default is a lazily-initialised [`microsandbox::LocalBackend`], and
+//! callers may install a different default process-wide or for a scoped block.
+//!
+//! Local-only operations (image cache, aggregate metrics, `msb` path) need a
+//! concrete `&LocalBackend`; [`local_backend`] resolves the ambient default and
+//! downcasts it, surfacing a clean [`MicrosandboxError::Unsupported`] under a
+//! cloud backend (exactly as the pyo3 `resolve_local` helper does). The backend
+//! selection setters (`set_default_backend` / `with_backend` push-pop /
+//! `default_backend_kind`) deliberately expose only a `kind`/`url`/`api_key`/
+//! `profile` facade — the raw `LocalBackend`/`CloudBackend` builders stay hidden,
+//! matching Python and Node.
+
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+
+use magnus::{function, prelude::*, Error, RModule, Ruby};
+use microsandbox::{Backend, MicrosandboxError};
+
+use crate::error;
+
+/// Resolve the ambient default backend, requiring it to be local.
+///
+/// Returns the `Arc<dyn Backend>` so the caller can keep it alive while
+/// borrowing `&LocalBackend` from it (`as_local()` borrows the `Arc`). Pure
+/// Rust — safe to call inside `block_on` (no Ruby C API), and it returns a raw
+/// `MicrosandboxError` so the Ruby-exception mapping happens *after* `block_on`
+/// re-acquires the GVL. Cloud backends yield `Unsupported`, mirroring pyo3's
+/// `resolve_local`.
+pub fn local_backend() -> Result<Arc<dyn Backend>, MicrosandboxError> {
+    let backend = microsandbox::default_backend();
+    if backend.as_local().is_some() {
+        Ok(backend)
+    } else {
+        Err(MicrosandboxError::Unsupported {
+            feature: "this operation requires a local backend".into(),
+            available_when: "with the local backend (the default)".into(),
+        })
+    }
+}
+
+/// Build an `Arc<dyn Backend>` from the SDK facade. Ported from pyo3
+/// `build_backend` (`sdk/python/src/lib.rs`) / node `build_backend`. Synchronous
+/// (no network I/O): cloud construction only builds the HTTP client. Runs on the
+/// Ruby thread with the GVL held, so it may map errors to Ruby directly.
+fn build_backend(
+    kind: String,
+    url: Option<String>,
+    api_key: Option<String>,
+    profile: Option<String>,
+) -> Result<Arc<dyn Backend>, Error> {
+    match kind.trim().to_ascii_lowercase().as_str() {
+        "local" => Ok(Arc::new(microsandbox::LocalBackend::lazy())),
+        "cloud" => {
+            let cloud = if let Some(profile) = profile {
+                microsandbox::CloudBackend::from_profile(&profile)
+            } else {
+                let url = url.ok_or_else(|| {
+                    error::to_ruby(MicrosandboxError::InvalidConfig(
+                        "cloud backend requires url + api_key or profile".into(),
+                    ))
+                })?;
+                let api_key = api_key.ok_or_else(|| {
+                    error::to_ruby(MicrosandboxError::InvalidConfig(
+                        "cloud backend requires url + api_key or profile".into(),
+                    ))
+                })?;
+                microsandbox::CloudBackend::new(url, api_key)
+            }
+            .map_err(error::to_ruby)?;
+            Ok(Arc::new(cloud))
+        }
+        other => Err(error::to_ruby(MicrosandboxError::InvalidConfig(format!(
+            "backend kind must be 'local' or 'cloud', got {other:?}"
+        )))),
+    }
+}
+
+/// Install a process-wide default backend. Synchronous (an `RwLock` write) — no
+/// `block_on`. Mirrors Python `set_default_backend` / Node `setDefaultBackend`.
+fn set_default_backend(
+    kind: String,
+    url: Option<String>,
+    api_key: Option<String>,
+    profile: Option<String>,
+) -> Result<(), Error> {
+    microsandbox::set_default_backend(build_backend(kind, url, api_key, profile)?);
+    Ok(())
+}
+
+// Scoped-override registry. `with_backend` in Ruby is a swap-and-restore around
+// a synchronous block, so it cannot use the core's async task-local
+// `with_backend`. We mirror Node's process-wide push/pop token registry: push
+// swaps the default and stores the previous backend under a fresh token; pop
+// restores it. The Ruby wrapper drives this through an `ensure` block.
+static NEXT_BACKEND_SCOPE: AtomicU32 = AtomicU32::new(1);
+static BACKEND_SCOPES: OnceLock<Mutex<HashMap<u32, Arc<dyn Backend>>>> = OnceLock::new();
+
+fn backend_scopes() -> &'static Mutex<HashMap<u32, Arc<dyn Backend>>> {
+    BACKEND_SCOPES.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+/// Swap in a new default backend and return a token for restoring the previous
+/// one via [`pop_default_backend`]. Process-wide while active (not task-local):
+/// concurrent Ruby threads observe the swapped default.
+fn push_default_backend(
+    kind: String,
+    url: Option<String>,
+    api_key: Option<String>,
+    profile: Option<String>,
+) -> Result<u32, Error> {
+    let previous = microsandbox::swap_default_backend(build_backend(kind, url, api_key, profile)?);
+    let token = NEXT_BACKEND_SCOPE.fetch_add(1, Ordering::Relaxed);
+    backend_scopes()
+        .lock()
+        .map_err(|_| error::base_error("backend scope registry poisoned"))?
+        .insert(token, previous);
+    Ok(token)
+}
+
+/// Restore the backend saved by [`push_default_backend`].
+fn pop_default_backend(token: u32) -> Result<(), Error> {
+    let previous = backend_scopes()
+        .lock()
+        .map_err(|_| error::base_error("backend scope registry poisoned"))?
+        .remove(&token)
+        .ok_or_else(|| error::base_error("unknown backend scope token"))?;
+    microsandbox::set_default_backend(previous);
+    Ok(())
+}
+
+/// The active default backend kind: `"local"` or `"cloud"`. First call lazily
+/// resolves the env/profile/config ladder. Synchronous (an `RwLock` read).
+fn default_backend_kind() -> String {
+    match microsandbox::default_backend().kind() {
+        microsandbox::BackendKind::Local => "local",
+        microsandbox::BackendKind::Cloud => "cloud",
+    }
+    .to_string()
+}
+
+pub fn define(_ruby: &Ruby, native: &RModule) -> Result<(), Error> {
+    native.define_singleton_method("set_default_backend", function!(set_default_backend, 4))?;
+    native.define_singleton_method("push_default_backend", function!(push_default_backend, 4))?;
+    native.define_singleton_method("pop_default_backend", function!(pop_default_backend, 1))?;
+    native.define_singleton_method("default_backend_kind", function!(default_backend_kind, 0))?;
+    Ok(())
+}

--- a/ext/microsandbox/src/error.rs
+++ b/ext/microsandbox/src/error.rs
@@ -28,6 +28,12 @@ fn class_name(err: &MicrosandboxError) -> &'static str {
         MetricsDisabled(_) => "MetricsDisabledError",
         MetricsUnavailable(_) => "MetricsUnavailableError",
         AgentClient(AgentClientError::UnsupportedOperation { .. }) => "UnsupportedOperationError",
+        // Backend routing (v0.5.8 / PR #754). `Unsupported` is reachable on the
+        // local backend too (e.g. `Volume::path` on a cloud volume, snapshot
+        // ops), so it must map even for local-only use. Distinct from the agent
+        // client's `UnsupportedOperation` above.
+        CloudHttp { .. } => "CloudHttpError",
+        Unsupported { .. } => "UnsupportedError",
         _ => "Error",
     }
 }

--- a/ext/microsandbox/src/image.rs
+++ b/ext/microsandbox/src/image.rs
@@ -8,6 +8,7 @@
 use magnus::{function, prelude::*, Error, RArray, RHash, RModule, Ruby};
 use microsandbox::image::{Image, ImageDetail, ImageHandle, ImagePruneReport};
 
+use crate::backend::local_backend;
 use crate::error;
 use crate::runtime::{block_on, ruby};
 
@@ -76,12 +77,20 @@ fn report_to_hash(report: ImagePruneReport) -> RHash {
 }
 
 fn get(reference: String) -> Result<RHash, Error> {
-    let handle = block_on(Image::get(&reference)).map_err(error::to_ruby)?;
+    let handle = block_on(async {
+        let backend = local_backend()?;
+        Image::get(backend.as_local().expect("checked local"), &reference).await
+    })
+    .map_err(error::to_ruby)?;
     Ok(handle_to_hash(&handle))
 }
 
 fn list() -> Result<RArray, Error> {
-    let handles = block_on(Image::list()).map_err(error::to_ruby)?;
+    let handles = block_on(async {
+        let backend = local_backend()?;
+        Image::list(backend.as_local().expect("checked local")).await
+    })
+    .map_err(error::to_ruby)?;
     let arr = ruby().ary_new();
     for h in handles.iter() {
         arr.push(handle_to_hash(h))?;
@@ -90,16 +99,33 @@ fn list() -> Result<RArray, Error> {
 }
 
 fn inspect(reference: String) -> Result<RHash, Error> {
-    let detail = block_on(Image::inspect(&reference)).map_err(error::to_ruby)?;
+    let detail = block_on(async {
+        let backend = local_backend()?;
+        Image::inspect(backend.as_local().expect("checked local"), &reference).await
+    })
+    .map_err(error::to_ruby)?;
     Ok(detail_to_hash(detail))
 }
 
 fn remove(reference: String, force: bool) -> Result<(), Error> {
-    block_on(Image::remove(&reference, force)).map_err(error::to_ruby)
+    block_on(async {
+        let backend = local_backend()?;
+        Image::remove(
+            backend.as_local().expect("checked local"),
+            &reference,
+            force,
+        )
+        .await
+    })
+    .map_err(error::to_ruby)
 }
 
 fn prune() -> Result<RHash, Error> {
-    let report = block_on(Image::prune()).map_err(error::to_ruby)?;
+    let report = block_on(async {
+        let backend = local_backend()?;
+        Image::prune(backend.as_local().expect("checked local")).await
+    })
+    .map_err(error::to_ruby)?;
     Ok(report_to_hash(report))
 }
 

--- a/ext/microsandbox/src/image.rs
+++ b/ext/microsandbox/src/image.rs
@@ -8,9 +8,8 @@
 use magnus::{function, prelude::*, Error, RArray, RHash, RModule, Ruby};
 use microsandbox::image::{Image, ImageDetail, ImageHandle, ImagePruneReport};
 
-use crate::backend::local_backend;
-use crate::error;
-use crate::runtime::{block_on, ruby};
+use crate::backend::with_local_backend;
+use crate::runtime::ruby;
 
 fn handle_to_hash(h: &ImageHandle) -> RHash {
     let hash = ruby().hash_new();
@@ -77,20 +76,12 @@ fn report_to_hash(report: ImagePruneReport) -> RHash {
 }
 
 fn get(reference: String) -> Result<RHash, Error> {
-    let handle = block_on(async {
-        let backend = local_backend()?;
-        Image::get(backend.as_local().expect("checked local"), &reference).await
-    })
-    .map_err(error::to_ruby)?;
+    let handle = with_local_backend(async |local| Image::get(local, &reference).await)?;
     Ok(handle_to_hash(&handle))
 }
 
 fn list() -> Result<RArray, Error> {
-    let handles = block_on(async {
-        let backend = local_backend()?;
-        Image::list(backend.as_local().expect("checked local")).await
-    })
-    .map_err(error::to_ruby)?;
+    let handles = with_local_backend(async |local| Image::list(local).await)?;
     let arr = ruby().ary_new();
     for h in handles.iter() {
         arr.push(handle_to_hash(h))?;
@@ -99,33 +90,16 @@ fn list() -> Result<RArray, Error> {
 }
 
 fn inspect(reference: String) -> Result<RHash, Error> {
-    let detail = block_on(async {
-        let backend = local_backend()?;
-        Image::inspect(backend.as_local().expect("checked local"), &reference).await
-    })
-    .map_err(error::to_ruby)?;
+    let detail = with_local_backend(async |local| Image::inspect(local, &reference).await)?;
     Ok(detail_to_hash(detail))
 }
 
 fn remove(reference: String, force: bool) -> Result<(), Error> {
-    block_on(async {
-        let backend = local_backend()?;
-        Image::remove(
-            backend.as_local().expect("checked local"),
-            &reference,
-            force,
-        )
-        .await
-    })
-    .map_err(error::to_ruby)
+    with_local_backend(async |local| Image::remove(local, &reference, force).await)
 }
 
 fn prune() -> Result<RHash, Error> {
-    let report = block_on(async {
-        let backend = local_backend()?;
-        Image::prune(backend.as_local().expect("checked local")).await
-    })
-    .map_err(error::to_ruby)?;
+    let report = with_local_backend(async |local| Image::prune(local).await)?;
     Ok(report_to_hash(report))
 }
 

--- a/ext/microsandbox/src/lib.rs
+++ b/ext/microsandbox/src/lib.rs
@@ -9,6 +9,7 @@
 //! surface is the pure-Ruby layer in `lib/microsandbox/`.
 
 mod agent;
+mod backend;
 mod conv;
 mod error;
 mod exec;
@@ -31,8 +32,11 @@ fn version() -> String {
 /// Ruby Hash. Mirrors the official `all_sandbox_metrics` / `allSandboxMetrics`
 /// helpers (Python/Node/Go).
 fn all_sandbox_metrics() -> Result<RHash, Error> {
-    let map =
-        runtime::block_on(microsandbox::sandbox::all_sandbox_metrics()).map_err(error::to_ruby)?;
+    let map = runtime::block_on(async {
+        let backend = backend::local_backend()?;
+        microsandbox::sandbox::all_sandbox_metrics(backend.as_local().expect("checked local")).await
+    })
+    .map_err(error::to_ruby)?;
     let hash = runtime::ruby().hash_new();
     for (name, metrics) in &map {
         hash.aset(name.as_str(), sandbox::metrics_to_hash(metrics))?;
@@ -55,9 +59,25 @@ fn set_runtime_msb_path(path: String) {
     microsandbox::config::set_sdk_msb_path(path);
 }
 
-/// The currently-resolved `msb` runtime path.
+/// Override the resolved `libkrunfw` path (SDK tier of the resolver). Set-once
+/// per process; the `MSB_LIBKRUNFW_PATH` env var still takes precedence. Mirrors
+/// `set_runtime_msb_path` for the libkrunfw shared library.
+fn set_runtime_libkrunfw_path(path: String) {
+    microsandbox::config::set_sdk_libkrunfw_path(path);
+}
+
+/// The currently-resolved `msb` runtime path. Synchronous (filesystem probes,
+/// no async) — runs on the Ruby thread; resolves the path from the local
+/// backend's config.
 fn resolved_msb_path() -> Result<String, Error> {
-    let path = microsandbox::config::resolve_msb_path().map_err(error::to_ruby)?;
+    let backend = microsandbox::default_backend();
+    let local = backend.as_local().ok_or_else(|| {
+        error::to_ruby(microsandbox::MicrosandboxError::Unsupported {
+            feature: "resolved_msb_path requires a local backend".into(),
+            available_when: "with the local backend".into(),
+        })
+    })?;
+    let path = microsandbox::config::resolve_msb_path(local.config()).map_err(error::to_ruby)?;
     Ok(path.to_string_lossy().into_owned())
 }
 
@@ -72,9 +92,14 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     native.define_singleton_method("install", function!(install, 0))?;
     native.define_singleton_method("installed?", function!(is_installed, 0))?;
     native.define_singleton_method("set_runtime_msb_path", function!(set_runtime_msb_path, 1))?;
+    native.define_singleton_method(
+        "set_runtime_libkrunfw_path",
+        function!(set_runtime_libkrunfw_path, 1),
+    )?;
     native.define_singleton_method("resolved_msb_path", function!(resolved_msb_path, 0))?;
     native.define_singleton_method("all_sandbox_metrics", function!(all_sandbox_metrics, 0))?;
 
+    backend::define(ruby, &native)?;
     sandbox::define(ruby, &native)?;
     exec::define(ruby, &native)?;
     stream::define(ruby, &native)?;

--- a/ext/microsandbox/src/lib.rs
+++ b/ext/microsandbox/src/lib.rs
@@ -32,11 +32,9 @@ fn version() -> String {
 /// Ruby Hash. Mirrors the official `all_sandbox_metrics` / `allSandboxMetrics`
 /// helpers (Python/Node/Go).
 fn all_sandbox_metrics() -> Result<RHash, Error> {
-    let map = runtime::block_on(async {
-        let backend = backend::local_backend()?;
-        microsandbox::sandbox::all_sandbox_metrics(backend.as_local().expect("checked local")).await
-    })
-    .map_err(error::to_ruby)?;
+    let map = backend::with_local_backend(async |local| {
+        microsandbox::sandbox::all_sandbox_metrics(local).await
+    })?;
     let hash = runtime::ruby().hash_new();
     for (name, metrics) in &map {
         hash.aset(name.as_str(), sandbox::metrics_to_hash(metrics))?;

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -209,27 +209,36 @@ impl Sandbox {
         Ok(Sandbox::from_inner(inner))
     }
 
-    /// Lightweight metadata for a sandbox by name (running or not).
-    fn get(name: String) -> Result<RHash, Error> {
+    /// A controllable handle for a sandbox by name (running or not). Carries
+    /// metadata accessors and the full lifecycle surface (see `SbHandle`).
+    fn get(name: String) -> Result<SbHandle, Error> {
         let handle = block_on(microsandbox::Sandbox::get(&name)).map_err(error::to_ruby)?;
-        Ok(handle_to_hash(&handle))
+        Ok(SbHandle::from_inner(handle))
     }
 
-    /// All sandboxes as metadata hashes.
+    /// All sandboxes as controllable handles.
     fn list() -> Result<RArray, Error> {
         let handles = block_on(microsandbox::Sandbox::list()).map_err(error::to_ruby)?;
-        rhash_array(handles.iter().map(handle_to_hash))
+        let arr = ruby().ary_new();
+        for h in handles {
+            arr.push(SbHandle::from_inner(h))?;
+        }
+        Ok(arr)
     }
 
-    /// Sandboxes filtered by required `key=value` labels (AND-matched). `opts`
-    /// carries a string→string `labels` map.
+    /// Sandboxes filtered by required `key=value` labels (AND-matched), as
+    /// controllable handles. `opts` carries a string→string `labels` map.
     fn list_with(opts: RHash) -> Result<RArray, Error> {
         let mut filter = SandboxFilter::new();
         for (k, v) in conv::opt_string_map(opts, "labels")? {
             filter = filter.label(k, v);
         }
         let handles = block_on(microsandbox::Sandbox::list_with(filter)).map_err(error::to_ruby)?;
-        rhash_array(handles.iter().map(handle_to_hash))
+        let arr = ruby().ary_new();
+        for h in handles {
+            arr.push(SbHandle::from_inner(h))?;
+        }
+        Ok(arr)
     }
 
     /// Remove a (stopped) sandbox by name.
@@ -286,44 +295,46 @@ impl Sandbox {
         Ok(ExecHandle::from_core(handle))
     }
 
-    /// Graceful stop (+ wait). `timeout` is optional seconds.
-    fn stop(&self, timeout: Option<f64>) -> Result<(), Error> {
-        match timeout {
-            Some(secs) => block_on(self.inner.stop_with_timeout(Duration::from_secs_f64(secs))),
-            None => block_on(self.inner.stop()),
-        }
+    /// Graceful stop. Mirrors the official SDKs: the live handle routes through
+    /// a freshly fetched `SandboxHandle::stop` (SIGTERM→SIGKILL escalation with
+    /// a 10s default). Fine-grained control — a custom timeout or fire-and-
+    /// return `request_*` — lives on `SandboxHandle`, obtained via `Sandbox.get`.
+    fn stop(&self) -> Result<(), Error> {
+        let name = self.inner.name().to_string();
+        block_on(async move {
+            let handle = microsandbox::sandbox::Sandbox::get(&name).await?;
+            handle.stop().await
+        })
         .map_err(error::to_ruby)
     }
 
-    /// Force kill (SIGKILL). `timeout` is optional seconds.
-    fn kill(&self, timeout: Option<f64>) -> Result<(), Error> {
-        match timeout {
-            Some(secs) => block_on(self.inner.kill_with_timeout(Duration::from_secs_f64(secs))),
-            None => block_on(self.inner.kill()),
-        }
-        .map_err(error::to_ruby)
+    /// Graceful stop, then wait for the process to exit. Returns an exit-status
+    /// Hash (`exit_code`, `success`). Local backend only.
+    fn stop_and_wait(&self) -> Result<RHash, Error> {
+        let status = block_on(self.inner.stop_and_wait()).map_err(error::to_ruby)?;
+        Ok(exit_status_to_hash(status))
     }
 
-    /// Send the graceful-shutdown request and return without waiting.
-    fn request_stop(&self) -> Result<(), Error> {
-        block_on(self.inner.request_stop()).map_err(error::to_ruby)
+    /// Force kill (SIGKILL).
+    fn kill(&self) -> Result<(), Error> {
+        block_on(self.inner.kill()).map_err(error::to_ruby)
     }
 
-    /// Send the force-kill request and return without waiting.
-    fn request_kill(&self) -> Result<(), Error> {
-        block_on(self.inner.request_kill()).map_err(error::to_ruby)
+    /// Trigger a graceful drain (SIGUSR1 on local).
+    fn drain(&self) -> Result<(), Error> {
+        block_on(self.inner.drain()).map_err(error::to_ruby)
     }
 
-    /// Send the drain request and return without waiting.
-    fn request_drain(&self) -> Result<(), Error> {
-        block_on(self.inner.request_drain()).map_err(error::to_ruby)
+    /// Wait for the process to exit. Returns an exit-status Hash. Local only.
+    fn wait(&self) -> Result<RHash, Error> {
+        let status = block_on(self.inner.wait()).map_err(error::to_ruby)?;
+        Ok(exit_status_to_hash(status))
     }
 
-    /// Block until the sandbox is observed in a terminal state; returns a
-    /// stop-result Hash (name, status, exit_code, signal, observed_at_ms, source).
-    fn wait_until_stopped(&self) -> Result<RHash, Error> {
-        let result = block_on(self.inner.wait_until_stopped()).map_err(error::to_ruby)?;
-        Ok(stop_result_to_hash(&result))
+    /// Live status fetched from the backend (a round-trip per call).
+    fn status(&self) -> Result<String, Error> {
+        let status = block_on(self.inner.status()).map_err(error::to_ruby)?;
+        Ok(sandbox_status_str(status).to_string())
     }
 
     /// Whether this handle owns the sandbox process lifecycle (a synchronous,
@@ -1203,13 +1214,28 @@ pub(crate) fn metrics_to_hash(m: &SandboxMetrics) -> RHash {
 }
 
 fn sandbox_status_str(status: SandboxStatus) -> &'static str {
+    // Lowercased `Debug` names, matching the official SDKs' `format!("{:?}")`.
+    // `Created`/`Starting` are new in v0.5.8 (cloud-only today). The match is
+    // intentionally exhaustive — no wildcard — so a future upstream variant
+    // surfaces as a compile error rather than a silent fallback.
     match status {
+        SandboxStatus::Created => "created",
+        SandboxStatus::Starting => "starting",
         SandboxStatus::Running => "running",
         SandboxStatus::Draining => "draining",
         SandboxStatus::Paused => "paused",
         SandboxStatus::Stopped => "stopped",
         SandboxStatus::Crashed => "crashed",
     }
+}
+
+/// A `std::process::ExitStatus` as a Ruby Hash: `exit_code` (Integer or nil) and
+/// `success` (Boolean). Returned by the live `Sandbox#wait` / `#stop_and_wait`.
+fn exit_status_to_hash(status: std::process::ExitStatus) -> RHash {
+    let hash = ruby().hash_new();
+    let _ = hash.aset("exit_code", status.code());
+    let _ = hash.aset("success", status.success());
+    hash
 }
 
 fn stop_result_to_hash(result: &SandboxStopResult) -> RHash {
@@ -1223,19 +1249,85 @@ fn stop_result_to_hash(result: &SandboxStopResult) -> RHash {
     hash
 }
 
-fn handle_to_hash(handle: &SandboxHandle) -> RHash {
-    let hash = ruby().hash_new();
-    let _ = hash.aset("name", handle.name().to_string());
-    let _ = hash.aset("status", sandbox_status_str(handle.status()));
-    let _ = hash.aset(
-        "created_at_ms",
-        handle.created_at().map(|dt| dt.timestamp_millis()),
-    );
-    let _ = hash.aset(
-        "updated_at_ms",
-        handle.updated_at().map(|dt| dt.timestamp_millis()),
-    );
-    hash
+//--------------------------------------------------------------------------------------------------
+// SandboxHandle — the controllable lightweight handle
+//--------------------------------------------------------------------------------------------------
+
+/// Wraps a core `microsandbox::sandbox::SandboxHandle` (returned by
+/// `Sandbox.get`/`list`/`list_with`). Carries metadata accessors plus the rich
+/// lifecycle surface that moved off the live `Sandbox` in v0.5.8 — mirroring the
+/// official Python (`PySandboxHandle`) and Node (`SandboxHandle`) SDKs. Status is
+/// a synchronous snapshot read off the handle (no round-trip).
+#[magnus::wrap(class = "Microsandbox::Native::SandboxHandle", free_immediately, size)]
+pub struct SbHandle {
+    inner: SandboxHandle,
+}
+
+impl SbHandle {
+    fn from_inner(inner: SandboxHandle) -> Self {
+        Self { inner }
+    }
+
+    fn name(&self) -> String {
+        self.inner.name().to_string()
+    }
+
+    /// Status snapshot captured when the handle was fetched (synchronous).
+    fn status(&self) -> String {
+        sandbox_status_str(self.inner.status_snapshot()).to_string()
+    }
+
+    fn created_at_ms(&self) -> Option<i64> {
+        self.inner.created_at().map(|dt| dt.timestamp_millis())
+    }
+
+    fn updated_at_ms(&self) -> Option<i64> {
+        self.inner.updated_at().map(|dt| dt.timestamp_millis())
+    }
+
+    /// Graceful stop (SIGTERM→SIGKILL escalation, 10s default) and wait.
+    fn stop(&self) -> Result<(), Error> {
+        block_on(self.inner.stop()).map_err(error::to_ruby)
+    }
+
+    /// Graceful stop with a custom escalation timeout (seconds).
+    fn stop_with_timeout(&self, secs: f64) -> Result<(), Error> {
+        block_on(self.inner.stop_with_timeout(Duration::from_secs_f64(secs)))
+            .map_err(error::to_ruby)
+    }
+
+    /// Force kill (SIGKILL) and wait.
+    fn kill(&self) -> Result<(), Error> {
+        block_on(self.inner.kill()).map_err(error::to_ruby)
+    }
+
+    /// Force kill, waiting up to `secs` for the process to disappear.
+    fn kill_with_timeout(&self, secs: f64) -> Result<(), Error> {
+        block_on(self.inner.kill_with_timeout(Duration::from_secs_f64(secs)))
+            .map_err(error::to_ruby)
+    }
+
+    /// Send the graceful-shutdown request and return without waiting.
+    fn request_stop(&self) -> Result<(), Error> {
+        block_on(self.inner.request_stop()).map_err(error::to_ruby)
+    }
+
+    /// Send the force-kill request and return without waiting.
+    fn request_kill(&self) -> Result<(), Error> {
+        block_on(self.inner.request_kill()).map_err(error::to_ruby)
+    }
+
+    /// Send the drain request (SIGUSR1) and return without waiting.
+    fn request_drain(&self) -> Result<(), Error> {
+        block_on(self.inner.request_drain()).map_err(error::to_ruby)
+    }
+
+    /// Block until the sandbox reaches a terminal state; returns a stop-result
+    /// Hash (name, status, exit_code, signal, observed_at_ms, source).
+    fn wait_until_stopped(&self) -> Result<RHash, Error> {
+        let result = block_on(self.inner.wait_until_stopped()).map_err(error::to_ruby)?;
+        Ok(stop_result_to_hash(&result))
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1336,15 +1428,12 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     class.define_method("shell", method!(Sandbox::shell, 2))?;
     class.define_method("exec_stream", method!(Sandbox::exec_stream, 3))?;
     class.define_method("shell_stream", method!(Sandbox::shell_stream, 2))?;
-    class.define_method("stop", method!(Sandbox::stop, 1))?;
-    class.define_method("kill", method!(Sandbox::kill, 1))?;
-    class.define_method("request_stop", method!(Sandbox::request_stop, 0))?;
-    class.define_method("request_kill", method!(Sandbox::request_kill, 0))?;
-    class.define_method("request_drain", method!(Sandbox::request_drain, 0))?;
-    class.define_method(
-        "wait_until_stopped",
-        method!(Sandbox::wait_until_stopped, 0),
-    )?;
+    class.define_method("stop", method!(Sandbox::stop, 0))?;
+    class.define_method("stop_and_wait", method!(Sandbox::stop_and_wait, 0))?;
+    class.define_method("kill", method!(Sandbox::kill, 0))?;
+    class.define_method("drain", method!(Sandbox::drain, 0))?;
+    class.define_method("wait", method!(Sandbox::wait, 0))?;
+    class.define_method("status", method!(Sandbox::status, 0))?;
     class.define_method("owns_lifecycle", method!(Sandbox::owns_lifecycle, 0))?;
     class.define_method("detach", method!(Sandbox::detach, 0))?;
     class.define_method("metrics", method!(Sandbox::metrics, 0))?;
@@ -1374,6 +1463,23 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
 
     class.define_method("attach", method!(Sandbox::attach, 3))?;
     class.define_method("attach_shell", method!(Sandbox::attach_shell, 0))?;
+
+    let handle = native.define_class("SandboxHandle", ruby.class_object())?;
+    handle.define_method("name", method!(SbHandle::name, 0))?;
+    handle.define_method("status", method!(SbHandle::status, 0))?;
+    handle.define_method("created_at_ms", method!(SbHandle::created_at_ms, 0))?;
+    handle.define_method("updated_at_ms", method!(SbHandle::updated_at_ms, 0))?;
+    handle.define_method("stop", method!(SbHandle::stop, 0))?;
+    handle.define_method("stop_with_timeout", method!(SbHandle::stop_with_timeout, 1))?;
+    handle.define_method("kill", method!(SbHandle::kill, 0))?;
+    handle.define_method("kill_with_timeout", method!(SbHandle::kill_with_timeout, 1))?;
+    handle.define_method("request_stop", method!(SbHandle::request_stop, 0))?;
+    handle.define_method("request_kill", method!(SbHandle::request_kill, 0))?;
+    handle.define_method("request_drain", method!(SbHandle::request_drain, 0))?;
+    handle.define_method(
+        "wait_until_stopped",
+        method!(SbHandle::wait_until_stopped, 0),
+    )?;
 
     Ok(())
 }

--- a/ext/microsandbox/src/volume.rs
+++ b/ext/microsandbox/src/volume.rs
@@ -65,7 +65,12 @@ fn create(name: String, opts: RHash) -> Result<RHash, Error> {
     let vol = block_on(builder.create()).map_err(error::to_ruby)?;
     let hash = ruby().hash_new();
     hash.aset("name", vol.name().to_string())?;
-    hash.aset("path", vol.path().display().to_string())?;
+    // `path()` is fallible as of v0.5.8 (returns `Unsupported` for cloud
+    // volumes); the volume just created here is local, so this resolves.
+    hash.aset(
+        "path",
+        vol.path().map_err(error::to_ruby)?.display().to_string(),
+    )?;
     Ok(hash)
 }
 

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -78,6 +78,11 @@ module Microsandbox
     # @return [nil]
     def ensure_runtime!
       return if @runtime_ready
+      # A cloud backend has no local msb/libkrunfw runtime to provision: skip the
+      # presence check and the first-use download entirely. Resolving the kind
+      # uses the same lazy env/profile/config ladder every operation already
+      # consults, so this adds no work for local hosts (the common case).
+      return if default_backend_kind == :cloud
       if installed?
         @runtime_ready = true
         return
@@ -132,7 +137,12 @@ module Microsandbox
     # Run the given block with a temporary default backend, restoring the
     # previous one afterward (even on error). NOTE: the swap is process-wide
     # while the block runs, not fiber/thread-local — concurrent threads observe
-    # the temporary backend. Mirrors the official SDKs' scoped-backend helper.
+    # the temporary backend. It is also NOT safe to call from multiple threads
+    # at once: two interleaved `with_backend` calls can restore each other's
+    # saved backend out of order and leave a temporary backend installed
+    # permanently. Use it only when no other thread is changing the backend, and
+    # avoid calling {set_default_backend} inside the block (the restore on exit
+    # would overwrite that change). Mirrors the official SDKs' scoped-backend helper.
     #
     # @param kind ["local","cloud", Symbol]
     # @param url [String, nil]

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -104,6 +104,57 @@ module Microsandbox
       Native.set_runtime_msb_path(path.to_s)
     end
 
+    # Override the `libkrunfw` shared-library path (SDK tier of the resolver,
+    # below the `MSB_LIBKRUNFW_PATH` environment variable). Process-level and
+    # set-once: a second call is silently ignored, and the env var still wins.
+    # Mirrors {runtime_path=} for libkrunfw.
+    # @param path [String]
+    # @return [void]
+    def libkrunfw_path=(path)
+      Native.set_runtime_libkrunfw_path(path.to_s)
+    end
+
+    # Install a process-wide default backend (v0.5.8 backend routing). Without a
+    # call to this, operations use a local libkrun backend; the env/profile
+    # ladder (`MSB_BACKEND`, `MSB_API_URL`+`MSB_API_KEY`, `MSB_PROFILE`,
+    # `~/.microsandbox/config.json`) is resolved lazily on first use. Call once
+    # at startup, before any sandbox operations.
+    #
+    # @param kind ["local","cloud", Symbol] backend kind
+    # @param url [String, nil] cloud control-plane URL (cloud, unless `profile:`)
+    # @param api_key [String, nil] cloud API key (cloud, unless `profile:`)
+    # @param profile [String, nil] named profile from `~/.microsandbox/config.json`
+    # @return [void]
+    def set_default_backend(kind, url: nil, api_key: nil, profile: nil)
+      Native.set_default_backend(kind.to_s, url&.to_s, api_key&.to_s, profile&.to_s)
+    end
+
+    # Run the given block with a temporary default backend, restoring the
+    # previous one afterward (even on error). NOTE: the swap is process-wide
+    # while the block runs, not fiber/thread-local — concurrent threads observe
+    # the temporary backend. Mirrors the official SDKs' scoped-backend helper.
+    #
+    # @param kind ["local","cloud", Symbol]
+    # @param url [String, nil]
+    # @param api_key [String, nil]
+    # @param profile [String, nil]
+    # @yield with the temporary backend installed
+    # @return [Object] the block's return value
+    def with_backend(kind, url: nil, api_key: nil, profile: nil)
+      token = Native.push_default_backend(kind.to_s, url&.to_s, api_key&.to_s, profile&.to_s)
+      begin
+        yield
+      ensure
+        Native.pop_default_backend(token)
+      end
+    end
+
+    # @return [Symbol] the active default backend kind, :local or :cloud.
+    #   The first call resolves the env/profile/config ladder.
+    def default_backend_kind
+      Native.default_backend_kind.to_sym
+    end
+
     # Latest resource-usage snapshot for every running sandbox, keyed by name.
     # Mirrors the official `all_sandbox_metrics`/`allSandboxMetrics` helpers.
     # @return [Hash{String => Metrics}]

--- a/lib/microsandbox/errors.rb
+++ b/lib/microsandbox/errors.rb
@@ -65,4 +65,10 @@ module Microsandbox
 
   # Runtime compatibility ---------------------------------------------------
   define_error(:UnsupportedOperationError, "unsupported-operation")
+
+  # Cloud / backend routing errors (v0.5.8) ---------------------------------
+  # `UnsupportedError` (a backend feature gap, e.g. an op not yet wired on the
+  # cloud backend) is distinct from `UnsupportedOperationError` above.
+  define_error(:CloudHttpError, "cloud-http")
+  define_error(:UnsupportedError, "unsupported")
 end

--- a/lib/microsandbox/exec_handle.rb
+++ b/lib/microsandbox/exec_handle.rb
@@ -38,9 +38,12 @@ module Microsandbox
     end
   end
 
-  # The terminal status of a streamed execution, from {ExecHandle#wait}.
+  # The terminal status of a streamed execution ({ExecHandle#wait}) or of a
+  # sandbox process ({Sandbox#wait}, {Sandbox#stop_and_wait}).
   class ExitStatus
-    # @return [Integer]
+    # @return [Integer, nil] the exit code, or nil when the process was
+    #   terminated by a signal and so carries no code (e.g. a SIGKILL'd sandbox
+    #   from {Sandbox#kill} then {Sandbox#wait}) — check {#success?} in that case.
     attr_reader :exit_code
 
     def initialize(data)

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -22,6 +22,10 @@ module Microsandbox
     #   :stopped, or :crashed (a snapshot, captured when this handle was fetched)
     def status = @native.status.to_sym
 
+    # Whether the fetch-time {#status} snapshot is `:running` / `:stopped`.
+    # Like {#status}, these do NOT refresh: to observe a state change after
+    # {#request_stop}/{#request_kill}/{#request_drain}, use {#wait_until_stopped}
+    # or re-fetch the handle with {Sandbox.get}.
     def running? = status == :running
     def stopped? = status == :stopped
 
@@ -102,11 +106,14 @@ module Microsandbox
 
   # @deprecated since v0.5.8. {Sandbox.get}/{Sandbox.list} now return a
   #   controllable {SandboxHandle}; this constant remains as an alias so code
-  #   that referenced the old read-only metadata type by name still resolves.
+  #   that referenced the old read-only metadata type by name (e.g. `is_a?`
+  #   checks) still resolves. Note it is now the same class as {SandboxHandle},
+  #   whose constructor takes a native handle, not the metadata Hash the old
+  #   `SandboxInfo.new` accepted — construct via {Sandbox.get}/{Sandbox.list}.
   SandboxInfo = SandboxHandle
 
   # The terminal observation of a stopped sandbox, returned by
-  # {Sandbox#wait_until_stopped}. Mirrors the official SDKs' `SandboxStopResult`.
+  # {SandboxHandle#wait_until_stopped}. Mirrors the official SDKs' `SandboxStopResult`.
   class SandboxStopResult
     # @return [String]
     attr_reader :name

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -1,38 +1,109 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  # Lightweight metadata about a sandbox, returned by {Sandbox.get} and
-  # {Sandbox.list}. This is a snapshot, not a live handle.
-  class SandboxInfo
-    # @return [String]
-    attr_reader :name
-    # @return [Symbol] :running, :draining, :paused, :stopped, or :crashed
-    attr_reader :status
-
-    def initialize(data)
-      @name = data["name"]
-      @status = data["status"].to_sym
-      @created_at_ms = data["created_at_ms"]
-      @updated_at_ms = data["updated_at_ms"]
+  # A controllable handle to a sandbox, returned by {Sandbox.get}, {Sandbox.list},
+  # and {Sandbox.list_with}. Carries a metadata snapshot (captured when fetched)
+  # plus the fine-grained lifecycle surface — `stop_with_timeout`, `request_stop`,
+  # `request_kill`, `request_drain`, `wait_until_stopped` — that mirrors the
+  # official SDKs' `SandboxHandle`. (The live {Sandbox} from {Sandbox.create}/
+  # {Sandbox.start} carries only the high-level `stop`/`kill`/`drain`/`wait`.)
+  #
+  # As of v0.5.8 this replaces the old read-only `SandboxInfo` (kept as a
+  # deprecated constant alias); `#status` here is a synchronous snapshot.
+  class SandboxHandle
+    def initialize(native)
+      @native = native
     end
 
-    def running? = @status == :running
-    def stopped? = @status == :stopped
+    # @return [String]
+    def name = @native.name
+
+    # @return [Symbol] :created, :starting, :running, :draining, :paused,
+    #   :stopped, or :crashed (a snapshot, captured when this handle was fetched)
+    def status = @native.status.to_sym
+
+    def running? = status == :running
+    def stopped? = status == :stopped
 
     # @return [Time, nil]
     def created_at
-      @created_at_ms && Time.at(@created_at_ms / 1000.0)
+      ms = @native.created_at_ms
+      ms && Time.at(ms / 1000.0)
     end
 
     # @return [Time, nil]
     def updated_at
-      @updated_at_ms && Time.at(@updated_at_ms / 1000.0)
+      ms = @native.updated_at_ms
+      ms && Time.at(ms / 1000.0)
+    end
+
+    # Gracefully stop the sandbox (SIGTERM→SIGKILL escalation, 10s default).
+    # @return [nil]
+    def stop
+      @native.stop
+      nil
+    end
+
+    # Gracefully stop with a custom escalation timeout.
+    # @param timeout [Numeric] seconds to wait before escalating to SIGKILL
+    # @return [nil]
+    def stop_with_timeout(timeout)
+      @native.stop_with_timeout(Sandbox.send(:coerce_duration, timeout, "timeout"))
+      nil
+    end
+
+    # Force-kill the sandbox (SIGKILL).
+    # @return [nil]
+    def kill
+      @native.kill
+      nil
+    end
+
+    # Force-kill, waiting up to `timeout` seconds for the process to disappear.
+    # @param timeout [Numeric]
+    # @return [nil]
+    def kill_with_timeout(timeout)
+      @native.kill_with_timeout(Sandbox.send(:coerce_duration, timeout, "timeout"))
+      nil
+    end
+
+    # Send the graceful-shutdown request and return immediately, without waiting.
+    # Pair with {#wait_until_stopped}.
+    # @return [nil]
+    def request_stop
+      @native.request_stop
+      nil
+    end
+
+    # Send the force-kill request and return immediately, without waiting.
+    # @return [nil]
+    def request_kill
+      @native.request_kill
+      nil
+    end
+
+    # Request a graceful drain (SIGUSR1) and return immediately, without waiting.
+    # @return [nil]
+    def request_drain
+      @native.request_drain
+      nil
+    end
+
+    # Block until the sandbox is observed in a terminal (non-running) state.
+    # @return [SandboxStopResult]
+    def wait_until_stopped
+      SandboxStopResult.new(@native.wait_until_stopped)
     end
 
     def inspect
-      "#<Microsandbox::SandboxInfo name=#{@name.inspect} status=#{@status}>"
+      "#<Microsandbox::SandboxHandle name=#{name.inspect} status=#{status}>"
     end
   end
+
+  # @deprecated since v0.5.8. {Sandbox.get}/{Sandbox.list} now return a
+  #   controllable {SandboxHandle}; this constant remains as an alias so code
+  #   that referenced the old read-only metadata type by name still resolves.
+  SandboxInfo = SandboxHandle
 
   # The terminal observation of a stopped sandbox, returned by
   # {Sandbox#wait_until_stopped}. Mirrors the official SDKs' `SandboxStopResult`.
@@ -215,24 +286,24 @@ module Microsandbox
         new(Native::Sandbox.start(name.to_s, {"detached" => detached}))
       end
 
-      # Fetch metadata for a sandbox by name.
-      # @return [SandboxInfo]
+      # Fetch a controllable handle for a sandbox by name (running or not).
+      # @return [SandboxHandle]
       def get(name)
-        SandboxInfo.new(Native::Sandbox.get(name.to_s))
+        SandboxHandle.new(Native::Sandbox.get(name.to_s))
       end
 
-      # List all sandboxes.
-      # @return [Array<SandboxInfo>]
+      # List all sandboxes as controllable handles.
+      # @return [Array<SandboxHandle>]
       def list
-        Native::Sandbox.list.map { |info| SandboxInfo.new(info) }
+        Native::Sandbox.list.map { |h| SandboxHandle.new(h) }
       end
 
       # List sandboxes carrying all of the given labels (AND-matched).
       # @param labels [Hash] required key => value labels
-      # @return [Array<SandboxInfo>]
+      # @return [Array<SandboxHandle>]
       def list_with(labels: {})
         opts = {"labels" => stringify(labels)}
-        Native::Sandbox.list_with(opts).map { |info| SandboxInfo.new(info) }
+        Native::Sandbox.list_with(opts).map { |h| SandboxHandle.new(h) }
       end
 
       # Remove a (stopped) sandbox by name.
@@ -517,48 +588,46 @@ module Microsandbox
       LogStream.new(@native.log_stream(opts))
     end
 
-    # Gracefully stop the sandbox (and wait for it to terminate).
-    # @param timeout [Numeric, nil] seconds to wait before SIGKILL
+    # Gracefully stop the sandbox (SIGTERM→SIGKILL escalation, 10s default) and
+    # wait for it to terminate. For a custom timeout or fire-and-return
+    # `request_*` control, fetch a {SandboxHandle} via {Sandbox.get}.
     # @return [nil]
-    def stop(timeout: nil)
-      @native.stop(timeout && coerce_duration(timeout, "timeout"))
+    def stop
+      @native.stop
       nil
+    end
+
+    # Gracefully stop, then wait for the process to exit.
+    # @return [ExitStatus]
+    def stop_and_wait
+      ExitStatus.new(@native.stop_and_wait)
     end
 
     # Force-kill the sandbox (SIGKILL).
-    # @param timeout [Numeric, nil] seconds to wait
     # @return [nil]
-    def kill(timeout: nil)
-      @native.kill(timeout && coerce_duration(timeout, "timeout"))
+    def kill
+      @native.kill
       nil
     end
 
-    # Send the graceful-shutdown request and return immediately, without waiting
-    # for the sandbox to terminate. Pair with {#wait_until_stopped}.
+    # Trigger a graceful drain (SIGUSR1).
     # @return [nil]
-    def request_stop
-      @native.request_stop
+    def drain
+      @native.drain
       nil
     end
 
-    # Send the force-kill request and return immediately, without waiting.
-    # @return [nil]
-    def request_kill
-      @native.request_kill
-      nil
+    # Wait for the sandbox process to exit.
+    # @return [ExitStatus]
+    def wait
+      ExitStatus.new(@native.wait)
     end
 
-    # Request a graceful drain and return immediately, without waiting.
-    # @return [nil]
-    def request_drain
-      @native.request_drain
-      nil
-    end
-
-    # Block until the sandbox is observed in a terminal (non-running) state.
-    # @return [SandboxStopResult]
-    def wait_until_stopped
-      SandboxStopResult.new(@native.wait_until_stopped)
+    # The live status, fetched from the backend (a round-trip per call).
+    # @return [Symbol] :created, :starting, :running, :draining, :paused,
+    #   :stopped, or :crashed
+    def status
+      @native.status.to_sym
     end
 
     # @return [Boolean] whether this handle owns the sandbox process lifecycle

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -9,7 +9,12 @@ module Microsandbox
   def self.ensure_runtime!: () -> nil
   def self.runtime_path: () -> String
   def self.runtime_path=: (String path) -> void
+  def self.libkrunfw_path=: (String path) -> void
   def self.all_sandbox_metrics: () -> Hash[String, Metrics]
+
+  def self.set_default_backend: (String | Symbol kind, ?url: String?, ?api_key: String?, ?profile: String?) -> void
+  def self.with_backend: [T] (String | Symbol kind, ?url: String?, ?api_key: String?, ?profile: String?) { () -> T } -> T
+  def self.default_backend_kind: () -> Symbol
 
   class Error < StandardError
     def self.code: () -> String
@@ -37,6 +42,8 @@ module Microsandbox
   class MetricsDisabledError < Error end
   class MetricsUnavailableError < Error end
   class UnsupportedOperationError < Error end
+  class CloudHttpError < Error end
+  class UnsupportedError < Error end
 
   class ExecOutput
     def initialize: (Hash[String, untyped] data) -> void
@@ -114,14 +121,25 @@ module Microsandbox
     def timestamp: () -> Time
   end
 
-  class SandboxInfo
+  class SandboxHandle
     def name: () -> String
     def status: () -> Symbol
     def running?: () -> bool
     def stopped?: () -> bool
     def created_at: () -> Time?
     def updated_at: () -> Time?
+    def stop: () -> nil
+    def stop_with_timeout: (Numeric timeout) -> nil
+    def kill: () -> nil
+    def kill_with_timeout: (Numeric timeout) -> nil
+    def request_stop: () -> nil
+    def request_kill: () -> nil
+    def request_drain: () -> nil
+    def wait_until_stopped: () -> SandboxStopResult
   end
+
+  # Deprecated alias for SandboxHandle (was a read-only metadata type pre-v0.5.8).
+  SandboxInfo: singleton(SandboxHandle)
 
   class SandboxStopResult
     def name: () -> String
@@ -151,9 +169,9 @@ module Microsandbox
                       ?replace: bool, ?replace_with_timeout: Numeric?)
                       ?{ (Sandbox) -> untyped } -> untyped
     def self.start: (String name, ?detached: bool) -> Sandbox
-    def self.get: (String name) -> SandboxInfo
-    def self.list: () -> Array[SandboxInfo]
-    def self.list_with: (?labels: Hash[untyped, untyped]) -> Array[SandboxInfo]
+    def self.get: (String name) -> SandboxHandle
+    def self.list: () -> Array[SandboxHandle]
+    def self.list_with: (?labels: Hash[untyped, untyped]) -> Array[SandboxHandle]
     def self.remove: (String name) -> nil
 
     def name: () -> String
@@ -179,12 +197,12 @@ module Microsandbox
     def metrics_stream: (?interval: Numeric) -> MetricsStream
     def log_stream: (?sources: Array[String | Symbol]?, ?since_ms: Numeric?,
                      ?from_cursor: String?, ?until_ms: Numeric?, ?follow: bool) -> LogStream
-    def stop: (?timeout: Numeric?) -> nil
-    def kill: (?timeout: Numeric?) -> nil
-    def request_stop: () -> nil
-    def request_kill: () -> nil
-    def request_drain: () -> nil
-    def wait_until_stopped: () -> SandboxStopResult
+    def stop: () -> nil
+    def stop_and_wait: () -> ExitStatus
+    def kill: () -> nil
+    def drain: () -> nil
+    def wait: () -> ExitStatus
+    def status: () -> Symbol
     def owns_lifecycle?: () -> bool
     def detach: () -> nil
   end

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -234,7 +234,7 @@ module Microsandbox
   end
 
   class ExitStatus
-    def exit_code: () -> Integer
+    def exit_code: () -> Integer?
     def success?: () -> bool
     def failure?: () -> bool
   end

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -6,12 +6,15 @@ RSpec.describe "lifecycle controls + streaming", :integration do
   let(:image) { default_test_image }
 
   describe "async lifecycle" do
-    it "owns_lifecycle? is true and wait_until_stopped reports a terminal result" do
+    it "owns_lifecycle? is true and a handle's wait_until_stopped reports a terminal result" do
       sb = Microsandbox::Sandbox.create(unique_sandbox_name, image: image)
       begin
         expect(sb.owns_lifecycle?).to be(true)
-        sb.request_stop
-        result = sb.wait_until_stopped
+        # The fine-grained request_*/wait_until_stopped controls live on the
+        # controllable SandboxHandle (v0.5.8 lifecycle split), not the live object.
+        handle = Microsandbox::Sandbox.get(sb.name)
+        handle.request_stop
+        result = handle.wait_until_stopped
         expect(result).to be_a(Microsandbox::SandboxStopResult)
         expect(result.status).to be_a(Symbol)
         expect(result.observed_at).to be_a(Time)

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -23,8 +23,8 @@ RSpec.describe "lifecycle controls + streaming", :integration do
         # kill here just guards against an early failure leaving it running.
         begin
           sb.kill
-        rescue
-          Microsandbox::Error
+        rescue Microsandbox::Error
+          # ignore stop/kill failures during teardown
         end
       end
     end

--- a/spec/unit/backend_spec.rb
+++ b/spec/unit/backend_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+# Backend routing surface (v0.5.8 / upstream PR #754). These exercise the
+# pure-config selection API; no microVM is booted. Tests avoid leaving a
+# non-local backend installed process-wide: only validation errors (which raise
+# before installing), the read-only kind query, and `with_backend(:local)`
+# (which restores) touch real state.
+RSpec.describe "Microsandbox backend routing" do
+  describe ".default_backend_kind" do
+    it "returns :local or :cloud" do
+      expect(%i[local cloud]).to include(Microsandbox.default_backend_kind)
+    end
+
+    it "is :local by default (no backend configured)" do
+      expect(Microsandbox.default_backend_kind).to eq(:local)
+    end
+  end
+
+  describe ".set_default_backend" do
+    it "rejects an unknown kind with InvalidConfigError" do
+      expect { Microsandbox.set_default_backend(:bogus) }
+        .to raise_error(Microsandbox::InvalidConfigError, /local.*cloud|cloud.*local/)
+    end
+
+    it "rejects cloud without url/api_key/profile with InvalidConfigError" do
+      expect { Microsandbox.set_default_backend(:cloud) }
+        .to raise_error(Microsandbox::InvalidConfigError, /url.*api_key|profile/)
+    end
+
+    it "accepts :local (a no-op-equivalent reinstall of the default)" do
+      expect { Microsandbox.set_default_backend(:local) }.not_to raise_error
+      expect(Microsandbox.default_backend_kind).to eq(:local)
+    end
+  end
+
+  describe ".with_backend" do
+    it "yields and returns the block's value, restoring the previous backend" do
+      result = Microsandbox.with_backend(:local) { :inside }
+      expect(result).to eq(:inside)
+      expect(Microsandbox.default_backend_kind).to eq(:local)
+    end
+
+    it "restores the previous backend even when the block raises" do
+      expect {
+        Microsandbox.with_backend(:local) { raise "boom" }
+      }.to raise_error("boom")
+      expect(Microsandbox.default_backend_kind).to eq(:local)
+    end
+
+    it "rejects an invalid backend before yielding (nothing to restore)" do
+      expect { Microsandbox.with_backend(:cloud) { :never } }
+        .to raise_error(Microsandbox::InvalidConfigError)
+    end
+  end
+end

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -29,7 +29,9 @@ RSpec.describe "Microsandbox error hierarchy" do
     "IoError" => "io-error",
     "MetricsDisabledError" => "metrics-disabled",
     "MetricsUnavailableError" => "metrics-unavailable",
-    "UnsupportedOperationError" => "unsupported-operation"
+    "UnsupportedOperationError" => "unsupported-operation",
+    "CloudHttpError" => "cloud-http",
+    "UnsupportedError" => "unsupported"
   }
 
   expected_codes.each do |name, code|

--- a/spec/unit/runtime_spec.rb
+++ b/spec/unit/runtime_spec.rb
@@ -34,11 +34,17 @@ RSpec.describe "Microsandbox runtime helpers" do
   end
 
   describe ".libkrunfw_path=" do
-    it "is callable and forwards to the native set-once setter" do
-      # Process-level + set-once at the core; MSB_LIBKRUNFW_PATH still wins. We
-      # only assert the binding is wired (no VM boots in unit tests, so the value
-      # is inert here).
-      expect(Microsandbox.libkrunfw_path = "/custom/path/to/libkrunfw.dylib").to eq("/custom/path/to/libkrunfw.dylib")
+    it "forwards the stringified path to the native set-once setter" do
+      # Stub the native setter so we (a) actually verify the binding forwards,
+      # and (b) never consume the real process-wide set-once OnceLock — it has no
+      # getter and cannot be restored, so touching it would leak into a combined
+      # unit+integration run. Asserting the assignment's value would be a Ruby
+      # tautology (an assignment evaluates to its RHS regardless of the setter),
+      # so assert the forwarded native call instead.
+      allow(Microsandbox::Native).to receive(:set_runtime_libkrunfw_path)
+      Microsandbox.libkrunfw_path = "/custom/path/to/libkrunfw.dylib"
+      expect(Microsandbox::Native).to have_received(:set_runtime_libkrunfw_path)
+        .with("/custom/path/to/libkrunfw.dylib")
     end
   end
 

--- a/spec/unit/runtime_spec.rb
+++ b/spec/unit/runtime_spec.rb
@@ -33,9 +33,22 @@ RSpec.describe "Microsandbox runtime helpers" do
     end
   end
 
+  describe ".libkrunfw_path=" do
+    it "is callable and forwards to the native set-once setter" do
+      # Process-level + set-once at the core; MSB_LIBKRUNFW_PATH still wins. We
+      # only assert the binding is wired (no VM boots in unit tests, so the value
+      # is inert here).
+      expect(Microsandbox.libkrunfw_path = "/custom/path/to/libkrunfw.dylib").to eq("/custom/path/to/libkrunfw.dylib")
+    end
+  end
+
   describe "Native module" do
     it "exposes the expected module functions" do
-      %i[version install installed? set_runtime_msb_path resolved_msb_path].each do |m|
+      %i[
+        version install installed? set_runtime_msb_path set_runtime_libkrunfw_path
+        resolved_msb_path set_default_backend push_default_backend pop_default_backend
+        default_backend_kind
+      ].each do |m|
         expect(Microsandbox::Native).to respond_to(m)
       end
     end

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -264,14 +264,40 @@ RSpec.describe Microsandbox::Sandbox do
     end
   end
 
-  describe "#stop / #kill" do
-    it "forwards optional float timeouts" do
+  describe "live lifecycle (#stop / #stop_and_wait / #kill / #drain / #wait / #status)" do
+    subject(:sb) { Microsandbox::Sandbox.create("box", image: "x") }
+
+    before do
       allow(native).to receive(:kill)
-      sb = Microsandbox::Sandbox.create("box", image: "x")
-      sb.stop(timeout: 3)
-      sb.kill
-      expect(native).to have_received(:stop).with(3.0)
-      expect(native).to have_received(:kill).with(nil)
+      allow(native).to receive(:drain)
+      allow(native).to receive(:stop_and_wait).and_return("exit_code" => 0, "success" => true)
+      allow(native).to receive(:wait).and_return("exit_code" => 137, "success" => false)
+      allow(native).to receive(:status).and_return("running")
+    end
+
+    it "forwards the high-level lifecycle calls (no timeout args on the live handle)" do
+      expect(sb.stop).to be_nil
+      expect(sb.kill).to be_nil
+      expect(sb.drain).to be_nil
+      expect(native).to have_received(:stop).with(no_args)
+      expect(native).to have_received(:kill).with(no_args)
+      expect(native).to have_received(:drain).with(no_args)
+    end
+
+    it "wraps #stop_and_wait and #wait in an ExitStatus" do
+      done = sb.stop_and_wait
+      expect(done).to be_a(Microsandbox::ExitStatus)
+      expect(done).to be_success
+      expect(done.exit_code).to eq(0)
+
+      killed = sb.wait
+      expect(killed).to be_a(Microsandbox::ExitStatus)
+      expect(killed).to be_failure
+      expect(killed.exit_code).to eq(137)
+    end
+
+    it "exposes the live #status as a Symbol" do
+      expect(sb.status).to eq(:running)
     end
   end
 
@@ -295,8 +321,11 @@ RSpec.describe Microsandbox::Sandbox do
         expect(native).not_to have_received(:exec)
       end
 
-      it "rejects #{bad.inspect} as a stop timeout" do
-        expect { sb.stop(timeout: bad) }
+      it "rejects #{bad.inspect} as a handle stop_with_timeout" do
+        handle = Microsandbox::SandboxHandle.new(
+          instance_double(Microsandbox::Native::SandboxHandle)
+        )
+        expect { handle.stop_with_timeout(bad) }
           .to raise_error(ArgumentError, /timeout must be a finite, non-negative/)
       end
 
@@ -323,23 +352,12 @@ RSpec.describe Microsandbox::Sandbox do
     end
   end
 
-  describe "async lifecycle controls" do
+  describe "live owns_lifecycle? / detach" do
     subject(:sb) { Microsandbox::Sandbox.create("box", image: "x") }
 
-    it "forwards request_stop/request_kill/request_drain and detach, returning nil" do
-      allow(native).to receive(:request_stop)
-      allow(native).to receive(:request_kill)
-      allow(native).to receive(:request_drain)
+    it "forwards detach, returning nil" do
       allow(native).to receive(:detach)
-
-      expect(sb.request_stop).to be_nil
-      expect(sb.request_kill).to be_nil
-      expect(sb.request_drain).to be_nil
       expect(sb.detach).to be_nil
-
-      expect(native).to have_received(:request_stop)
-      expect(native).to have_received(:request_kill)
-      expect(native).to have_received(:request_drain)
       expect(native).to have_received(:detach)
     end
 
@@ -347,13 +365,41 @@ RSpec.describe Microsandbox::Sandbox do
       allow(native).to receive(:owns_lifecycle).and_return(true)
       expect(sb.owns_lifecycle?).to be(true)
     end
+  end
+
+  describe "SandboxHandle fine-grained lifecycle (from Sandbox.get/list)" do
+    let(:native_handle) { instance_double(Microsandbox::Native::SandboxHandle) }
+    subject(:handle) { Microsandbox::SandboxHandle.new(native_handle) }
+
+    it "forwards request_stop/request_kill/request_drain, returning nil" do
+      allow(native_handle).to receive(:request_stop)
+      allow(native_handle).to receive(:request_kill)
+      allow(native_handle).to receive(:request_drain)
+
+      expect(handle.request_stop).to be_nil
+      expect(handle.request_kill).to be_nil
+      expect(handle.request_drain).to be_nil
+
+      expect(native_handle).to have_received(:request_stop)
+      expect(native_handle).to have_received(:request_kill)
+      expect(native_handle).to have_received(:request_drain)
+    end
+
+    it "forwards stop_with_timeout/kill_with_timeout with coerced floats" do
+      allow(native_handle).to receive(:stop_with_timeout)
+      allow(native_handle).to receive(:kill_with_timeout)
+      handle.stop_with_timeout(3)
+      handle.kill_with_timeout(1.5)
+      expect(native_handle).to have_received(:stop_with_timeout).with(3.0)
+      expect(native_handle).to have_received(:kill_with_timeout).with(1.5)
+    end
 
     it "wraps wait_until_stopped in a SandboxStopResult" do
-      allow(native).to receive(:wait_until_stopped).and_return(
+      allow(native_handle).to receive(:wait_until_stopped).and_return(
         "name" => "box", "status" => "stopped", "exit_code" => 0,
         "signal" => nil, "observed_at_ms" => 1_700_000_000_000, "source" => "owned process handle"
       )
-      result = sb.wait_until_stopped
+      result = handle.wait_until_stopped
       expect(result).to be_a(Microsandbox::SandboxStopResult)
       expect(result).to be_stopped
       expect(result.exit_code).to eq(0)
@@ -416,15 +462,16 @@ RSpec.describe Microsandbox::Sandbox do
 
   describe ".list_with" do
     it "normalizes label filters into a string-keyed labels hash" do
-      allow(Microsandbox::Native::Sandbox).to receive(:list_with).and_return(
-        [{"name" => "box", "status" => "running"}]
+      native_handle = instance_double(
+        Microsandbox::Native::SandboxHandle, name: "box", status: "running"
       )
-      infos = Microsandbox::Sandbox.list_with(labels: {team: :core})
+      allow(Microsandbox::Native::Sandbox).to receive(:list_with).and_return([native_handle])
+      handles = Microsandbox::Sandbox.list_with(labels: {team: :core})
       expect(Microsandbox::Native::Sandbox).to have_received(:list_with).with(
         "labels" => {"team" => "core"}
       )
-      expect(infos.first).to be_a(Microsandbox::SandboxInfo)
-      expect(infos.first.name).to eq("box")
+      expect(handles.first).to be_a(Microsandbox::SandboxHandle)
+      expect(handles.first.name).to eq("box")
     end
   end
 end

--- a/spec/unit/value_objects_spec.rb
+++ b/spec/unit/value_objects_spec.rb
@@ -114,18 +114,24 @@ RSpec.describe "value objects" do
     end
   end
 
-  describe Microsandbox::SandboxInfo do
-    it "parses name/status and timestamps" do
-      info = described_class.new(
-        "name" => "box", "status" => "running",
-        "created_at_ms" => 1_700_000_000_000, "updated_at_ms" => nil
+  describe Microsandbox::SandboxHandle do
+    it "exposes name/status and timestamps from the native handle" do
+      native = instance_double(
+        Microsandbox::Native::SandboxHandle,
+        name: "box", status: "running",
+        created_at_ms: 1_700_000_000_000, updated_at_ms: nil
       )
-      expect(info.name).to eq("box")
-      expect(info.status).to eq(:running)
-      expect(info).to be_running
-      expect(info).not_to be_stopped
-      expect(info.created_at).to be_a(Time)
-      expect(info.updated_at).to be_nil
+      handle = described_class.new(native)
+      expect(handle.name).to eq("box")
+      expect(handle.status).to eq(:running)
+      expect(handle).to be_running
+      expect(handle).not_to be_stopped
+      expect(handle.created_at).to be_a(Time)
+      expect(handle.updated_at).to be_nil
+    end
+
+    it "is still reachable through the deprecated SandboxInfo alias" do
+      expect(Microsandbox::SandboxInfo).to equal(Microsandbox::SandboxHandle)
     end
   end
 


### PR DESCRIPTION
## Summary

Adopts the upstream **microsandbox `v0.5.8`** runtime (was `v0.5.7`), closing the alignment tracked in #7. The gate condition there ("hold until a release contains backend-routing PR #754") was satisfied when upstream cut `v0.5.8` (tag `47d0cdf1`) — and `#754` (`926fe45c`) is a verified ancestor of it.

The surprise: **`v0.5.8` is not purely additive.** PR #754's backend-routing rewrite threads an ambient backend through the core and **splits the sandbox lifecycle** across the live `Sandbox` and a lightweight `SandboxHandle`, which broke 16 existing bindings. So this is a migration, not just new surface. The full delta was mapped and adversarially verified against the v0.5.8 source (28 claims, each re-checked at file:line) before any code was written.

## Migration (the 16 compile breaks)

- Bump `microsandbox` / `microsandbox-network` git deps to `tag = "v0.5.8"` (regenerate `Cargo.lock`); fix the moved crate path in `.cargo/config.toml.example` (`crates/microsandbox` → `sdk/rust`; resolution is by package name, so the git dep needed only the tag bump).
- New `ext/microsandbox/src/backend.rs` with a private `local_backend()` helper (resolves the ambient `default_backend()` and downcasts via `as_local()`, mirroring pyo3's `resolve_local`), threaded into `Image::{get,list,inspect,remove,prune}`, `all_sandbox_metrics` (async), and `resolved_msb_path` (sync — kept off `block_on`). `Sandbox`/`Volume` CRUD are unchanged (they resolve the backend internally).
- `Volume#path` now handles the fallible core return; `sandbox_status_str` is exhaustive over the new `:created`/`:starting` variants.

## Lifecycle split — ⚠️ BREAKING (mirrors the official Python/Node SDKs)

- **Live `Microsandbox::Sandbox`** (from `create`/`start`): `stop`, `stop_and_wait`, `kill`, `drain`, `wait` (→ `ExitStatus`), `status`, `detach`, `owns_lifecycle?`. `stop`/`kill` **no longer take a `timeout:`**; `stop` performs the SDKs' graceful SIGTERM→SIGKILL escalation (10s default).
- **New controllable `Microsandbox::SandboxHandle`** (returned by `Sandbox.get`/`.list`/`.list_with`, replacing the read-only `SandboxInfo` — kept as a deprecated constant alias): `stop`, `stop_with_timeout`, `kill`, `kill_with_timeout`, `request_stop`, `request_kill`, `request_drain`, `wait_until_stopped` (→ `SandboxStopResult`), plus metadata accessors.

## New surface (issue #7 checklist)

- **Backend routing**: `Microsandbox.set_default_backend(kind, url:, api_key:, profile:)`, `Microsandbox.with_backend(kind, …) { … }` (scoped, restoring), `Microsandbox.default_backend_kind`. Env/profile resolution (`MSB_BACKEND` / `MSB_API_URL`+`MSB_API_KEY` / `MSB_PROFILE` / `~/.microsandbox/config.json`) is inherited from the core.
- **`Microsandbox.libkrunfw_path=`** (mirrors `runtime_path=`).
- **`Microsandbox::CloudHttpError`** (`cloud-http`) and **`Microsandbox::UnsupportedError`** (`unsupported`), distinct from the existing `UnsupportedOperationError`.

## Verification

| Check | Result |
|---|---|
| `cargo fmt --check` | ✅ |
| `cargo clippy -- -D warnings` | ✅ (0) |
| `standardrb` | ✅ |
| `rspec spec/unit` | ✅ 241 / 0 |
| `rbs validate` | ✅ |

Docs updated: `README.md` (lifecycle change note + backend-routing section), `DESIGN.md`, `CHANGELOG.md` (`[Unreleased]`), and the hand-maintained `sig/microsandbox.rbs`. Integration specs updated for the new API (gated by `MICROSANDBOX_INTEGRATION=1`; not run here).

Version stays at `0.5.9` — the lock-step bump to `0.5.10` is the release-time action (push a `vX.Y.Z` tag) per the gem's convention; everything here is staged under `[Unreleased]`.

> **Note (CI-irrelevant):** on a bleeding-edge macOS toolchain the locally compiled `.bundle` won't `dlopen` because rb_sys 0.9.128 writes an empty `LC_ID_DYLIB` install name (`install_name_tool -id ""`) that the new `dyld` rejects. It's an rb_sys/toolchain issue, not this change, and CI's Linux build (ELF, no such load command) is unaffected.

Closes #7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
