### PR TITLE
Release 0.5.10: streaming stdin pipe (exec_stream stdin: :pipe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-06-22
+
+### Added
+
+- **Streaming stdin pipe for `exec_stream`/`shell_stream`** (`stdin: :pipe`).
+  Opens a writable `ExecHandle#stdin` sink (`ExecStdin`) lifted out of the core
+  handle via `take_stdin`, distinct from the existing fixed-bytes `stdin:`
+  buffer. This is the load-bearing primitive for driving an interactive
+  long-running process (e.g. a `claude` CLI) over `exec_stream` from a host
+  reactor. The published `0.5.9` shipped without it (`stdin: :pipe` was fed as
+  the literal byte string `"pipe"`), so any consumer of the streaming sink must
+  require `>= 0.5.10`.
+
 Adopts the upstream **microsandbox `v0.5.8`** runtime (was `v0.5.7`), whose
 backend-routing rewrite (upstream PR #754) both adds new surface and reshapes the
 sandbox lifecycle.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "futures",

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.5.9"
+version = "0.5.10"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  # Gem version. Tracks the upstream microsandbox runtime (currently `v0.5.7`,
+  # Gem version. Tracks the upstream microsandbox runtime (currently `v0.5.8`,
   # the pinned core-crate tag); the patch segment advances for gem-only revisions
   # that add bindings atop the same core. Must equal the native ext's Cargo crate
   # version (`Native.version`), enforced by spec/unit/version_spec.rb.
-  VERSION = "0.5.9"
+  VERSION = "0.5.10"
 end


### PR DESCRIPTION
Cuts **0.5.10** so the streaming stdin sink — already on `main` from #9 (`af67bb0`) — ships in a *published* version.

## Why this release exists
`exec_stream`/`shell_stream` with `stdin: :pipe` opens a writable `ExecHandle#stdin` (`ExecStdin`, lifted out of the core handle via `take_stdin`) — the load-bearing primitive for driving an interactive long-running process (e.g. a `claude` CLI inside a microVM) from a host reactor.

This never shipped in a published gem: the **published `0.5.9` fed `stdin: :pipe` as the literal byte string `"pipe"`** (no sink), and `0.5.7` returns `nil` from `handle.stdin`. So any consumer of the streaming sink must require `>= 0.5.10`. (Voyager's `MicrosandboxCliTransport` is the first such consumer — it currently can't resolve the dependency from rubygems until this is published.)

## Changes
- `lib/microsandbox/version.rb`: `VERSION` → `0.5.10` (+ fix the stale core-tag note `v0.5.7` → `v0.5.8`).
- `ext/microsandbox/Cargo.toml`: package version → `0.5.10` (`Native.version` == `CARGO_PKG_VERSION`, asserted by `spec/unit/version_spec.rb`).
- `CHANGELOG.md`: `[0.5.10]` entry.

Single commit on top of `main`; no code changes beyond the version bump (the streaming-pipe code is already merged). After merge: `gem build` + `gem push` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qe4zqpsEZ2ocARr2RHpa2