### PR TITLE
Release 0.5.11: read-only / mount-option passthrough for volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-06-22
+
+### Added
+
+- **Streaming stdin pipe for `exec_stream`/`shell_stream`** (`stdin: :pipe`).
+  Opens a writable `ExecHandle#stdin` sink (`ExecStdin`) lifted out of the core
+  handle via `take_stdin`, distinct from the existing fixed-bytes `stdin:`
+  buffer. This is the load-bearing primitive for driving an interactive
+  long-running process (e.g. a `claude` CLI) over `exec_stream` from a host
+  reactor. The published `0.5.9` shipped without it (`stdin: :pipe` was fed as
+  the literal byte string `"pipe"`), so any consumer of the streaming sink must
+  require `>= 0.5.10`.
+
 Adopts the upstream **microsandbox `v0.5.8`** runtime (was `v0.5.7`), whose
 backend-routing rewrite (upstream PR #754) both adds new surface and reshapes the
 sandbox lifecycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+## [0.5.11] - 2026-06-23
+
+### Added
+
+- **Read-only / mount-option passthrough for volumes.** A volume spec Hash may
+  now carry `ro:`/`readonly:`, `noexec:`, `nosuid:`, `nodev:`, or an explicit
+  `options:` array, e.g. `volumes: { "/repos" => { bind: "/host/repos", ro: true } }`.
+  The Ruby layer appends a 4th comma-joined options element to the normalized
+  mount triple and the native ext applies the matching `MountBuilder` flags. RO is
+  enforced both host-side (virtiofs rejects writes) and guest-side (kernel returns
+  `EROFS`). Previously the gem could only request read-write mounts, so callers had
+  to fake read-only with host `chmod -R a-w`. Backward compatible: String specs and
+  option-less Hash specs serialize to the exact same 3-element triple as before.
+
 ## [0.5.10] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.9"
+version = "0.5.10"
 dependencies = [
  "chrono",
  "futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.9"
+version = "0.5.11"
 dependencies = [
  "chrono",
  "futures",

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.5.10"
+version = "0.5.11"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.5.9"
+version = "0.5.10"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -127,7 +127,11 @@ impl Sandbox {
                 }
             }
             b = b.volume(guest, move |m| {
-                let mut m = if kind == "named" { m.named(source) } else { m.bind(source) };
+                let mut m = if kind == "named" {
+                    m.named(source)
+                } else {
+                    m.bind(source)
+                };
                 for opt in &mount_opts {
                     m = match opt.as_str() {
                         "ro" | "readonly" => m.readonly(),

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -89,9 +89,11 @@ impl Sandbox {
         for (host, guest) in conv::opt_port_map(opts, "ports")? {
             b = b.port(host, guest);
         }
-        // volumes: normalized by the Ruby layer to [guest, kind, source] triples.
+        // volumes: normalized by the Ruby layer to [guest, kind, source] triples,
+        // or [guest, kind, source, options] quads where options is a comma-joined
+        // list (ro/readonly, rw, noexec, nosuid, nodev).
         for spec in conv::opt::<Vec<Vec<String>>>(opts, "volumes")?.unwrap_or_default() {
-            if spec.len() != 3 {
+            if spec.len() < 3 || spec.len() > 4 {
                 return Err(error::base_error("invalid volume mount spec"));
             }
             let (guest, kind, source) = (spec[0].clone(), spec[1].clone(), spec[2].clone());
@@ -103,12 +105,39 @@ impl Sandbox {
                     )))
                 }
             }
-            b = b.volume(guest, move |m| {
-                if kind == "named" {
-                    m.named(source)
-                } else {
-                    m.bind(source)
+            // Validate options up front (the volume closure cannot return an error).
+            let mount_opts: Vec<String> = spec
+                .get(3)
+                .map(|s| {
+                    s.split(',')
+                        .map(|o| o.trim().to_string())
+                        .filter(|o| !o.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            for opt in &mount_opts {
+                match opt.as_str() {
+                    "ro" | "readonly" | "rw" | "noexec" | "nosuid" | "nodev" => {}
+                    other => {
+                        return Err(error::base_error(format!(
+                            "unknown volume mount option {other:?} \
+                             (expected ro/rw/noexec/nosuid/nodev)"
+                        )))
+                    }
                 }
+            }
+            b = b.volume(guest, move |m| {
+                let mut m = if kind == "named" { m.named(source) } else { m.bind(source) };
+                for opt in &mount_opts {
+                    m = match opt.as_str() {
+                        "ro" | "readonly" => m.readonly(),
+                        "noexec" => m.noexec(),
+                        "nosuid" => m.nosuid(),
+                        "nodev" => m.nodev(),
+                        _ => m, // "rw" — default; already validated above
+                    };
+                }
+                m
             });
         }
         // patches: rootfs modifications applied before boot. The Ruby layer

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -387,8 +387,10 @@ module Microsandbox
       end
 
       # Normalize volumes (Hash of guest_path => spec) into [guest, kind, source]
-      # triples for the native layer. A spec is a host path String (bind mount),
-      # or a Hash { bind: "/host" } / { named: "volume-name" }.
+      # triples (or [guest, kind, source, options] quads) for the native layer. A
+      # spec is a host path String (read-write bind mount), or a Hash
+      # { bind: "/host" } / { named: "volume-name" } optionally carrying mount
+      # options: { bind: "/host", ro: true } / { named: "v", options: %w[ro noexec] }.
       def normalize_volumes(volumes)
         volumes.map do |guest, spec|
           guest = guest.to_s
@@ -396,17 +398,37 @@ module Microsandbox
           when String
             [guest, "bind", spec]
           when Hash
-            if (named = spec[:named] || spec["named"])
-              [guest, "named", named.to_s]
-            elsif (bind = spec[:bind] || spec["bind"])
-              [guest, "bind", bind.to_s]
-            else
-              raise ArgumentError, "volume spec for #{guest.inspect} needs :bind or :named"
-            end
+            triple =
+              if (named = spec[:named] || spec["named"])
+                [guest, "named", named.to_s]
+              elsif (bind = spec[:bind] || spec["bind"])
+                [guest, "bind", bind.to_s]
+              else
+                raise ArgumentError, "volume spec for #{guest.inspect} needs :bind or :named"
+              end
+            # Optional 4th element: comma-joined mount options. Omitted when empty
+            # so existing [guest,kind,source] consumers and the common read-write
+            # case are byte-for-byte unchanged.
+            opts = mount_options(spec)
+            opts.empty? ? triple : triple + [opts.join(",")]
           else
             raise ArgumentError, "invalid volume spec for #{guest.inspect}: #{spec.inspect}"
           end
         end
+      end
+
+      # Collect mount options from a volume spec Hash. `ro:`/`readonly:` makes the
+      # mount read-only (host virtiofs rejects writes + guest kernel returns EROFS);
+      # `noexec:`/`nosuid:`/`nodev:` set the matching flags; an explicit `options:`
+      # array passes through verbatim. Unknown options are rejected natively.
+      def mount_options(spec)
+        opts = []
+        opts << "ro" if spec[:ro] || spec["ro"] || spec[:readonly] || spec["readonly"]
+        opts << "noexec" if spec[:noexec] || spec["noexec"]
+        opts << "nosuid" if spec[:nosuid] || spec["nosuid"]
+        opts << "nodev" if spec[:nodev] || spec["nodev"]
+        Array(spec[:options] || spec["options"]).each { |o| opts << o.to_s }
+        opts.uniq
       end
 
       # Normalize a list of patches (each a Hash from the {Patch} factory, or a

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  # Gem version. Tracks the upstream microsandbox runtime (currently `v0.5.7`,
+  # Gem version. Tracks the upstream microsandbox runtime (currently `v0.5.8`,
   # the pinned core-crate tag); the patch segment advances for gem-only revisions
   # that add bindings atop the same core. Must equal the native ext's Cargo crate
   # version (`Native.version`), enforced by spec/unit/version_spec.rb.
-  VERSION = "0.5.9"
+  VERSION = "0.5.10"
 end

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -5,5 +5,5 @@ module Microsandbox
   # the pinned core-crate tag); the patch segment advances for gem-only revisions
   # that add bindings atop the same core. Must equal the native ext's Cargo crate
   # version (`Native.version`), enforced by spec/unit/version_spec.rb.
-  VERSION = "0.5.10"
+  VERSION = "0.5.11"
 end


### PR DESCRIPTION
Releases **0.5.11** (read-only / mount-option passthrough) on top of **0.5.10** (the streaming stdin pipe — previously #10). Both commits are here, so this **supersedes #10** — merge this one and close #10.

## 0.5.11 — read-only / mount-option passthrough
Volume specs can now carry mount options, e.g.:
```ruby
volumes: { "/repos" => { bind: "/host/repos", ro: true } }   # also noexec:/nosuid:/nodev:/options:
```
The Ruby layer appends a 4th comma-joined options element to the normalized mount triple; the native ext validates it and applies the matching core `MountBuilder` flags (`readonly`/`noexec`/`nosuid`/`nodev`). RO is enforced **host-side** (virtiofs rejects writes) **and guest-side** (kernel returns `EROFS`). The core already supported this; only the gem binding was missing it (callers had to fake RO with host `chmod -R a-w`).

**Backward compatible:** a String spec and an option-less Hash spec serialize to the exact same 3-element `[guest, kind, source]` triple; the native parser accepts both 3- and 4-element specs.

## 0.5.10 — streaming stdin pipe (from #10)
`exec_stream`/`shell_stream` `stdin: :pipe` → writable `ExecHandle#stdin` sink (the published 0.5.9 fed `"pipe"` as bytes; 0.5.7 returned nil).

## Validation
Both validated against a live microVM: `stdin: :pipe` round-trips a real `claude` turn; a `ro: true` bind blocks guest writes (EROFS, host file never appears) while a control `rw` bind succeeds.

Consumers requiring the RO mount (Voyager's shared repo mirror) must depend on `>= 0.5.11`. After merge: `gem build && gem push` to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017qe4zqpsEZ2ocARr2RHpa2