### PR TITLE
Release 0.5.11: read-only / mount-option passthrough for volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+## [0.5.11] - 2026-06-23
+
+### Added
+
+- **Read-only / mount-option passthrough for volumes.** A volume spec Hash may
+  now carry `ro:`/`readonly:`, `noexec:`, `nosuid:`, `nodev:`, or an explicit
+  `options:` array, e.g. `volumes: { "/repos" => { bind: "/host/repos", ro: true } }`.
+  The Ruby layer appends a 4th comma-joined options element to the normalized
+  mount triple and the native ext applies the matching `MountBuilder` flags. RO is
+  enforced both host-side (virtiofs rejects writes) and guest-side (kernel returns
+  `EROFS`). Previously the gem could only request read-write mounts, so callers had
+  to fake read-only with host `chmod -R a-w`. Backward compatible: String specs and
+  option-less Hash specs serialize to the exact same 3-element triple as before.
+
 ## [0.5.10] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.9"
+version = "0.5.11"
 dependencies = [
  "chrono",
  "futures",

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.5.10"
+version = "0.5.11"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -127,7 +127,11 @@ impl Sandbox {
                 }
             }
             b = b.volume(guest, move |m| {
-                let mut m = if kind == "named" { m.named(source) } else { m.bind(source) };
+                let mut m = if kind == "named" {
+                    m.named(source)
+                } else {
+                    m.bind(source)
+                };
                 for opt in &mount_opts {
                     m = match opt.as_str() {
                         "ro" | "readonly" => m.readonly(),

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -89,9 +89,11 @@ impl Sandbox {
         for (host, guest) in conv::opt_port_map(opts, "ports")? {
             b = b.port(host, guest);
         }
-        // volumes: normalized by the Ruby layer to [guest, kind, source] triples.
+        // volumes: normalized by the Ruby layer to [guest, kind, source] triples,
+        // or [guest, kind, source, options] quads where options is a comma-joined
+        // list (ro/readonly, rw, noexec, nosuid, nodev).
         for spec in conv::opt::<Vec<Vec<String>>>(opts, "volumes")?.unwrap_or_default() {
-            if spec.len() != 3 {
+            if spec.len() < 3 || spec.len() > 4 {
                 return Err(error::base_error("invalid volume mount spec"));
             }
             let (guest, kind, source) = (spec[0].clone(), spec[1].clone(), spec[2].clone());
@@ -103,12 +105,39 @@ impl Sandbox {
                     )))
                 }
             }
-            b = b.volume(guest, move |m| {
-                if kind == "named" {
-                    m.named(source)
-                } else {
-                    m.bind(source)
+            // Validate options up front (the volume closure cannot return an error).
+            let mount_opts: Vec<String> = spec
+                .get(3)
+                .map(|s| {
+                    s.split(',')
+                        .map(|o| o.trim().to_string())
+                        .filter(|o| !o.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default();
+            for opt in &mount_opts {
+                match opt.as_str() {
+                    "ro" | "readonly" | "rw" | "noexec" | "nosuid" | "nodev" => {}
+                    other => {
+                        return Err(error::base_error(format!(
+                            "unknown volume mount option {other:?} \
+                             (expected ro/rw/noexec/nosuid/nodev)"
+                        )))
+                    }
                 }
+            }
+            b = b.volume(guest, move |m| {
+                let mut m = if kind == "named" { m.named(source) } else { m.bind(source) };
+                for opt in &mount_opts {
+                    m = match opt.as_str() {
+                        "ro" | "readonly" => m.readonly(),
+                        "noexec" => m.noexec(),
+                        "nosuid" => m.nosuid(),
+                        "nodev" => m.nodev(),
+                        _ => m, // "rw" — default; already validated above
+                    };
+                }
+                m
             });
         }
         // patches: rootfs modifications applied before boot. The Ruby layer

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -387,8 +387,10 @@ module Microsandbox
       end
 
       # Normalize volumes (Hash of guest_path => spec) into [guest, kind, source]
-      # triples for the native layer. A spec is a host path String (bind mount),
-      # or a Hash { bind: "/host" } / { named: "volume-name" }.
+      # triples (or [guest, kind, source, options] quads) for the native layer. A
+      # spec is a host path String (read-write bind mount), or a Hash
+      # { bind: "/host" } / { named: "volume-name" } optionally carrying mount
+      # options: { bind: "/host", ro: true } / { named: "v", options: %w[ro noexec] }.
       def normalize_volumes(volumes)
         volumes.map do |guest, spec|
           guest = guest.to_s
@@ -396,17 +398,37 @@ module Microsandbox
           when String
             [guest, "bind", spec]
           when Hash
-            if (named = spec[:named] || spec["named"])
-              [guest, "named", named.to_s]
-            elsif (bind = spec[:bind] || spec["bind"])
-              [guest, "bind", bind.to_s]
-            else
-              raise ArgumentError, "volume spec for #{guest.inspect} needs :bind or :named"
-            end
+            triple =
+              if (named = spec[:named] || spec["named"])
+                [guest, "named", named.to_s]
+              elsif (bind = spec[:bind] || spec["bind"])
+                [guest, "bind", bind.to_s]
+              else
+                raise ArgumentError, "volume spec for #{guest.inspect} needs :bind or :named"
+              end
+            # Optional 4th element: comma-joined mount options. Omitted when empty
+            # so existing [guest,kind,source] consumers and the common read-write
+            # case are byte-for-byte unchanged.
+            opts = mount_options(spec)
+            opts.empty? ? triple : triple + [opts.join(",")]
           else
             raise ArgumentError, "invalid volume spec for #{guest.inspect}: #{spec.inspect}"
           end
         end
+      end
+
+      # Collect mount options from a volume spec Hash. `ro:`/`readonly:` makes the
+      # mount read-only (host virtiofs rejects writes + guest kernel returns EROFS);
+      # `noexec:`/`nosuid:`/`nodev:` set the matching flags; an explicit `options:`
+      # array passes through verbatim. Unknown options are rejected natively.
+      def mount_options(spec)
+        opts = []
+        opts << "ro" if spec[:ro] || spec["ro"] || spec[:readonly] || spec["readonly"]
+        opts << "noexec" if spec[:noexec] || spec["noexec"]
+        opts << "nosuid" if spec[:nosuid] || spec["nosuid"]
+        opts << "nodev" if spec[:nodev] || spec["nodev"]
+        Array(spec[:options] || spec["options"]).each { |o| opts << o.to_s }
+        opts.uniq
       end
 
       # Normalize a list of patches (each a Hash from the {Patch} factory, or a

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -5,5 +5,5 @@ module Microsandbox
   # the pinned core-crate tag); the patch segment advances for gem-only revisions
   # that add bindings atop the same core. Must equal the native ext's Cargo crate
   # version (`Native.version`), enforced by spec/unit/version_spec.rb.
-  VERSION = "0.5.10"
+  VERSION = "0.5.11"
 end


### PR DESCRIPTION
Cuts **0.5.11**. Stacked on top of #10 (`release/0.5.10`) — **merge #10 first**, then this. Base is `release/0.5.10` so the diff shows only the 0.5.11 increment; GitHub retargets it to `main` once #10 merges.

## What ships in 0.5.11
**Read-only / mount-option passthrough for volumes.** A volume spec Hash may now carry `ro:`/`readonly:`, `noexec:`, `nosuid:`, `nodev:`, or an explicit `options:` array, e.g. `volumes: { "/repos" => { bind: "/host/repos", ro: true } }`. The Ruby layer appends a 4th comma-joined options element to the normalized mount triple and the native ext applies the matching `MountBuilder` flags. RO is enforced both host-side (virtiofs rejects writes) and guest-side (kernel returns `EROFS`). Previously the gem could only request read-write mounts, so callers faked read-only with host `chmod -R a-w`.

Backward compatible: String specs and option-less Hash specs serialize to the exact same 3-element triple as before.

## Changes
- `lib/microsandbox/sandbox.rb` + `ext/microsandbox/src/sandbox.rs` — volume option parsing → `MountBuilder` flags.
- `lib/microsandbox/version.rb` + `ext/microsandbox/Cargo.toml` → `0.5.11` (lock-step; `Native.version` asserted by `version_spec.rb`).
- `Cargo.lock` — `microsandbox_rb` synced to `0.5.11` (the stale-lockfile fix surfaced reviewing #10; the gemspec packages `Cargo.lock` into the source gem, so a `--locked`/`--frozen`/offline build would otherwise fail on the mismatch).
- `CHANGELOG.md` — `[0.5.11]` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
