### PR TITLE
Release 0.5.12: fork-safe tokio runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ upstream microsandbox runtime.
 
 ## [Unreleased]
 
+## [0.5.12] - 2026-06-23
+
+### Fixed
+
+- **fork-safe tokio runtime.** The process-wide multi-threaded runtime is now
+  tagged with the pid it was built under and rebuilt automatically after a
+  `fork(2)`. A forking host (Solid Queue / Resque job servers, clustered Puma)
+  used to inherit a runtime whose worker + I/O-driver threads do not survive the
+  fork — `block_on` could still drive the calling thread, but background I/O (e.g.
+  the agent-relay connection that streams `exec_stream` output) never ran, so
+  long-lived operations stalled or the connection dropped mid-stream in the child.
+  `runtime()` now detects the pid change and builds a fresh runtime for the child
+  (the stale one is leaked, never dropped — dropping a runtime whose threads
+  vanished across fork can hang on the shutdown join). No API change.
+
 ## [0.5.11] - 2026-06-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.11"
+version = "0.5.12"
 dependencies = [
  "chrono",
  "futures",

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.5.11"
+version = "0.5.12"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/src/runtime.rs
+++ b/ext/microsandbox/src/runtime.rs
@@ -60,7 +60,9 @@ pub fn runtime() -> &'static Runtime {
         return unsafe { &*ptr };
     }
 
-    let _guard = RUNTIME_LOCK.lock().expect("microsandbox: runtime lock poisoned");
+    let _guard = RUNTIME_LOCK
+        .lock()
+        .expect("microsandbox: runtime lock poisoned");
     // Re-check under the lock (another thread may have just built it).
     let ptr = RUNTIME_PTR.load(Ordering::Acquire);
     if !ptr.is_null() && RUNTIME_PID.load(Ordering::Acquire) == cur {

--- a/ext/microsandbox/src/runtime.rs
+++ b/ext/microsandbox/src/runtime.rs
@@ -9,7 +9,8 @@
 use std::ffi::c_void;
 use std::future::Future;
 use std::panic::{catch_unwind, AssertUnwindSafe};
-use std::sync::OnceLock;
+use std::sync::atomic::{AtomicPtr, AtomicU32, Ordering};
+use std::sync::Mutex;
 
 use magnus::Ruby;
 use tokio::runtime::Runtime;
@@ -21,17 +22,58 @@ pub fn ruby() -> Ruby {
     Ruby::get().expect("microsandbox: not on a Ruby thread")
 }
 
-static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+// The process-wide tokio runtime, guarded by the pid it was built under. A
+// multi-threaded runtime owns worker + I/O-driver threads, and `fork(2)` copies
+// ONLY the calling thread — so a child that inherits this runtime has a runtime
+// whose threads are gone: `block_on` can still drive the current thread, but the
+// background I/O that keeps e.g. the agent-relay connection alive never runs, so
+// connections stall/drop mid-use. This is hit in practice by forking job servers
+// (Solid Queue, Resque) and clustered web servers (Puma workers).
+//
+// Fix: store the runtime behind a leaked raw pointer tagged with the building
+// pid. If `runtime()` is called in a process whose pid differs (we forked), build
+// a FRESH runtime for this process and swap the pointer. The stale runtime is
+// LEAKED, never dropped — dropping a tokio runtime whose worker threads vanished
+// across fork can hang on the shutdown thread-join. One runtime is leaked per
+// process that uses the SDK (bounded; equivalent to the old set-once behavior in
+// the common no-fork case).
+static RUNTIME_PTR: AtomicPtr<Runtime> = AtomicPtr::new(std::ptr::null_mut());
+static RUNTIME_PID: AtomicU32 = AtomicU32::new(0);
+static RUNTIME_LOCK: Mutex<()> = Mutex::new(());
 
-/// The process-wide multi-threaded tokio runtime, built on first use.
+fn build_runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("microsandbox-rb")
+        .build()
+        .expect("microsandbox: failed to build tokio runtime")
+}
+
+/// The multi-threaded tokio runtime for THIS process, built on first use and
+/// rebuilt after a `fork(2)` (fork-safe — see the note above).
 pub fn runtime() -> &'static Runtime {
-    RUNTIME.get_or_init(|| {
-        tokio::runtime::Builder::new_multi_thread()
-            .enable_all()
-            .thread_name("microsandbox-rb")
-            .build()
-            .expect("microsandbox: failed to build tokio runtime")
-    })
+    let cur = std::process::id();
+    let ptr = RUNTIME_PTR.load(Ordering::Acquire);
+    if !ptr.is_null() && RUNTIME_PID.load(Ordering::Acquire) == cur {
+        // SAFETY: ptr was produced by Box::leak (valid for 'static) and matches
+        // this process's pid, so its runtime threads are live in this process.
+        return unsafe { &*ptr };
+    }
+
+    let _guard = RUNTIME_LOCK.lock().expect("microsandbox: runtime lock poisoned");
+    // Re-check under the lock (another thread may have just built it).
+    let ptr = RUNTIME_PTR.load(Ordering::Acquire);
+    if !ptr.is_null() && RUNTIME_PID.load(Ordering::Acquire) == cur {
+        return unsafe { &*ptr };
+    }
+
+    // Build a fresh runtime for this process and publish it. The previous pointer
+    // (if any) belonged to a parent process and is intentionally leaked, not
+    // dropped (its threads are gone post-fork; Drop would block on join).
+    let rt: &'static Runtime = Box::leak(Box::new(build_runtime()));
+    RUNTIME_PTR.store(rt as *const Runtime as *mut Runtime, Ordering::Release);
+    RUNTIME_PID.store(cur, Ordering::Release);
+    rt
 }
 
 /// Run `f` with the Ruby GVL released.

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -5,5 +5,5 @@ module Microsandbox
   # the pinned core-crate tag); the patch segment advances for gem-only revisions
   # that add bindings atop the same core. Must equal the native ext's Cargo crate
   # version (`Native.version`), enforced by spec/unit/version_spec.rb.
-  VERSION = "0.5.11"
+  VERSION = "0.5.12"
 end


### PR DESCRIPTION
Cuts **0.5.12**. Stacked on top of #12 (`release/0.5.11`) — **merge #12 first**, then this. Base is `release/0.5.11`; GitHub retargets it to `main` once #12 merges.

## What ships in 0.5.12
**Fork-safe tokio runtime.** The process-wide multi-threaded tokio runtime is now rebuilt after `fork(2)` instead of being set once via `OnceLock`.

A multi-threaded runtime owns worker + I/O-driver threads, and `fork(2)` copies **only the calling thread** — so a child that inherits the parent's runtime has a runtime whose background threads are gone: `block_on` can still drive the current thread, but the background I/O that keeps e.g. the agent-relay connection alive never runs, so connections stall/drop mid-use. This is hit in practice by forking job servers (Solid Queue, Resque) and clustered web servers (Puma workers).

Fix: store the runtime behind a leaked raw pointer tagged with the building pid (`AtomicPtr` + `AtomicU32` + a `Mutex` for the build critical section). If `runtime()` is called in a process whose pid differs (we forked), build a **fresh** runtime for this process and swap the pointer. The stale runtime is **leaked, never dropped** — dropping a tokio runtime whose worker threads vanished across fork can hang on the shutdown thread-join. One runtime is leaked per process that uses the SDK (bounded; equivalent to the old set-once behavior in the common no-fork case).

## Changes
- `ext/microsandbox/src/runtime.rs` — fork-safe runtime (`04f00a1`) + rustfmt (`6433d83`).
- `lib/microsandbox/version.rb` + `ext/microsandbox/Cargo.toml` + `Cargo.lock` → `0.5.12` (lock-step; lockfile already synced in `04f00a1`).
- `CHANGELOG.md` — `[0.5.12]` entry.

> Note: the `04f00a1` commit (fork-safe runtime) failed CI `cargo fmt --check` (an over-long `RUNTIME_LOCK.lock().expect(...)` line); `6433d83` fixes the formatting with no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
