### PR TITLE
Release 0.6.0: independent gem semver + runtime_version

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -16,11 +16,17 @@ version with the user before pushing the tag.
    - `lib/microsandbox/version.rb` → `VERSION = "$ARGUMENTS"`
    - `ext/microsandbox/Cargo.toml` `[package]` → `version = "$ARGUMENTS"`
 
+   The gem version is on its OWN semver track, independent of the upstream runtime tag — do NOT
+   pick `$ARGUMENTS` to mirror the runtime version. While 0.x, a breaking API change bumps the
+   minor; a fix/addition bumps the patch. (See the Versioning section of `README.md`.)
+
 3. **Upstream runtime tag — only if this release adopts a new upstream runtime.** This is a
    SEPARATE axis from the gem version. If adopting a new runtime, update the `tag = "vX.Y.Z"` for
    BOTH `microsandbox` and `microsandbox-network` git deps in `ext/microsandbox/Cargo.toml` to the
-   same tag, then `bundle exec rake compile` to refresh `Cargo.lock`. Otherwise leave the deps
-   untouched.
+   same tag, then ALSO update `Microsandbox::RUNTIME_VERSION` in `lib/microsandbox/version.rb` to
+   match (`version_spec.rb` asserts the constant equals the Cargo tag) and add a row to the
+   Versioning table in `README.md`. Then `bundle exec rake compile` to refresh `Cargo.lock`.
+   Otherwise leave all of these untouched.
 
 4. **Update `CHANGELOG.md`** (Keep-a-Changelog) — move Unreleased items under a new
    `## [$ARGUMENTS] - <date>` heading.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,32 @@
 # Changelog
 
 All notable changes to this gem are documented here. The format is based on
-[Keep a Changelog](https://keepachangelog.com/), and the version tracks the
-upstream microsandbox runtime.
+[Keep a Changelog](https://keepachangelog.com/). The gem follows its own
+[semantic version](https://semver.org/), **independent of** the upstream
+microsandbox runtime it embeds; each release notes the upstream runtime tag it
+wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
+
+## [0.6.0] - 2026-06-23
+
+This release puts the gem on its **own semantic version**, decoupled from the
+upstream microsandbox runtime tag it embeds (which stays at `v0.5.8`). The
+`0.5.x` lineage had stopped tracking upstream 1:1 — gem-only revisions and a
+bundled breaking change (the `0.5.9 → 0.5.10` lifecycle split) had already
+diverged the two numbers. `0.6.0` makes the split explicit; the gem version no
+longer mirrors the upstream tag. See the README's **Versioning** section for the
+gem→runtime map and the go-forward policy. No runtime change and no breaking API
+change in this release.
+
+### Added
+
+- **`Microsandbox.runtime_version`** and the `Microsandbox::RUNTIME_VERSION`
+  constant — report the upstream microsandbox runtime tag this gem build embeds
+  (e.g. `"v0.5.8"`). The gem now versions itself independently of that tag, so
+  this is the supported way to learn which runtime is wrapped.
+  `spec/unit/version_spec.rb` pins the constant to the Cargo git tag so it can't
+  drift.
 
 ## [0.5.12] - 2026-06-23
 
@@ -269,6 +291,7 @@ microsandbox runtime, aligned with the official Python/Node/Go SDKs.
   core crate has Apple-native deps). Until precompiled gems are published,
   installing from source requires a Rust toolchain (stable >= 1.91).
 
-[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.8...HEAD
+[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.12...v0.6.0
 [0.5.8]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.7

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,17 @@ Deeper architecture is in `DESIGN.md`; usage in `README.md`.
 
 1. **Gem version** — `Microsandbox::VERSION` in `lib/microsandbox/version.rb` MUST equal `version`
    in `ext/microsandbox/Cargo.toml` `[package]`. `spec/unit/version_spec.rb` asserts equality via
-   `Native.version`. Bump both together, or specs fail.
+   `Native.version`. Bump both together, or specs fail. The gem follows its OWN semver and is NOT
+   numbered to mirror the upstream tag — the `0.5.x` lineage stopped mapping 1:1 once gem-only
+   revisions (and a bundled breaking change) diverged the two numbers. While 0.x, a breaking API
+   change bumps the minor and a fix bumps the patch. See the Versioning section of `README.md` for
+   the gem→runtime map.
 2. **Upstream runtime tag** — the `microsandbox` and `microsandbox-network` git deps in
-   `ext/microsandbox/Cargo.toml` are pinned to a `tag` (currently `v0.5.7`). This tracks the
-   upstream runtime, NOT the gem version. Bump it only when adopting a new upstream release, and
-   keep both deps on the same tag.
+   `ext/microsandbox/Cargo.toml` are pinned to a `tag` (currently `v0.5.8`). This tracks the
+   upstream runtime, NOT the gem version. Bump it only when adopting a new upstream release, keep
+   both deps on the same tag, AND update `Microsandbox::RUNTIME_VERSION` in
+   `lib/microsandbox/version.rb` to match — `spec/unit/version_spec.rb` asserts the constant equals
+   the Cargo tag, so it can't silently go stale.
 
 ## Conventions
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.5.12"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "futures",

--- a/README.md
+++ b/README.md
@@ -374,6 +374,43 @@ Resolution order when no backend is set programmatically: `MSB_BACKEND`
 operations (create/start/stop/remove/get/list, one-shot exec, follow log
 streaming); unsupported operations raise `Microsandbox::UnsupportedError`.
 
+## Versioning
+
+The gem follows its **own** [semantic version](https://semver.org/), **independent
+of** the upstream `microsandbox` runtime it embeds. Early releases (`0.5.7`–`0.5.9`)
+happened to share the upstream tag, but gem-only revisions and a bundled breaking
+change diverged the two numbers — the gem version is **not** a reliable indicator
+of the embedded runtime version. To learn which runtime a build wraps, ask it:
+
+```ruby
+Microsandbox::VERSION          # => "0.6.0"  (the gem's own version)
+Microsandbox.runtime_version   # => "v0.5.8"  (the embedded upstream runtime tag)
+```
+
+| Gem version | Upstream runtime | Notes |
+|-------------|------------------|-------|
+| `0.5.7`  | `v0.5.7` | initial release |
+| `0.5.8`  | `v0.5.7` | gem-only revision |
+| `0.5.9`  | `v0.5.7` | gem-only revision |
+| `0.5.10` | `v0.5.8` | adopts upstream `v0.5.8`; **breaking** lifecycle split |
+| `0.5.11` | `v0.5.8` | gem-only revision |
+| `0.5.12` | `v0.5.8` | gem-only revision |
+| `0.6.0`  | `v0.5.8` | gem version decoupled from the upstream tag; adds `runtime_version` |
+
+**Going forward** — the gem version moves on its own semver track and no longer
+mirrors the upstream tag:
+
+- A **gem-only** change (new bindings, fixes, refactors over the *same* runtime)
+  bumps the gem version by itself.
+- **Adopting a new upstream runtime** bumps the gem version too and updates the
+  pinned git tag, `Microsandbox::RUNTIME_VERSION`, and the table above together.
+- While the gem is `0.x`, a breaking API change bumps the **minor** (`0.5 → 0.6`),
+  not the patch — the `0.5.9 → 0.5.10` lifecycle split predates this policy and is
+  the reason for it.
+
+Every release records its embedded runtime in `CHANGELOG.md`, and
+`Microsandbox.runtime_version` reports it at runtime.
+
 ## Development
 
 ```bash
@@ -406,9 +443,13 @@ or credential setup is needed.
 
 **Each release:**
 
-1. Bump `Microsandbox::VERSION` (and the `tag = "vX.Y.Z"` on the core-crate
-   dependency in `ext/microsandbox/Cargo.toml`) to match the upstream runtime,
-   update `CHANGELOG.md`.
+1. Bump the gem's **own** version — `Microsandbox::VERSION` and the matching
+   `[package] version` in `ext/microsandbox/Cargo.toml` (they must stay equal) —
+   on its independent semver track (see [Versioning](#versioning)); **don't** pick
+   the number to mirror the upstream tag. If the release also adopts a new upstream
+   runtime, bump the `tag = "vX.Y.Z"` on **both** the `microsandbox` and
+   `microsandbox-network` git deps, update `Microsandbox::RUNTIME_VERSION` to match,
+   and add a row to the Versioning table. Update `CHANGELOG.md`.
 2. Push a `vX.Y.Z` tag. CI builds the **source gem** and pushes it to RubyGems
    via `rubygems/configure-rubygems-credentials` (OIDC, `id-token: write`) — no
    `RUBYGEMS_API_KEY` secret required.

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.5.12"
+version = "0.6.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -45,6 +45,15 @@ module Microsandbox
       VERSION
     end
 
+    # The upstream microsandbox runtime release this gem build embeds (the git
+    # `tag` pinned in ext/microsandbox/Cargo.toml). The gem's own {version} is
+    # versioned independently of this, so consult this to learn which runtime is
+    # wrapped. See the Versioning section of the README for the full map.
+    # @return [String] e.g. "v0.5.8"
+    def runtime_version
+      RUNTIME_VERSION
+    end
+
     # Download and install the `msb` runtime + `libkrunfw` into
     # `~/.microsandbox` (idempotent).
     #

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -1,9 +1,19 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  # Gem version. Tracks the upstream microsandbox runtime (currently `v0.5.8`,
-  # the pinned core-crate tag); the patch segment advances for gem-only revisions
-  # that add bindings atop the same core. Must equal the native ext's Cargo crate
-  # version (`Native.version`), enforced by spec/unit/version_spec.rb.
-  VERSION = "0.5.12"
+  # Gem version. Versioned independently of the upstream microsandbox runtime it
+  # embeds: the gem follows its own semver (while 0.x, breaking changes bump the
+  # minor and fixes bump the patch), so the number does NOT track the upstream tag
+  # one-to-one. Consult {RUNTIME_VERSION} for the wrapped runtime, and the
+  # Versioning section of the README for the full gem-to-runtime map. Must equal
+  # the native ext's Cargo crate version (`Native.version`), enforced by
+  # spec/unit/version_spec.rb.
+  VERSION = "0.6.0"
+
+  # The upstream microsandbox runtime release this gem build embeds — the `tag`
+  # pinned on the `microsandbox`/`microsandbox-network` git deps in
+  # ext/microsandbox/Cargo.toml. Exposed at runtime as
+  # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
+  # sync with the Cargo tag so it can't silently drift out of date.
+  RUNTIME_VERSION = "v0.5.8"
 end

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -2,8 +2,10 @@
 
 module Microsandbox
   VERSION: String
+  RUNTIME_VERSION: String
 
   def self.version: () -> String
+  def self.runtime_version: () -> String
   def self.install: () -> nil
   def self.installed?: () -> bool
   def self.ensure_runtime!: () -> nil

--- a/spec/unit/version_spec.rb
+++ b/spec/unit/version_spec.rb
@@ -16,4 +16,20 @@ RSpec.describe Microsandbox do
       expect(Microsandbox::Native.version).to eq(Microsandbox::VERSION)
     end
   end
+
+  describe "RUNTIME_VERSION" do
+    it "is exposed via .runtime_version" do
+      expect(Microsandbox.runtime_version).to eq(Microsandbox::RUNTIME_VERSION)
+    end
+
+    # Guards against the constant silently drifting from the pinned git tag — the
+    # exact failure mode (a stale "currently vX.Y.Z" note) that motivated adding
+    # the constant. Also asserts both git deps share one tag.
+    it "stays in sync with the upstream tag pinned in ext/microsandbox/Cargo.toml" do
+      cargo = File.read(File.expand_path("../../ext/microsandbox/Cargo.toml", __dir__))
+      tags = cargo.scan(/^microsandbox(?:-network)?\s*=\s*\{[^}]*\btag\s*=\s*"([^"]+)"/).flatten
+      expect(tags).not_to be_empty
+      expect(tags.uniq).to eq([Microsandbox::RUNTIME_VERSION])
+    end
+  end
 end


### PR DESCRIPTION
## What

Cuts **0.6.0** and formally puts the gem on its **own semantic version**, decoupled from the upstream `microsandbox` runtime tag it embeds.

### Why
The gem and upstream version numbers had silently diverged: gem `0.5.8`/`0.5.9` were gem-only revisions over upstream `v0.5.7`, and the `0.5.9 → 0.5.10` "patch" actually carried a **breaking** lifecycle split. A shared `0.5.x` number implied a lock-step that no longer held and collided with upstream's own patch numbers. `0.6.0` makes the split explicit.

### Changes
- **`Microsandbox.runtime_version`** + `Microsandbox::RUNTIME_VERSION` — report the embedded upstream runtime tag (`"v0.5.8"`) at runtime. `spec/unit/version_spec.rb` pins the constant to the `Cargo.toml` git tag so it can't go stale (the root cause of this whole drift).
- **README** — new **Versioning** section: the gem→runtime map + go-forward policy; the Releasing step rewritten.
- **CHANGELOG / CLAUDE.md / release SOP** — corrected the stale "version tracks upstream" / "currently v0.5.7" claims; documented the two independent version axes.
- Version bump `0.5.12 → 0.6.0` (`version.rb`, `Cargo.toml`, `Cargo.lock`); upstream runtime tag unchanged (`v0.5.8`).

### Verification (local)
`cargo fmt --check`, `clippy -D warnings`, `standardrb`, and `rspec spec/unit` (243 examples, 0 failures) all green.

> No runtime change and no breaking API change in this release.

After CI is green and this merges, tag `v0.6.0` to trigger the RubyGems publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLGnKZiTG96KUpGeaYYBDE
