### PR TITLE
feat: close upstream SDK parity gaps (v0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,29 +8,12 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-06-24
+## [0.7.0] - 2026-06-23
 
 A large parity release closing the binding gaps an audit against the upstream
-Python/Node SDKs surfaced, and adopting upstream runtime **`v0.5.9`** (up from
-`v0.5.8`). Two genuine gem-level bug fixes; the rest is newly-exposed surface, a
-few behavior corrections (see **Changed**), and the runtime bump (see
-**Runtime**).
-
-### Runtime
-
-- **Adopted upstream `v0.5.9`** — the `microsandbox`/`microsandbox-network` git
-  deps and `Microsandbox::RUNTIME_VERSION` now pin `v0.5.9`. No public Ruby API
-  change: that tag still declares crate `0.5.8` (upstream's own version bump
-  landed after the tag), so `Microsandbox::VERSION`/`Native.version` are
-  unaffected. The bump carries two upstream improvements:
-  - **Heartbeat no longer reclaims busy sandboxes** (upstream #1011). The host
-    watchdog is now idle-detection only — a healthy sandbox with an active (or
-    briefly starved) `exec` session is never killed for a stale heartbeat, the
-    way it could be before.
-  - **Launch config moved off the process argv** (upstream #1006). Bulky and
-    secret-bearing config (the network blob, env) is handed to the sandbox over
-    an inherited, unlinked-tempfile fd instead of `--`-flags, so it no longer
-    leaks into `ps` / `/proc/<pid>/cmdline`.
+Python/Node SDKs (at the wrapped `v0.5.8` runtime) surfaced. The runtime tag is
+unchanged. Two genuine bug fixes; the rest is newly-exposed surface plus a few
+behavior corrections (see **Changed**).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,85 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-23
+
+A large parity release closing the binding gaps an audit against the upstream
+Python/Node SDKs (at the wrapped `v0.5.8` runtime) surfaced. The runtime tag is
+unchanged. Two genuine bug fixes; the rest is newly-exposed surface plus a few
+behavior corrections (see **Changed**).
+
+### Fixed
+
+- **Lossy UTF-8 decoding.** `LogEntry#text`, `ExecOutput#stdout`/`#stderr`,
+  `ExecEvent#text`, `SshOutput#stdout`/`#stderr`, and `SftpClient#read_text` now
+  scrub invalid byte sequences (replacing them with U+FFFD) so they always
+  return a *valid* UTF-8 String — matching the Python/Node SDKs. Previously they
+  re-tagged raw bytes as UTF-8 without transcoding, so captured output
+  containing invalid UTF-8 produced strings that raised downstream (regex,
+  concatenation, `JSON.generate`). Raw bytes remain available via `#data` /
+  `#stdout_bytes` / `#stderr_bytes`.
+- **`runtime_path=` spec** no longer pollutes the process-wide set-once
+  `msb`-path `OnceLock` (it now stubs the native setter), removing an
+  order-dependent failure in combined unit+integration runs.
+
+### Added
+
+- **Streaming image-pull progress** — `Sandbox.create_with_progress` returns a
+  `PullSession` (an `Enumerable` of progress-event Hashes) with `#sandbox` for
+  the booted sandbox.
+- **Host-side volume filesystem** — `Volume.fs(name)` / `VolumeInfo#fs` return a
+  `VolumeFs` (read/read_text/write/list/mkdir/remove_file/remove_dir/exists?/
+  copy/rename/stat) that reads and writes a named volume without a running
+  sandbox.
+- **Streaming guest filesystem** — `FS#read_stream` / `FS#write_stream`
+  (`FsReadStream`/`FsWriteSink`) for files too large to buffer in memory.
+- **Full secrets surface** — `secrets:` entries accept `hosts:` / `host_patterns:`
+  (wildcards) allow-lists, `placeholder:`, `require_tls:`, injection toggles
+  (`inject_headers:`/`inject_basic_auth:`/`inject_query:`/`inject_body:`), and
+  per-secret `on_violation:`; plus a sandbox-level `on_secret_violation:`.
+- **Network configuration** — `Sandbox.create` now accepts `dns:` (nameservers/
+  rebind_protection/query_timeout_ms), `tls:` (interception tuning incl. bypass
+  patterns, intercepted ports, block_quic, and CA cert/key paths), `ipv4_pool:`/
+  `ipv6_pool:`, `max_connections:`, and `trust_host_cas:`.
+- **Create options** — `init:`/`init_with` (hand guest PID 1 to an init system),
+  `ephemeral:` (auto-remove state on terminal), and disk-image `fstype:`.
+- **Full mount options** — `volumes:` now supports `{ tmpfs: }`, `{ disk:,
+  format:, fstype: }`, and per-mount `stat_virtualization:`/`host_permissions:`
+  alongside the existing bind/named + ro/noexec/nosuid/nodev flags.
+- **Snapshots** — `Snapshot.open`/`list_dir`/`reindex`, `SnapshotInfo#open`/
+  `#remove`, and `SandboxHandle#snapshot`/`#snapshot_to`. `SnapshotInfo` now
+  carries the full manifest (`image_manifest_digest`, `fstype`,
+  `source_sandbox`, `labels`) on the artifact-opening paths.
+- **`SandboxHandle#config` / `#config_json`** — read the stored sandbox config.
+- **Metrics** — `upper_used_bytes`, `upper_free_bytes`,
+  `upper_host_allocated_bytes` (OCI writable-upper-layer accounting).
+- **`ImageDetail#config["labels"]`** — OCI config labels.
+- **`Microsandbox.setup`** — customizable runtime install (`base_dir:`,
+  `version:`, `force:`, `skip_verify:`); `force:` repairs a corrupt install.
+
+### Changed
+
+- **`exec`/`shell` stdin** is now a closed set: `nil`/`:null` = no stdin,
+  `:pipe` = streaming pipe (streaming variants only), a String = bytes. An
+  unrecognized Symbol now raises `ArgumentError` instead of being fed as its
+  characters (so a mistaken `stdin: :null` no longer sends the literal `"null"`).
+- **Write methods reject non-Strings.** `FS#write`, `SftpClient#write`,
+  `ExecStdin#write`, `VolumeFs#write`, and `FsWriteSink#write` now raise
+  `TypeError` for non-String data instead of silently writing its `to_s` form.
+- **Agent connect timeout.** `AgentClient.connect_sandbox`/`connect_path`
+  `timeout:` now treats `0` as an immediate deadline and raises on a
+  negative/non-finite value, instead of silently falling back to the default.
+- **Secrets shorthand** still accepts `{ env:, value:, host: }`; the validation
+  message changed and a host allow-list is now required.
+
+### Docs
+
+- README/DESIGN implemented-surface corrected to match the binding (and to list
+  the few secondary knobs still not exposed); assorted YARD fixes
+  (`runtime_path=` set-once note, `VolumeInfo#kind` `:dir`, `create`'s
+  `volumes:`/`from_snapshot:` params, `log_stream` `'all'` source); CHANGELOG
+  compare links added for 0.5.9–0.5.12.
+
 ## [0.6.0] - 2026-06-23
 
 This release puts the gem on its **own semantic version**, decoupled from the
@@ -291,7 +370,12 @@ microsandbox runtime, aligned with the official Python/Node/Go SDKs.
   core crate has Apple-native deps). Until precompiled gems are published,
   installing from source requires a Rust toolchain (stable >= 1.91).
 
-[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.12...v0.6.0
+[0.5.12]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.11...v0.5.12
+[0.5.11]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.10...v0.5.11
+[0.5.10]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.9...v0.5.10
+[0.5.9]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.8...v0.5.9
 [0.5.8]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.7...v0.5.8
 [0.5.7]: https://github.com/superradcompany/microsandbox/releases/tag/v0.5.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,9 @@ behavior corrections (see **Changed**).
   per-secret `on_violation:`; plus a sandbox-level `on_secret_violation:`. The
   block-variant actions accept both the underscore form (`block_and_log`) and the
   upstream kebab-case wire spelling (`block-and-log`) used by the CLI / Go SDK /
-  config files, so a policy copied from another SDK ports over unchanged.
+  config files; the bare `"passthrough"` string (passthrough-all-hosts, as in the
+  Python/Node SDKs) is also accepted, so a policy copied from another SDK ports
+  over unchanged.
 - **Network configuration** — `Sandbox.create` now accepts `dns:` (nameservers/
   rebind_protection/query_timeout_ms), `tls:` (interception tuning incl. bypass
   patterns, intercepted ports, block_quic, and CA cert/key paths), `ipv4_pool:`/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,16 +43,25 @@ behavior corrections (see **Changed**).
 - **Full secrets surface** — `secrets:` entries accept `hosts:` / `host_patterns:`
   (wildcards) allow-lists, `placeholder:`, `require_tls:`, injection toggles
   (`inject_headers:`/`inject_basic_auth:`/`inject_query:`/`inject_body:`), and
-  per-secret `on_violation:`; plus a sandbox-level `on_secret_violation:`.
+  per-secret `on_violation:`; plus a sandbox-level `on_secret_violation:`. The
+  block-variant actions accept both the underscore form (`block_and_log`) and the
+  upstream kebab-case wire spelling (`block-and-log`) used by the CLI / Go SDK /
+  config files, so a policy copied from another SDK ports over unchanged.
 - **Network configuration** — `Sandbox.create` now accepts `dns:` (nameservers/
   rebind_protection/query_timeout_ms), `tls:` (interception tuning incl. bypass
   patterns, intercepted ports, block_quic, and CA cert/key paths), `ipv4_pool:`/
   `ipv6_pool:`, `max_connections:`, and `trust_host_cas:`.
 - **Create options** — `init:`/`init_with` (hand guest PID 1 to an init system),
   `ephemeral:` (auto-remove state on terminal), and disk-image `fstype:`.
+  `fstype:` is rejected up front unless `image:` is a disk-image path (a local
+  path ending in `.raw`/`.qcow2`/`.vmdk`); pairing it with an OCI reference no
+  longer routes the ref through the disk-image builder and fails at boot.
 - **Full mount options** — `volumes:` now supports `{ tmpfs: }`, `{ disk:,
   format:, fstype: }`, and per-mount `stat_virtualization:`/`host_permissions:`
-  alongside the existing bind/named + ro/noexec/nosuid/nodev flags.
+  alongside the existing bind/named + ro/noexec/nosuid/nodev flags. The pre-0.7.0
+  `options: %w[ro noexec]` array form is still honored (translated onto the
+  boolean flags); an unrecognized token now raises rather than being silently
+  dropped, so a requested read-only/noexec mount can't quietly become writable.
 - **Snapshots** — `Snapshot.open`/`list_dir`/`reindex`, `SnapshotInfo#open`/
   `#remove`, and `SandboxHandle#snapshot`/`#snapshot_to`. `SnapshotInfo` now
   carries the full manifest (`image_manifest_digest`, `fstype`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,29 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
-## [0.7.0] - 2026-06-23
+## [0.7.0] - 2026-06-24
 
 A large parity release closing the binding gaps an audit against the upstream
-Python/Node SDKs (at the wrapped `v0.5.8` runtime) surfaced. The runtime tag is
-unchanged. Two genuine bug fixes; the rest is newly-exposed surface plus a few
-behavior corrections (see **Changed**).
+Python/Node SDKs surfaced, and adopting upstream runtime **`v0.5.9`** (up from
+`v0.5.8`). Two genuine gem-level bug fixes; the rest is newly-exposed surface, a
+few behavior corrections (see **Changed**), and the runtime bump (see
+**Runtime**).
+
+### Runtime
+
+- **Adopted upstream `v0.5.9`** — the `microsandbox`/`microsandbox-network` git
+  deps and `Microsandbox::RUNTIME_VERSION` now pin `v0.5.9`. No public Ruby API
+  change: that tag still declares crate `0.5.8` (upstream's own version bump
+  landed after the tag), so `Microsandbox::VERSION`/`Native.version` are
+  unaffected. The bump carries two upstream improvements:
+  - **Heartbeat no longer reclaims busy sandboxes** (upstream #1011). The host
+    watchdog is now idle-detection only — a healthy sandbox with an active (or
+    briefly starved) `exec` session is never killed for a stale heartbeat, the
+    way it could be before.
+  - **Launch config moved off the process argv** (upstream #1006). Bulky and
+    secret-bearing config (the network blob, env) is handed to the sandbox over
+    an inherited, unlinked-tempfile fd instead of `--`-flags, so it no longer
+    leaks into `ps` / `/proc/<pid>/cmdline`.
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "microsandbox"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-agent-client"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-db"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-filesystem"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-image"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3121,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-metrics"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "chrono",
  "libc",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-migration"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-network"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "base64",
  "bytes",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-protocol"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-runtime"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "bytes",
  "chrono",
@@ -3226,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-types"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "chrono",
  "serde",
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-utils"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
 dependencies = [
  "dirs",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3004,7 +3004,7 @@ dependencies = [
 [[package]]
 name = "microsandbox"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3057,7 +3057,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-agent-client"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3070,7 +3070,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-db"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3082,7 +3082,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-filesystem"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3095,7 +3095,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-image"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3121,7 +3121,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-metrics"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "chrono",
  "libc",
@@ -3132,7 +3132,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-migration"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3141,7 +3141,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-network"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "base64",
  "bytes",
@@ -3181,7 +3181,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-protocol"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3196,7 +3196,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-runtime"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "bytes",
  "chrono",
@@ -3226,7 +3226,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-types"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "chrono",
  "serde",
@@ -3238,7 +3238,7 @@ dependencies = [
 [[package]]
 name = "microsandbox-utils"
 version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.9#a1553bdfa61f45ff8abe14821686185e621e44bd"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
 dependencies = [
  "dirs",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "futures",

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -183,9 +183,19 @@ The binding is verified at four levels:
    microVM, confirming the gem manifest and source-install path are complete.
 
 **Roadmap:** the v1 roadmap (custom per-rule network policies, file patches,
-interactive `attach`/`attach_shell`, SSH, and the raw agent client) is now
-implemented — see the list above. What remains is upstream-gated rather than a
-binding gap: surfacing newer core features as the pinned core-crate tag advances
-(e.g. additional network knobs like DNS/TLS-proxy tuning and per-mount stat
-virtualization), which slot in module-by-module exactly as the existing bindings
-do.
+interactive `attach`/`attach_shell`, SSH, and the raw agent client) is
+implemented, and so is the bulk of the v0.5.8 configuration surface that a
+later parity pass added: streaming image-pull progress, host-side `VolumeFs`,
+streaming guest fs (`read_stream`/`write_stream`), the full secrets surface,
+network configuration (DNS, TLS-interception tuning, IPv4/IPv6 pools,
+`max_connections`, `trust_host_cas`), `init`/`ephemeral`/disk-image `fstype`
+create options, full mount options (tmpfs/disk + stat-virtualization/
+host-permissions), and snapshot inspection (`open`/`list_dir`/`reindex`).
+
+A few **secondary** upstream knobs remain unexposed (a genuine binding gap, not
+upstream-gated — they exist at the pinned `v0.5.8`): per-published-port host
+**bind address** (ports always bind loopback), network **interface overrides**,
+and inline **named-volume create-mode** (pre-create with `Volume.create`, then
+mount with `{ named: }`). These slot in module-by-module exactly as the existing
+bindings do. Beyond those, surfacing genuinely newer core features is gated on
+advancing the pinned core-crate tag.

--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ change diverged the two numbers — the gem version is **not** a reliable indica
 of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
-Microsandbox::VERSION          # => "0.7.0"  (the gem's own version)
-Microsandbox.runtime_version   # => "v0.5.9"  (the embedded upstream runtime tag)
+Microsandbox::VERSION          # => "0.6.0"  (the gem's own version)
+Microsandbox.runtime_version   # => "v0.5.8"  (the embedded upstream runtime tag)
 ```
 
 | Gem version | Upstream runtime | Notes |
@@ -396,7 +396,6 @@ Microsandbox.runtime_version   # => "v0.5.9"  (the embedded upstream runtime tag
 | `0.5.11` | `v0.5.8` | gem-only revision |
 | `0.5.12` | `v0.5.8` | gem-only revision |
 | `0.6.0`  | `v0.5.8` | gem version decoupled from the upstream tag; adds `runtime_version` |
-| `0.7.0`  | `v0.5.9` | SDK parity release; adopts upstream `v0.5.9` (idle-only heartbeat, config-fd hardening) |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ change diverged the two numbers — the gem version is **not** a reliable indica
 of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
-Microsandbox::VERSION          # => "0.6.0"  (the gem's own version)
-Microsandbox.runtime_version   # => "v0.5.8"  (the embedded upstream runtime tag)
+Microsandbox::VERSION          # => "0.7.0"  (the gem's own version)
+Microsandbox.runtime_version   # => "v0.5.9"  (the embedded upstream runtime tag)
 ```
 
 | Gem version | Upstream runtime | Notes |
@@ -396,6 +396,7 @@ Microsandbox.runtime_version   # => "v0.5.8"  (the embedded upstream runtime tag
 | `0.5.11` | `v0.5.8` | gem-only revision |
 | `0.5.12` | `v0.5.8` | gem-only revision |
 | `0.6.0`  | `v0.5.8` | gem version decoupled from the upstream tag; adds `runtime_version` |
+| `0.7.0`  | `v0.5.9` | SDK parity release; adopts upstream `v0.5.9` (idle-only heartbeat, config-fd hardening) |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ variable → an SDK-set override → the config file → `~/.microsandbox/bin/ms
 Microsandbox.installed?            # => true/false
 Microsandbox.install               # download + install the runtime (idempotent)
 Microsandbox.runtime_path          # => "/Users/you/.microsandbox/bin/msb"
-Microsandbox.runtime_path = "/opt/microsandbox/bin/msb"  # override
+Microsandbox.runtime_path = "/opt/microsandbox/bin/msb"  # override (set-once)
 Microsandbox.libkrunfw_path = "/opt/microsandbox/lib/libkrunfw.dylib"  # override (set-once)
 ```
 
@@ -470,25 +470,38 @@ or credential setup is needed.
 > Until promoted, users install the source gem (which compiles via `rb_sys`).
 
 See [DESIGN.md](DESIGN.md) for the architecture and the implemented-surface
-section. The binding now covers the full official-SDK surface: sandbox
+section. The binding covers the official-SDK surface: sandbox
 lifecycle (the live `Sandbox` `stop`/`stop_and_wait`/`kill`/`drain`/`wait`/
 `status`/`detach`/`owns_lifecycle?`, plus the `SandboxHandle` controls
 `stop_with_timeout`/`request_stop`/`request_kill`/`request_drain`/
-`wait_until_stopped` from `Sandbox.get`, and label-filtered `list_with`),
+`wait_until_stopped`/`config`/`config_json`/`snapshot`/`snapshot_to` from
+`Sandbox.get`, and label-filtered `list_with`),
 backend routing (`set_default_backend`/`with_backend`/`default_backend_kind`),
 `exec`/`shell` (collected and streaming), interactive `attach`/
-`attach_shell`, the full guest filesystem, metrics (per-sandbox,
-`Microsandbox.all_sandbox_metrics`, and streaming `metrics_stream`/`log_stream`),
-logs, OCI image-cache management, named volumes, snapshots (create/list/verify/
-export/import + boot-from-snapshot), **rootfs patches** (`Microsandbox::Patch`),
-**custom per-rule network policies** (`Microsandbox::NetworkPolicy`/`Rule`/
-`Destination`, alongside the presets), **SSH** (`Sandbox#ssh` →
-`SshClient`/`SftpClient`/`SshServer`), and the **raw agent client**
-(`Microsandbox::AgentClient`). Create options span resources, network policy,
-`log_level`/`security`/`rlimits`/`pull_policy`/`secrets`/`patches` and more;
-`exec`/`shell` take per-call `rlimits`, and `create` accepts
+`attach_shell`, the full guest filesystem (incl. streaming `read_stream`/
+`write_stream`), metrics (per-sandbox, `Microsandbox.all_sandbox_metrics`, and
+streaming `metrics_stream`/`log_stream`), logs, OCI image-cache management,
+named volumes (incl. host-side `Volume.fs`/`VolumeInfo#fs` read/write),
+snapshots (create/open/list/list_dir/reindex/verify/export/import +
+boot-from-snapshot), streaming image-pull progress
+(`Sandbox.create_with_progress` → `PullSession`), **rootfs patches**
+(`Microsandbox::Patch`), **network configuration** (presets, custom per-rule
+`Microsandbox::NetworkPolicy`/`Rule`/`Destination`, plus DNS, TLS interception,
+IPv4/IPv6 pools, `max_connections`, `trust_host_cas`), **secrets** (multi-host /
+wildcard allow-lists, injection toggles, per-secret + sandbox-level violation
+policy), **SSH** (`Sandbox#ssh` → `SshClient`/`SftpClient`/`SshServer`), and the
+**raw agent client** (`Microsandbox::AgentClient`). Create options span
+resources, `init`/`ephemeral`, disk-image `fstype`, network policy + config,
+`log_level`/`security`/`rlimits`/`pull_policy`/`secrets`/`patches`/`volumes`
+(bind/named/tmpfs/disk with mount policies) and more; `exec`/`shell` take
+per-call `rlimits`, and `create` accepts
 `registry_auth`/`registry_insecure`/`registry_ca_certs` for private and
-authenticated registries.
+authenticated registries, plus customizable provisioning via `Microsandbox.setup`.
+
+A few secondary upstream knobs are not yet exposed: per-published-port host bind
+address (ports always bind loopback), network interface overrides, and inline
+named-volume create-mode (pre-create the volume with `Volume.create`, then mount
+it with `{ named: "…" }`).
 
 ## Contributing
 

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.6.0"
+version = "0.7.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,7 +6,7 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.5.8).
+# The core-crate dependency below stays pinned at its own tag (v0.5.9).
 version = "0.7.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.9", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.9" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,7 +6,7 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.5.9).
+# The core-crate dependency below stays pinned at its own tag (v0.5.8).
 version = "0.7.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.9", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.9" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/ext/microsandbox/src/agent.rs
+++ b/ext/microsandbox/src/agent.rs
@@ -131,10 +131,14 @@ impl AgentClient {
 ///   - `0` → an explicit zero deadline (fail fast), *not* "use the default"
 ///   - negative or non-finite (NaN/Inf) → a caller error (rather than being
 ///     silently swallowed into the default)
+///   - finite but out of `Duration` range (e.g. `Float::MAX`) → a caller error
+///     via `try_from_secs_f64`, rather than the panic `from_secs_f64` would raise
 fn dur(timeout: Option<f64>) -> Result<Option<Duration>, Error> {
     match timeout {
         None => Ok(None),
-        Some(t) if t.is_finite() && t >= 0.0 => Ok(Some(Duration::from_secs_f64(t))),
+        Some(t) if t.is_finite() && t >= 0.0 => Duration::try_from_secs_f64(t)
+            .map(Some)
+            .map_err(|e| error::base_error(format!("timeout {t} seconds is out of range: {e}"))),
         Some(t) => Err(error::base_error(format!(
             "timeout must be a non-negative, finite number of seconds (got {t})"
         ))),

--- a/ext/microsandbox/src/agent.rs
+++ b/ext/microsandbox/src/agent.rs
@@ -40,7 +40,7 @@ impl AgentClient {
 
     /// Connect to a running sandbox by name. `timeout` is optional seconds.
     fn connect_sandbox(name: String, timeout: Option<f64>) -> Result<AgentClient, Error> {
-        let bridge = match dur(timeout) {
+        let bridge = match dur(timeout)? {
             Some(t) => block_on(AgentBridge::connect_sandbox_with_timeout(&name, t)),
             None => block_on(AgentBridge::connect_sandbox(&name)),
         }
@@ -50,7 +50,7 @@ impl AgentClient {
 
     /// Connect to an agentd relay socket by path. `timeout` is optional seconds.
     fn connect_path(path: String, timeout: Option<f64>) -> Result<AgentClient, Error> {
-        let bridge = match dur(timeout) {
+        let bridge = match dur(timeout)? {
             Some(t) => block_on(AgentBridge::connect_path_with_timeout(&path, t)),
             None => block_on(AgentBridge::connect_path(&path)),
         }
@@ -125,12 +125,19 @@ impl AgentClient {
     }
 }
 
-/// Convert seconds into a `Duration`, treating a non-positive/absent value as
-/// "use the default handshake timeout".
-fn dur(timeout: Option<f64>) -> Option<Duration> {
+/// Convert an optional `timeout` (seconds) into an optional `Duration`,
+/// mirroring the Python SDK's `timeout_duration`:
+///   - absent (`nil`) → `None` → the core's default handshake timeout
+///   - `0` → an explicit zero deadline (fail fast), *not* "use the default"
+///   - negative or non-finite (NaN/Inf) → a caller error (rather than being
+///     silently swallowed into the default)
+fn dur(timeout: Option<f64>) -> Result<Option<Duration>, Error> {
     match timeout {
-        Some(t) if t.is_finite() && t > 0.0 => Some(Duration::from_secs_f64(t)),
-        _ => None,
+        None => Ok(None),
+        Some(t) if t.is_finite() && t >= 0.0 => Ok(Some(Duration::from_secs_f64(t))),
+        Some(t) => Err(error::base_error(format!(
+            "timeout must be a non-negative, finite number of seconds (got {t})"
+        ))),
     }
 }
 

--- a/ext/microsandbox/src/conv.rs
+++ b/ext/microsandbox/src/conv.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use magnus::{value::ReprValue, Error, RArray, RHash, TryConvert, Value};
+use magnus::{value::ReprValue, Error, IntoValue, RArray, RHash, TryConvert, Value};
 
 /// Fetch a non-nil value for `key`, if present.
 fn get(hash: RHash, key: &str) -> Option<Value> {
@@ -88,5 +88,41 @@ pub fn opt_port_map(hash: RHash, key: &str) -> Result<Vec<(u16, u16)>, Error> {
             Ok(map.into_iter().collect())
         }
         None => Ok(Vec::new()),
+    }
+}
+
+/// Recursively convert a `serde_json::Value` into a Ruby value. Used for
+/// pass-through JSON whose shape is not fixed — e.g. an image config's OCI
+/// `labels` object, which the Ruby layer hands back verbatim (mirroring the
+/// Python SDK's `dict | None`).
+pub fn json_to_ruby(value: &serde_json::Value) -> Value {
+    let ruby = crate::runtime::ruby();
+    match value {
+        serde_json::Value::Null => ruby.qnil().as_value(),
+        serde_json::Value::Bool(b) => b.into_value_with(&ruby),
+        serde_json::Value::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                i.into_value_with(&ruby)
+            } else if let Some(u) = n.as_u64() {
+                u.into_value_with(&ruby)
+            } else {
+                n.as_f64().unwrap_or(0.0).into_value_with(&ruby)
+            }
+        }
+        serde_json::Value::String(s) => s.as_str().into_value_with(&ruby),
+        serde_json::Value::Array(items) => {
+            let arr = ruby.ary_new();
+            for item in items {
+                let _ = arr.push(json_to_ruby(item));
+            }
+            arr.into_value_with(&ruby)
+        }
+        serde_json::Value::Object(map) => {
+            let hash = ruby.hash_new();
+            for (k, v) in map {
+                let _ = hash.aset(k.as_str(), json_to_ruby(v));
+            }
+            hash.into_value_with(&ruby)
+        }
     }
 }

--- a/ext/microsandbox/src/fs_stream.rs
+++ b/ext/microsandbox/src/fs_stream.rs
@@ -1,0 +1,92 @@
+//! Streaming guest-filesystem I/O: `Microsandbox::Native::FsReadStream` and
+//! `Microsandbox::Native::FsWriteSink`.
+//!
+//! Wraps the core `SandboxFs::read_stream`/`write_stream` handles so large files
+//! can be moved without buffering the whole thing in memory. The core
+//! `FsReadStream::recv` needs `&mut self` and `FsWriteSink::close` consumes
+//! `self`, so each is held behind a `tokio::Mutex` (the sink as an `Option`, so
+//! `close` can take it and be idempotent). Each call drives the future to
+//! completion with the GVL released; the Ruby layer wraps these as an
+//! `Enumerable` reader and a writer with a block form.
+
+use std::sync::Arc;
+
+use magnus::{method, prelude::*, Error, RModule, RString, Ruby};
+use microsandbox::sandbox::{FsReadStream, FsWriteSink};
+use tokio::sync::Mutex;
+
+use crate::error;
+use crate::runtime::{block_on, ruby};
+
+#[magnus::wrap(class = "Microsandbox::Native::FsReadStream", free_immediately, size)]
+pub struct FsReadStreamHandle {
+    inner: Arc<Mutex<FsReadStream>>,
+}
+
+impl FsReadStreamHandle {
+    pub fn new(stream: FsReadStream) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(stream)),
+        }
+    }
+
+    /// Next chunk of bytes (ASCII-8BIT), or nil at end of stream.
+    fn recv(&self) -> Result<Option<RString>, Error> {
+        let inner = Arc::clone(&self.inner);
+        match block_on(async move { inner.lock().await.recv().await }).map_err(error::to_ruby)? {
+            Some(bytes) => Ok(Some(ruby().str_from_slice(bytes.as_ref()))),
+            None => Ok(None),
+        }
+    }
+}
+
+#[magnus::wrap(class = "Microsandbox::Native::FsWriteSink", free_immediately, size)]
+pub struct FsWriteSinkHandle {
+    inner: Arc<Mutex<Option<FsWriteSink>>>,
+}
+
+impl FsWriteSinkHandle {
+    pub fn new(sink: FsWriteSink) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(Some(sink))),
+        }
+    }
+
+    /// Write a chunk of bytes. Errors if the sink is already closed.
+    fn write(&self, data: RString) -> Result<(), Error> {
+        // Copy out while the GVL is held (GC.compact could move the buffer).
+        let bytes = unsafe { data.as_slice() }.to_vec();
+        let inner = Arc::clone(&self.inner);
+        let result = block_on(async move {
+            let guard = inner.lock().await;
+            match guard.as_ref() {
+                Some(sink) => Some(sink.write(&bytes).await),
+                None => None,
+            }
+        });
+        match result {
+            Some(r) => r.map_err(error::to_ruby),
+            None => Err(error::base_error("write to a closed FsWriteSink")),
+        }
+    }
+
+    /// Flush and close the sink. Idempotent.
+    fn close(&self) -> Result<(), Error> {
+        let inner = Arc::clone(&self.inner);
+        let taken = block_on(async move { inner.lock().await.take() });
+        match taken {
+            Some(sink) => block_on(sink.close()).map_err(error::to_ruby),
+            None => Ok(()),
+        }
+    }
+}
+
+pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
+    let rs = native.define_class("FsReadStream", ruby.class_object())?;
+    rs.define_method("recv", method!(FsReadStreamHandle::recv, 0))?;
+
+    let ws = native.define_class("FsWriteSink", ruby.class_object())?;
+    ws.define_method("write", method!(FsWriteSinkHandle::write, 1))?;
+    ws.define_method("close", method!(FsWriteSinkHandle::close, 0))?;
+    Ok(())
+}

--- a/ext/microsandbox/src/image.rs
+++ b/ext/microsandbox/src/image.rs
@@ -9,6 +9,7 @@ use magnus::{function, prelude::*, Error, RArray, RHash, RModule, Ruby};
 use microsandbox::image::{Image, ImageDetail, ImageHandle, ImagePruneReport};
 
 use crate::backend::with_local_backend;
+use crate::conv;
 use crate::runtime::ruby;
 
 fn handle_to_hash(h: &ImageHandle) -> RHash {
@@ -43,6 +44,11 @@ fn detail_to_hash(detail: ImageDetail) -> RHash {
         let _ = c.aset("entrypoint", config.entrypoint);
         let _ = c.aset("working_dir", config.working_dir);
         let _ = c.aset("user", config.user);
+        // OCI config labels: a free-form JSON object (or nil). Converted to a
+        // Ruby Hash so `ImageDetail#config["labels"]` matches the Python/Node
+        // `config.labels` dict. (The pinned v0.5.8 runtime persists this as
+        // null today; the key exists for forward-compatibility/parity.)
+        let _ = c.aset("labels", config.labels.as_ref().map(conv::json_to_ruby));
         let _ = c.aset("stop_signal", config.stop_signal);
         let _ = hash.aset("config", c);
     } else {

--- a/ext/microsandbox/src/lib.rs
+++ b/ext/microsandbox/src/lib.rs
@@ -13,6 +13,7 @@ mod backend;
 mod conv;
 mod error;
 mod exec;
+mod fs_stream;
 mod image;
 mod runtime;
 mod sandbox;
@@ -45,6 +46,43 @@ fn all_sandbox_metrics() -> Result<RHash, Error> {
 /// Download and install the `msb` runtime + `libkrunfw` into `~/.microsandbox`.
 fn install() -> Result<(), Error> {
     runtime::block_on(microsandbox::setup::install()).map_err(error::to_ruby)
+}
+
+/// Customizable install via the core `Setup` builder. `opts`: base_dir (install
+/// root), version (pin the runtime version), force (re-download even if present
+/// — repairs a corrupt install), skip_verify. Mirrors the Node `Setup` builder.
+fn setup(opts: RHash) -> Result<(), Error> {
+    use microsandbox::setup::Setup;
+    let base_dir = conv::opt_string(opts, "base_dir")?;
+    let version = conv::opt_string(opts, "version")?;
+    let skip_verify = conv::opt_bool(opts, "skip_verify")?;
+    let force = conv::opt_bool(opts, "force")?;
+    // `Setup` uses a typed-builder whose `strip_option` setters change the type
+    // on each call, so optional fields can't be set conditionally on one binding
+    // — branch on presence instead (matching the Node binding).
+    let setup = match (base_dir, version) {
+        (Some(d), Some(v)) => Setup::builder()
+            .base_dir(d)
+            .version(v)
+            .skip_verify(skip_verify)
+            .force(force)
+            .build(),
+        (Some(d), None) => Setup::builder()
+            .base_dir(d)
+            .skip_verify(skip_verify)
+            .force(force)
+            .build(),
+        (None, Some(v)) => Setup::builder()
+            .version(v)
+            .skip_verify(skip_verify)
+            .force(force)
+            .build(),
+        (None, None) => Setup::builder()
+            .skip_verify(skip_verify)
+            .force(force)
+            .build(),
+    };
+    runtime::block_on(setup.install()).map_err(error::to_ruby)
 }
 
 /// Whether the `msb` runtime + `libkrunfw` are installed and resolvable.
@@ -88,6 +126,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
 
     native.define_singleton_method("version", function!(version, 0))?;
     native.define_singleton_method("install", function!(install, 0))?;
+    native.define_singleton_method("setup", function!(setup, 1))?;
     native.define_singleton_method("installed?", function!(is_installed, 0))?;
     native.define_singleton_method("set_runtime_msb_path", function!(set_runtime_msb_path, 1))?;
     native.define_singleton_method(
@@ -101,6 +140,7 @@ fn init(ruby: &Ruby) -> Result<(), Error> {
     sandbox::define(ruby, &native)?;
     exec::define(ruby, &native)?;
     stream::define(ruby, &native)?;
+    fs_stream::define(ruby, &native)?;
     snapshot::define(ruby, &native)?;
     image::define(ruby, &native)?;
     volume::define(ruby, &native)?;

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -7,23 +7,32 @@
 //! as a plain Ruby `Hash`/`Array`/`String` and shaped into value objects by the
 //! Ruby layer.
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use magnus::{function, method, prelude::*, Error, RArray, RHash, RModule, RString, Ruby};
+use magnus::{
+    function, method, prelude::*, Error, RArray, RHash, RModule, RString, Ruby, TryConvert, Value,
+};
 use microsandbox::logs::{
     LogCursor, LogEntry, LogOptions, LogSource, LogStreamOptions, LogStreamStart,
 };
 use microsandbox::sandbox::{
-    AttachOptionsBuilder, FsEntry, FsEntryKind, FsMetadata, Patch, PullPolicy, RlimitResource,
-    SandboxFilter, SandboxHandle, SandboxMetrics, SandboxStatus, SandboxStopResult,
-    SecurityProfile,
+    AttachOptionsBuilder, DiskImageFormat, FsEntry, FsEntryKind, FsMetadata, HostPermissions,
+    Patch, PullPolicy, PullProgress, PullProgressHandle, RlimitResource, SandboxBuilder,
+    SandboxFilter, SandboxHandle, SandboxMetrics, SandboxStatus, SandboxStopResult, SecretBuilder,
+    SecurityProfile, StatVirtualization,
 };
 use microsandbox::LogLevel;
+use microsandbox::MicrosandboxResult;
 use microsandbox::RegistryAuth;
+use microsandbox_network::builder::ViolationActionBuilder;
+use microsandbox_network::dns::Nameserver;
 use microsandbox_network::policy::{
     Action, Destination, DestinationGroup, Direction, NetworkPolicy, PortRange, Protocol, Rule,
 };
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 use crate::conv;
 use crate::error;
@@ -45,12 +54,22 @@ impl Sandbox {
     // Lifecycle (singleton methods)
     //----------------------------------------------------------------------
 
-    /// Create and boot a sandbox. `opts` is a string-keyed options Hash.
-    fn create(name: String, opts: RHash) -> Result<Sandbox, Error> {
+    /// Build a configured `SandboxBuilder` from a string-keyed options Hash.
+    /// Shared by `create` (blocking) and `create_with_progress` (streaming pull).
+    fn build_builder(name: String, opts: RHash) -> Result<SandboxBuilder, Error> {
         let mut b = microsandbox::Sandbox::builder(name);
 
         if let Some(v) = conv::opt_string(opts, "image")? {
-            b = b.image(v);
+            if let Some(fstype) = conv::opt_string(opts, "fstype")? {
+                // An explicit fstype means `image` names a disk-image rootfs path
+                // whose inner filesystem can't be auto-probed: route through
+                // image_with(disk().fstype()). (A bare `image` string otherwise
+                // auto-detects OCI vs disk by extension.) Errors in disk()/fstype()
+                // are captured on the builder and surface at create().
+                b = b.image_with(move |i| i.disk(v).fstype(fstype));
+            } else {
+                b = b.image(v);
+            }
         }
         if let Some(v) = conv::opt_string(opts, "from_snapshot")? {
             b = b.from_snapshot(v);
@@ -89,59 +108,87 @@ impl Sandbox {
         for (host, guest) in conv::opt_port_map(opts, "ports")? {
             b = b.port(host, guest);
         }
-        // volumes: normalized by the Ruby layer to [guest, kind, source] triples,
-        // or [guest, kind, source, options] quads where options is a comma-joined
-        // list (ro/readonly, rw, noexec, nosuid, nodev).
-        for spec in conv::opt::<Vec<Vec<String>>>(opts, "volumes")?.unwrap_or_default() {
-            if spec.len() < 3 || spec.len() > 4 {
-                return Err(error::base_error("invalid volume mount spec"));
-            }
-            let (guest, kind, source) = (spec[0].clone(), spec[1].clone(), spec[2].clone());
+        // volumes: each mount is normalized by the Ruby layer to a string-keyed
+        // Hash — guest (req), kind ("bind"/"named"/"tmpfs"/"disk"), source
+        // (bind/named/disk), size_mib (tmpfs/disk), format + fstype (disk),
+        // readonly/noexec/nosuid/nodev (bool), stat_virtualization,
+        // host_permissions. Enum-valued options are validated up front (the
+        // volume closure can't return an error); the core validates the rest
+        // (e.g. rejecting stat_virtualization on tmpfs/disk) at create().
+        for m in conv::opt_hash_vec(opts, "volumes")? {
+            let guest = conv::opt_string(m, "guest")?
+                .ok_or_else(|| error::base_error("volume mount is missing :guest"))?;
+            let kind = conv::opt_string(m, "kind")?
+                .ok_or_else(|| error::base_error("volume mount is missing :kind"))?;
+            let source = conv::opt_string(m, "source")?;
+            let size_mib = conv::opt_u32(m, "size_mib")?;
+            let fstype = conv::opt_string(m, "fstype")?;
+            let readonly = conv::opt_bool(m, "readonly")?;
+            let noexec = conv::opt_bool(m, "noexec")?;
+            let nosuid = conv::opt_bool(m, "nosuid")?;
+            let nodev = conv::opt_bool(m, "nodev")?;
+            let format = match conv::opt_string(m, "format")? {
+                Some(f) => Some(disk_format_from_str(&f)?),
+                None => None,
+            };
+            let stat_virt = match conv::opt_string(m, "stat_virtualization")? {
+                Some(s) => Some(stat_virtualization_from_str(&s)?),
+                None => None,
+            };
+            let host_perms = match conv::opt_string(m, "host_permissions")? {
+                Some(s) => Some(host_permissions_from_str(&s)?),
+                None => None,
+            };
+            // bind/named/disk require a source; tmpfs must not have one.
             match kind.as_str() {
-                "bind" | "named" => {}
+                "bind" | "named" | "disk" if source.is_some() => {}
+                "bind" | "named" | "disk" => {
+                    return Err(error::base_error(format!(
+                        "volume mount kind {kind:?} requires a source"
+                    )))
+                }
+                "tmpfs" => {}
                 other => {
                     return Err(error::base_error(format!(
-                        "unknown volume mount kind {other:?} (expected \"bind\" or \"named\")"
+                        "unknown volume mount kind {other:?} (expected bind/named/tmpfs/disk)"
                     )))
                 }
             }
-            // Validate options up front (the volume closure cannot return an error).
-            let mount_opts: Vec<String> = spec
-                .get(3)
-                .map(|s| {
-                    s.split(',')
-                        .map(|o| o.trim().to_string())
-                        .filter(|o| !o.is_empty())
-                        .collect()
-                })
-                .unwrap_or_default();
-            for opt in &mount_opts {
-                match opt.as_str() {
-                    "ro" | "readonly" | "rw" | "noexec" | "nosuid" | "nodev" => {}
-                    other => {
-                        return Err(error::base_error(format!(
-                            "unknown volume mount option {other:?} \
-                             (expected ro/rw/noexec/nosuid/nodev)"
-                        )))
-                    }
-                }
-            }
-            b = b.volume(guest, move |m| {
-                let mut m = if kind == "named" {
-                    m.named(source)
-                } else {
-                    m.bind(source)
+            b = b.volume(guest, move |mut mb| {
+                mb = match kind.as_str() {
+                    "named" => mb.named(source.unwrap()),
+                    "tmpfs" => mb.tmpfs(),
+                    "disk" => mb.disk(source.unwrap()),
+                    _ => mb.bind(source.unwrap()), // "bind"
                 };
-                for opt in &mount_opts {
-                    m = match opt.as_str() {
-                        "ro" | "readonly" => m.readonly(),
-                        "noexec" => m.noexec(),
-                        "nosuid" => m.nosuid(),
-                        "nodev" => m.nodev(),
-                        _ => m, // "rw" — default; already validated above
-                    };
+                if let Some(n) = size_mib {
+                    mb = mb.size(n);
                 }
-                m
+                if let Some(f) = format {
+                    mb = mb.format(f);
+                }
+                if let Some(ft) = fstype {
+                    mb = mb.fstype(ft);
+                }
+                if readonly {
+                    mb = mb.readonly();
+                }
+                if noexec {
+                    mb = mb.noexec();
+                }
+                if nosuid {
+                    mb = mb.nosuid();
+                }
+                if nodev {
+                    mb = mb.nodev();
+                }
+                if let Some(sv) = stat_virt {
+                    mb = mb.stat_virtualization(sv);
+                }
+                if let Some(hp) = host_perms {
+                    mb = mb.host_permissions(hp);
+                }
+                mb
             });
         }
         // patches: rootfs modifications applied before boot. The Ruby layer
@@ -207,16 +254,130 @@ impl Sandbox {
         for (resource, soft, hard) in parse_rlimits(opts)? {
             b = b.rlimit_range(resource, soft, hard);
         }
-        // secrets: normalized by the Ruby layer to [env_var, value, allowed_host]
-        // triples. Uses the placeholder-based `secret_env` shorthand, which also
-        // auto-enables TLS interception (required for value substitution).
-        for spec in conv::opt::<Vec<Vec<String>>>(opts, "secrets")?.unwrap_or_default() {
-            if spec.len() != 3 {
-                return Err(error::base_error(
-                    "invalid secret spec (expected [env, value, host])",
-                ));
+        // secrets: each entry is normalized by the Ruby layer to a string-keyed
+        // Hash — env (req), value (req), hosts / host_patterns (allow lists),
+        // placeholder, require_tls, inject_{headers,basic_auth,query,body},
+        // on_violation. Routed through the full secret builder (`b.secret`), which
+        // auto-enables TLS interception. Mirrors the Python/Node SecretEntry.
+        for h in conv::opt_hash_vec(opts, "secrets")? {
+            let spec = parse_secret(h)?;
+            b = b.secret(move |s| spec.apply(s));
+        }
+        // Sandbox-level secret-leak policy (block / block_and_log /
+        // block_and_terminate / passthrough). Applied via the network builder,
+        // which accumulates on top of any policy/dns/tls already configured.
+        if let Some(v) = conv::opt::<Value>(opts, "on_secret_violation")? {
+            let spec = parse_violation_spec(v)?;
+            b = b.network(move |n| n.on_secret_violation(move |va| spec.apply(va)));
+        }
+        // Advanced network configuration (custom DNS, TLS-interception tuning,
+        // guest IP pools, connection cap, host-CA trust), applied via the network
+        // builder, which accumulates on top of any policy already configured.
+        // Mirrors the Python binding's `apply_network`. Parsed up front because
+        // the builder closures cannot return an error.
+        let dns = match conv::opt::<RHash>(opts, "dns")? {
+            Some(d) => Some(parse_dns(d)?),
+            None => None,
+        };
+        let tls = match conv::opt::<RHash>(opts, "tls")? {
+            Some(t) => Some(parse_tls(t)?),
+            None => None,
+        };
+        let ipv4_pool = match conv::opt_string(opts, "ipv4_pool")? {
+            Some(s) => Some(
+                s.parse::<ipnetwork::Ipv4Network>()
+                    .map_err(|e| error::base_error(format!("invalid ipv4_pool {s:?}: {e}")))?,
+            ),
+            None => None,
+        };
+        let ipv6_pool = match conv::opt_string(opts, "ipv6_pool")? {
+            Some(s) => Some(
+                s.parse::<ipnetwork::Ipv6Network>()
+                    .map_err(|e| error::base_error(format!("invalid ipv6_pool {s:?}: {e}")))?,
+            ),
+            None => None,
+        };
+        let max_connections = conv::opt::<usize>(opts, "max_connections")?;
+        let trust_host_cas = conv::opt::<bool>(opts, "trust_host_cas")?;
+        if dns.is_some()
+            || tls.is_some()
+            || ipv4_pool.is_some()
+            || ipv6_pool.is_some()
+            || max_connections.is_some()
+            || trust_host_cas.is_some()
+        {
+            b = b.network(move |mut n| {
+                if let Some(dns) = dns {
+                    n = n.dns(move |mut d| {
+                        if !dns.nameservers.is_empty() {
+                            d = d.nameservers(dns.nameservers);
+                        }
+                        if let Some(rp) = dns.rebind_protection {
+                            d = d.rebind_protection(rp);
+                        }
+                        if let Some(qt) = dns.query_timeout_ms {
+                            d = d.query_timeout_ms(qt);
+                        }
+                        d
+                    });
+                }
+                if let Some(tls) = tls {
+                    n = n.tls(move |mut t| {
+                        for pat in tls.bypass {
+                            t = t.bypass(pat);
+                        }
+                        if let Some(v) = tls.verify_upstream {
+                            t = t.verify_upstream(v);
+                        }
+                        if let Some(ports) = tls.intercepted_ports {
+                            t = t.intercepted_ports(ports);
+                        }
+                        if let Some(q) = tls.block_quic {
+                            t = t.block_quic(q);
+                        }
+                        if let Some(p) = tls.upstream_ca_cert {
+                            t = t.upstream_ca_cert(p);
+                        }
+                        if let Some(p) = tls.intercept_ca_cert {
+                            t = t.intercept_ca_cert(p);
+                        }
+                        if let Some(p) = tls.intercept_ca_key {
+                            t = t.intercept_ca_key(p);
+                        }
+                        t
+                    });
+                }
+                if let Some(p) = ipv4_pool {
+                    n = n.ipv4_pool(p);
+                }
+                if let Some(p) = ipv6_pool {
+                    n = n.ipv6_pool(p);
+                }
+                if let Some(m) = max_connections {
+                    n = n.max_connections(m);
+                }
+                if let Some(t) = trust_host_cas {
+                    n = n.trust_host_cas(t);
+                }
+                n
+            });
+        }
+        // init: hand guest PID 1 to an init system. The Ruby layer normalizes
+        // `init:` to a Hash { cmd:, args?:, env?: }. With no args/env, use the
+        // plain `init(cmd)`; otherwise the `init_with` closure-builder.
+        if let Some(h) = conv::opt::<RHash>(opts, "init")? {
+            let cmd = conv::opt_string(h, "cmd")?
+                .ok_or_else(|| error::base_error("init requires a :cmd"))?;
+            let args = conv::opt_string_vec(h, "args")?;
+            let env = conv::opt_string_map(h, "env")?;
+            if args.is_empty() && env.is_empty() {
+                b = b.init(cmd);
+            } else {
+                b = b.init_with(cmd, move |i| i.args(args).envs(env));
             }
-            b = b.secret_env(spec[0].clone(), spec[1].clone(), spec[2].clone());
+        }
+        if conv::opt_bool(opts, "ephemeral")? {
+            b = b.ephemeral(true);
         }
         if conv::opt_bool(opts, "detached")? {
             b = b.detached(true);
@@ -227,8 +388,27 @@ impl Sandbox {
             b = b.replace();
         }
 
+        Ok(b)
+    }
+
+    /// Create and boot a sandbox. `opts` is a string-keyed options Hash.
+    fn create(name: String, opts: RHash) -> Result<Sandbox, Error> {
+        let b = Self::build_builder(name, opts)?;
         let inner = block_on(b.create()).map_err(error::to_ruby)?;
         Ok(Sandbox::from_inner(inner))
+    }
+
+    /// Create a sandbox with streaming image-pull progress. Returns a
+    /// `PullSession` whose `recv` yields progress events and whose `result`
+    /// resolves to the booted sandbox. Mirrors Python `create_with_progress` /
+    /// Node `createWithPullProgress`.
+    fn create_with_progress(name: String, opts: RHash) -> Result<PullSession, Error> {
+        let b = Self::build_builder(name, opts)?;
+        // `create_with_pull_progress` spawns a tokio task, so it must run inside
+        // the runtime context even though the call itself is synchronous.
+        let (handle, join) =
+            block_on(async move { b.create_with_pull_progress() }).map_err(error::to_ruby)?;
+        Ok(PullSession::new(handle, join))
     }
 
     /// Restart a previously-defined sandbox by name.
@@ -495,6 +675,20 @@ impl Sandbox {
         block_on(fs.copy_to_host(&guest_path, &host_path)).map_err(error::to_ruby)
     }
 
+    /// Open a streaming reader over a guest file (for files too large to buffer).
+    fn fs_read_stream(&self, path: String) -> Result<crate::fs_stream::FsReadStreamHandle, Error> {
+        let fs = self.inner.fs();
+        let stream = block_on(fs.read_stream(&path)).map_err(error::to_ruby)?;
+        Ok(crate::fs_stream::FsReadStreamHandle::new(stream))
+    }
+
+    /// Open a streaming writer to a guest file.
+    fn fs_write_stream(&self, path: String) -> Result<crate::fs_stream::FsWriteSinkHandle, Error> {
+        let fs = self.inner.fs();
+        let sink = block_on(fs.write_stream(&path)).map_err(error::to_ruby)?;
+        Ok(crate::fs_stream::FsWriteSinkHandle::new(sink))
+    }
+
     //----------------------------------------------------------------------
     // SSH (mirror SandboxSshOps)
     //----------------------------------------------------------------------
@@ -686,6 +880,51 @@ fn parse_rlimits(opts: RHash) -> Result<Vec<(RlimitResource, u64, u64)>, Error> 
 }
 
 //--------------------------------------------------------------------------------------------------
+// Mount enum parsing
+//--------------------------------------------------------------------------------------------------
+
+fn disk_format_from_str(s: &str) -> Result<DiskImageFormat, Error> {
+    use DiskImageFormat::*;
+    Ok(match s {
+        "qcow2" => Qcow2,
+        "raw" => Raw,
+        "vmdk" => Vmdk,
+        other => {
+            return Err(error::base_error(format!(
+                "unknown disk format {other:?} (expected qcow2/raw/vmdk)"
+            )))
+        }
+    })
+}
+
+fn stat_virtualization_from_str(s: &str) -> Result<StatVirtualization, Error> {
+    use StatVirtualization::*;
+    Ok(match s {
+        "strict" => Strict,
+        "relaxed" => Relaxed,
+        "off" => Off,
+        other => {
+            return Err(error::base_error(format!(
+                "unknown stat_virtualization {other:?} (expected strict/relaxed/off)"
+            )))
+        }
+    })
+}
+
+fn host_permissions_from_str(s: &str) -> Result<HostPermissions, Error> {
+    use HostPermissions::*;
+    Ok(match s {
+        "private" => Private,
+        "mirror" => Mirror,
+        other => {
+            return Err(error::base_error(format!(
+                "unknown host_permissions {other:?} (expected private/mirror)"
+            )))
+        }
+    })
+}
+
+//--------------------------------------------------------------------------------------------------
 // Patch parsing (mirrors the Python binding's `apply_patch`)
 //--------------------------------------------------------------------------------------------------
 
@@ -762,6 +1001,199 @@ fn parse_patches(opts: RHash) -> Result<Vec<Patch>, Error> {
         out.push(patch);
     }
     Ok(out)
+}
+
+//--------------------------------------------------------------------------------------------------
+// Secret parsing (mirrors the Python/Node SecretEntry surface)
+//--------------------------------------------------------------------------------------------------
+
+/// A secret-leak response. Per-secret (`on_violation:`) and sandbox-level
+/// (`on_secret_violation:`) share the same shape.
+enum ViolationSpec {
+    Block,
+    BlockAndLog,
+    BlockAndTerminate,
+    Passthrough {
+        hosts: Vec<String>,
+        patterns: Vec<String>,
+        all: bool,
+    },
+}
+
+impl ViolationSpec {
+    fn apply(self, mut v: ViolationActionBuilder) -> ViolationActionBuilder {
+        match self {
+            ViolationSpec::Block => v.block(),
+            ViolationSpec::BlockAndLog => v.block_and_log(),
+            ViolationSpec::BlockAndTerminate => v.block_and_terminate(),
+            ViolationSpec::Passthrough {
+                hosts,
+                patterns,
+                all,
+            } => {
+                for h in hosts {
+                    v = v.passthrough_host(h);
+                }
+                for p in patterns {
+                    v = v.passthrough_host_pattern(p);
+                }
+                if all {
+                    v = v.passthrough_all_hosts(true);
+                }
+                v
+            }
+        }
+    }
+}
+
+/// Parse `on_violation:` — a String (block variants) or a Hash describing a
+/// passthrough action — into a [`ViolationSpec`].
+fn parse_violation_spec(v: Value) -> Result<ViolationSpec, Error> {
+    if let Ok(s) = String::try_convert(v) {
+        return match s.as_str() {
+            "block" => Ok(ViolationSpec::Block),
+            "block_and_log" => Ok(ViolationSpec::BlockAndLog),
+            "block_and_terminate" => Ok(ViolationSpec::BlockAndTerminate),
+            other => Err(error::base_error(format!(
+                "unknown on_violation {other:?} (expected block/block_and_log/\
+                 block_and_terminate, or a Hash with :passthrough_hosts/\
+                 :passthrough_host_patterns/:passthrough_all_hosts)"
+            ))),
+        };
+    }
+    let h = RHash::try_convert(v)
+        .map_err(|_| error::base_error("on_violation must be a String or a Hash"))?;
+    Ok(ViolationSpec::Passthrough {
+        hosts: conv::opt_string_vec(h, "passthrough_hosts")?,
+        patterns: conv::opt_string_vec(h, "passthrough_host_patterns")?,
+        all: conv::opt_bool(h, "passthrough_all_hosts")?,
+    })
+}
+
+struct SecretSpec {
+    env: String,
+    value: String,
+    hosts: Vec<String>,
+    host_patterns: Vec<String>,
+    placeholder: Option<String>,
+    require_tls: Option<bool>,
+    inject_headers: Option<bool>,
+    inject_basic_auth: Option<bool>,
+    inject_query: Option<bool>,
+    inject_body: Option<bool>,
+    on_violation: Option<ViolationSpec>,
+}
+
+fn parse_secret(h: RHash) -> Result<SecretSpec, Error> {
+    let env =
+        conv::opt_string(h, "env")?.ok_or_else(|| error::base_error("secret requires :env"))?;
+    let value =
+        conv::opt_string(h, "value")?.ok_or_else(|| error::base_error("secret requires :value"))?;
+    let hosts = conv::opt_string_vec(h, "hosts")?;
+    let host_patterns = conv::opt_string_vec(h, "host_patterns")?;
+    if hosts.is_empty() && host_patterns.is_empty() {
+        return Err(error::base_error(
+            "secret requires at least one allowed host (:host, :hosts, or :host_patterns)",
+        ));
+    }
+    let on_violation = match conv::opt::<Value>(h, "on_violation")? {
+        Some(v) => Some(parse_violation_spec(v)?),
+        None => None,
+    };
+    Ok(SecretSpec {
+        env,
+        value,
+        hosts,
+        host_patterns,
+        placeholder: conv::opt_string(h, "placeholder")?,
+        require_tls: conv::opt::<bool>(h, "require_tls")?,
+        inject_headers: conv::opt::<bool>(h, "inject_headers")?,
+        inject_basic_auth: conv::opt::<bool>(h, "inject_basic_auth")?,
+        inject_query: conv::opt::<bool>(h, "inject_query")?,
+        inject_body: conv::opt::<bool>(h, "inject_body")?,
+        on_violation,
+    })
+}
+
+impl SecretSpec {
+    fn apply(self, mut s: SecretBuilder) -> SecretBuilder {
+        s = s.env(self.env).value(self.value);
+        for host in self.hosts {
+            s = s.allow_host(host);
+        }
+        for pat in self.host_patterns {
+            s = s.allow_host_pattern(pat);
+        }
+        if let Some(p) = self.placeholder {
+            s = s.placeholder(p);
+        }
+        if let Some(rt) = self.require_tls {
+            s = s.require_tls_identity(rt);
+        }
+        if let Some(enabled) = self.inject_headers {
+            s = s.inject_headers(enabled);
+        }
+        if let Some(enabled) = self.inject_basic_auth {
+            s = s.inject_basic_auth(enabled);
+        }
+        if let Some(enabled) = self.inject_query {
+            s = s.inject_query(enabled);
+        }
+        if let Some(enabled) = self.inject_body {
+            s = s.inject_body(enabled);
+        }
+        if let Some(action) = self.on_violation {
+            s = s.on_violation(move |v| action.apply(v));
+        }
+        s
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Network connection config parsing (DNS / TLS interception)
+//--------------------------------------------------------------------------------------------------
+
+struct DnsSpec {
+    nameservers: Vec<Nameserver>,
+    rebind_protection: Option<bool>,
+    query_timeout_ms: Option<u64>,
+}
+
+fn parse_dns(d: RHash) -> Result<DnsSpec, Error> {
+    let mut nameservers = Vec::new();
+    for s in conv::opt_string_vec(d, "nameservers")? {
+        nameservers.push(
+            s.parse::<Nameserver>()
+                .map_err(|e| error::base_error(format!("invalid nameserver {s:?}: {e}")))?,
+        );
+    }
+    Ok(DnsSpec {
+        nameservers,
+        rebind_protection: conv::opt::<bool>(d, "rebind_protection")?,
+        query_timeout_ms: conv::opt::<u64>(d, "query_timeout_ms")?,
+    })
+}
+
+struct TlsSpec {
+    bypass: Vec<String>,
+    verify_upstream: Option<bool>,
+    intercepted_ports: Option<Vec<u16>>,
+    block_quic: Option<bool>,
+    upstream_ca_cert: Option<String>,
+    intercept_ca_cert: Option<String>,
+    intercept_ca_key: Option<String>,
+}
+
+fn parse_tls(t: RHash) -> Result<TlsSpec, Error> {
+    Ok(TlsSpec {
+        bypass: conv::opt_string_vec(t, "bypass")?,
+        verify_upstream: conv::opt::<bool>(t, "verify_upstream")?,
+        intercepted_ports: conv::opt::<Vec<u16>>(t, "intercepted_ports")?,
+        block_quic: conv::opt::<bool>(t, "block_quic")?,
+        upstream_ca_cert: conv::opt_string(t, "upstream_ca_cert")?,
+        intercept_ca_cert: conv::opt_string(t, "intercept_ca_cert")?,
+        intercept_ca_key: conv::opt_string(t, "intercept_ca_key")?,
+    })
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1205,7 +1637,7 @@ fn fs_entry_kind_str(kind: FsEntryKind) -> &'static str {
     }
 }
 
-fn fs_entry_to_hash(entry: &FsEntry) -> RHash {
+pub(crate) fn fs_entry_to_hash(entry: &FsEntry) -> RHash {
     let hash = ruby().hash_new();
     let _ = hash.aset("path", entry.path.clone());
     let _ = hash.aset("type", fs_entry_kind_str(entry.kind));
@@ -1218,7 +1650,7 @@ fn fs_entry_to_hash(entry: &FsEntry) -> RHash {
     hash
 }
 
-fn fs_metadata_to_hash(meta: &FsMetadata) -> RHash {
+pub(crate) fn fs_metadata_to_hash(meta: &FsMetadata) -> RHash {
     let hash = ruby().hash_new();
     let _ = hash.aset("type", fs_entry_kind_str(meta.kind));
     let _ = hash.aset("size", meta.size);
@@ -1241,6 +1673,11 @@ pub(crate) fn metrics_to_hash(m: &SandboxMetrics) -> RHash {
     let _ = hash.aset("disk_write_bytes", m.disk_write_bytes);
     let _ = hash.aset("net_rx_bytes", m.net_rx_bytes);
     let _ = hash.aset("net_tx_bytes", m.net_tx_bytes);
+    // OCI writable-upper-layer accounting (Option<u64> → Integer or nil), for
+    // sandboxes capped by `oci_upper_size`. Mirrors the Python/Node metrics.
+    let _ = hash.aset("upper_used_bytes", m.upper_used_bytes);
+    let _ = hash.aset("upper_free_bytes", m.upper_free_bytes);
+    let _ = hash.aset("upper_host_allocated_bytes", m.upper_host_allocated_bytes);
     let _ = hash.aset("uptime_secs", m.uptime.as_secs_f64());
     let _ = hash.aset("timestamp_ms", m.timestamp.timestamp_millis());
     hash
@@ -1280,6 +1717,159 @@ fn stop_result_to_hash(result: &SandboxStopResult) -> RHash {
     let _ = hash.aset("observed_at_ms", result.observed_at.timestamp_millis());
     let _ = hash.aset("source", result.source.clone());
     hash
+}
+
+//--------------------------------------------------------------------------------------------------
+// Pull progress (streaming image-pull during create_with_progress)
+//--------------------------------------------------------------------------------------------------
+
+/// Convert a core `PullProgress` event into a `{ "kind" => …, fields… }` Hash.
+/// The match is exhaustive (no wildcard) so a future upstream variant surfaces
+/// as a compile error rather than a silently-dropped event.
+fn pull_progress_to_hash(p: &PullProgress) -> RHash {
+    use PullProgress::*;
+    let h = ruby().hash_new();
+    match p {
+        Resolving { reference } => {
+            let _ = h.aset("kind", "resolving");
+            let _ = h.aset("reference", reference.to_string());
+        }
+        Resolved {
+            reference,
+            manifest_digest,
+            layer_count,
+            total_download_bytes,
+        } => {
+            let _ = h.aset("kind", "resolved");
+            let _ = h.aset("reference", reference.to_string());
+            let _ = h.aset("manifest_digest", manifest_digest.to_string());
+            let _ = h.aset("layer_count", *layer_count);
+            let _ = h.aset("total_download_bytes", *total_download_bytes);
+        }
+        LayerDownloadProgress {
+            layer_index,
+            digest,
+            downloaded_bytes,
+            total_bytes,
+        } => {
+            let _ = h.aset("kind", "layer_download_progress");
+            let _ = h.aset("layer_index", *layer_index);
+            let _ = h.aset("digest", digest.to_string());
+            let _ = h.aset("downloaded_bytes", *downloaded_bytes);
+            let _ = h.aset("total_bytes", *total_bytes);
+        }
+        LayerDownloadComplete {
+            layer_index,
+            digest,
+            downloaded_bytes,
+        } => {
+            let _ = h.aset("kind", "layer_download_complete");
+            let _ = h.aset("layer_index", *layer_index);
+            let _ = h.aset("digest", digest.to_string());
+            let _ = h.aset("downloaded_bytes", *downloaded_bytes);
+        }
+        LayerDownloadVerifying {
+            layer_index,
+            digest,
+        } => {
+            let _ = h.aset("kind", "layer_download_verifying");
+            let _ = h.aset("layer_index", *layer_index);
+            let _ = h.aset("digest", digest.to_string());
+        }
+        LayerMaterializeStarted {
+            layer_index,
+            diff_id,
+        } => {
+            let _ = h.aset("kind", "layer_materialize_started");
+            let _ = h.aset("layer_index", *layer_index);
+            let _ = h.aset("diff_id", diff_id.to_string());
+        }
+        LayerMaterializeProgress {
+            layer_index,
+            bytes_read,
+            total_bytes,
+        } => {
+            let _ = h.aset("kind", "layer_materialize_progress");
+            let _ = h.aset("layer_index", *layer_index);
+            let _ = h.aset("bytes_read", *bytes_read);
+            let _ = h.aset("total_bytes", *total_bytes);
+        }
+        LayerMaterializeWriting { layer_index } => {
+            let _ = h.aset("kind", "layer_materialize_writing");
+            let _ = h.aset("layer_index", *layer_index);
+        }
+        LayerMaterializeComplete {
+            layer_index,
+            diff_id,
+        } => {
+            let _ = h.aset("kind", "layer_materialize_complete");
+            let _ = h.aset("layer_index", *layer_index);
+            let _ = h.aset("diff_id", diff_id.to_string());
+        }
+        StitchMergingTrees { layer_count } => {
+            let _ = h.aset("kind", "stitch_merging_trees");
+            let _ = h.aset("layer_count", *layer_count);
+        }
+        StitchWritingFsmeta => {
+            let _ = h.aset("kind", "stitch_writing_fsmeta");
+        }
+        StitchWritingVmdk => {
+            let _ = h.aset("kind", "stitch_writing_vmdk");
+        }
+        StitchComplete => {
+            let _ = h.aset("kind", "stitch_complete");
+        }
+        Complete {
+            reference,
+            layer_count,
+        } => {
+            let _ = h.aset("kind", "complete");
+            let _ = h.aset("reference", reference.to_string());
+            let _ = h.aset("layer_count", *layer_count);
+        }
+    }
+    h
+}
+
+/// A streaming image-pull + create session, from `Sandbox.create_with_progress`.
+/// `recv` yields progress events; `result` awaits the booted sandbox. The pull
+/// runs as a tokio task; the progress receiver needs `&mut self` and the join
+/// handle is consumed once, so both sit behind a `tokio::Mutex`.
+#[magnus::wrap(class = "Microsandbox::Native::PullSession", free_immediately, size)]
+pub struct PullSession {
+    progress: Arc<Mutex<PullProgressHandle>>,
+    join: Arc<Mutex<Option<JoinHandle<MicrosandboxResult<microsandbox::Sandbox>>>>>,
+}
+
+impl PullSession {
+    fn new(
+        progress: PullProgressHandle,
+        join: JoinHandle<MicrosandboxResult<microsandbox::Sandbox>>,
+    ) -> Self {
+        Self {
+            progress: Arc::new(Mutex::new(progress)),
+            join: Arc::new(Mutex::new(Some(join))),
+        }
+    }
+
+    /// Next progress event as a Hash, or nil when the pull is finished.
+    fn recv(&self) -> Result<Option<RHash>, Error> {
+        let progress = Arc::clone(&self.progress);
+        let event = block_on(async move { progress.lock().await.recv().await });
+        Ok(event.map(|p| pull_progress_to_hash(&p)))
+    }
+
+    /// Await the booted sandbox. Call after draining `recv` (it joins the
+    /// create task). Consumes the join handle, so it is callable only once.
+    fn result(&self) -> Result<Sandbox, Error> {
+        let join = Arc::clone(&self.join);
+        let taken = block_on(async move { join.lock().await.take() });
+        let handle = taken.ok_or_else(|| error::base_error("pull session result already taken"))?;
+        let inner = block_on(handle)
+            .map_err(|e| error::base_error(format!("sandbox creation task failed: {e}")))?
+            .map_err(error::to_ruby)?;
+        Ok(Sandbox::from_inner(inner))
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -1360,6 +1950,27 @@ impl SbHandle {
     fn wait_until_stopped(&self) -> Result<RHash, Error> {
         let result = block_on(self.inner.wait_until_stopped()).map_err(error::to_ruby)?;
         Ok(stop_result_to_hash(&result))
+    }
+
+    /// The sandbox's stored configuration as a JSON string (synchronous — the
+    /// handle already carries it, no runtime round-trip). The Ruby layer parses
+    /// it into a Hash for `#config`. Mirrors the Python/Node `config_json`.
+    fn config_json(&self) -> String {
+        self.inner.config_json().to_string()
+    }
+
+    /// Snapshot this (stopped) sandbox under a bare name (resolved under the
+    /// snapshots directory). Returns the same SnapshotInfo Hash as
+    /// `Snapshot.create`. Mirrors the Python/Node `handle.snapshot(name)`.
+    fn snapshot(&self, name: String) -> Result<RHash, Error> {
+        let snap = block_on(self.inner.snapshot(&name)).map_err(error::to_ruby)?;
+        Ok(crate::snapshot::snapshot_to_hash(&snap))
+    }
+
+    /// Snapshot this (stopped) sandbox to an explicit filesystem path.
+    fn snapshot_to(&self, path: String) -> Result<RHash, Error> {
+        let snap = block_on(self.inner.snapshot_to(path)).map_err(error::to_ruby)?;
+        Ok(crate::snapshot::snapshot_to_hash(&snap))
     }
 }
 
@@ -1450,6 +2061,10 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     let class = native.define_class("Sandbox", ruby.class_object())?;
 
     class.define_singleton_method("create", function!(Sandbox::create, 2))?;
+    class.define_singleton_method(
+        "create_with_progress",
+        function!(Sandbox::create_with_progress, 2),
+    )?;
     class.define_singleton_method("start", function!(Sandbox::start, 2))?;
     class.define_singleton_method("get", function!(Sandbox::get, 1))?;
     class.define_singleton_method("list", function!(Sandbox::list, 0))?;
@@ -1487,6 +2102,8 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     class.define_method("fs_stat", method!(Sandbox::fs_stat, 1))?;
     class.define_method("fs_copy_from_host", method!(Sandbox::fs_copy_from_host, 2))?;
     class.define_method("fs_copy_to_host", method!(Sandbox::fs_copy_to_host, 2))?;
+    class.define_method("fs_read_stream", method!(Sandbox::fs_read_stream, 1))?;
+    class.define_method("fs_write_stream", method!(Sandbox::fs_write_stream, 1))?;
 
     class.define_method("ssh_open_client", method!(Sandbox::ssh_open_client, 1))?;
     class.define_method(
@@ -1513,6 +2130,13 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
         "wait_until_stopped",
         method!(SbHandle::wait_until_stopped, 0),
     )?;
+    handle.define_method("config_json", method!(SbHandle::config_json, 0))?;
+    handle.define_method("snapshot", method!(SbHandle::snapshot, 1))?;
+    handle.define_method("snapshot_to", method!(SbHandle::snapshot_to, 1))?;
+
+    let session = native.define_class("PullSession", ruby.class_object())?;
+    session.define_method("recv", method!(PullSession::recv, 0))?;
+    session.define_method("result", method!(PullSession::result, 0))?;
 
     Ok(())
 }

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -127,18 +127,15 @@ impl Sandbox {
             let noexec = conv::opt_bool(m, "noexec")?;
             let nosuid = conv::opt_bool(m, "nosuid")?;
             let nodev = conv::opt_bool(m, "nodev")?;
-            let format = match conv::opt_string(m, "format")? {
-                Some(f) => Some(disk_format_from_str(&f)?),
-                None => None,
-            };
-            let stat_virt = match conv::opt_string(m, "stat_virtualization")? {
-                Some(s) => Some(stat_virtualization_from_str(&s)?),
-                None => None,
-            };
-            let host_perms = match conv::opt_string(m, "host_permissions")? {
-                Some(s) => Some(host_permissions_from_str(&s)?),
-                None => None,
-            };
+            let format = conv::opt_string(m, "format")?
+                .map(|f| disk_format_from_str(&f))
+                .transpose()?;
+            let stat_virt = conv::opt_string(m, "stat_virtualization")?
+                .map(|s| stat_virtualization_from_str(&s))
+                .transpose()?;
+            let host_perms = conv::opt_string(m, "host_permissions")?
+                .map(|s| host_permissions_from_str(&s))
+                .transpose()?;
             // bind/named/disk require a source; tmpfs must not have one.
             match kind.as_str() {
                 "bind" | "named" | "disk" if source.is_some() => {}
@@ -275,28 +272,24 @@ impl Sandbox {
         // builder, which accumulates on top of any policy already configured.
         // Mirrors the Python binding's `apply_network`. Parsed up front because
         // the builder closures cannot return an error.
-        let dns = match conv::opt::<RHash>(opts, "dns")? {
-            Some(d) => Some(parse_dns(d)?),
-            None => None,
-        };
-        let tls = match conv::opt::<RHash>(opts, "tls")? {
-            Some(t) => Some(parse_tls(t)?),
-            None => None,
-        };
-        let ipv4_pool = match conv::opt_string(opts, "ipv4_pool")? {
-            Some(s) => Some(
+        let dns = conv::opt::<RHash>(opts, "dns")?
+            .map(parse_dns)
+            .transpose()?;
+        let tls = conv::opt::<RHash>(opts, "tls")?
+            .map(parse_tls)
+            .transpose()?;
+        let ipv4_pool = conv::opt_string(opts, "ipv4_pool")?
+            .map(|s| {
                 s.parse::<ipnetwork::Ipv4Network>()
-                    .map_err(|e| error::base_error(format!("invalid ipv4_pool {s:?}: {e}")))?,
-            ),
-            None => None,
-        };
-        let ipv6_pool = match conv::opt_string(opts, "ipv6_pool")? {
-            Some(s) => Some(
+                    .map_err(|e| error::base_error(format!("invalid ipv4_pool {s:?}: {e}")))
+            })
+            .transpose()?;
+        let ipv6_pool = conv::opt_string(opts, "ipv6_pool")?
+            .map(|s| {
                 s.parse::<ipnetwork::Ipv6Network>()
-                    .map_err(|e| error::base_error(format!("invalid ipv6_pool {s:?}: {e}")))?,
-            ),
-            None => None,
-        };
+                    .map_err(|e| error::base_error(format!("invalid ipv6_pool {s:?}: {e}")))
+            })
+            .transpose()?;
         let max_connections = conv::opt::<usize>(opts, "max_connections")?;
         let trust_host_cas = conv::opt::<bool>(opts, "trust_host_cas")?;
         if dns.is_some()
@@ -363,18 +356,15 @@ impl Sandbox {
             });
         }
         // init: hand guest PID 1 to an init system. The Ruby layer normalizes
-        // `init:` to a Hash { cmd:, args?:, env?: }. With no args/env, use the
-        // plain `init(cmd)`; otherwise the `init_with` closure-builder.
+        // `init:` to a Hash { cmd:, args?:, env?: }. `init_with` with empty
+        // args/env builds the same HandoffInit as the plain `init(cmd)`, so route
+        // everything through the one closure-builder.
         if let Some(h) = conv::opt::<RHash>(opts, "init")? {
             let cmd = conv::opt_string(h, "cmd")?
                 .ok_or_else(|| error::base_error("init requires a :cmd"))?;
             let args = conv::opt_string_vec(h, "args")?;
             let env = conv::opt_string_map(h, "env")?;
-            if args.is_empty() && env.is_empty() {
-                b = b.init(cmd);
-            } else {
-                b = b.init_with(cmd, move |i| i.args(args).envs(env));
-            }
+            b = b.init_with(cmd, move |i| i.args(args).envs(env));
         }
         if conv::opt_bool(opts, "ephemeral")? {
             b = b.ephemeral(true);
@@ -884,16 +874,12 @@ fn parse_rlimits(opts: RHash) -> Result<Vec<(RlimitResource, u64, u64)>, Error> 
 //--------------------------------------------------------------------------------------------------
 
 fn disk_format_from_str(s: &str) -> Result<DiskImageFormat, Error> {
-    use DiskImageFormat::*;
-    Ok(match s {
-        "qcow2" => Qcow2,
-        "raw" => Raw,
-        "vmdk" => Vmdk,
-        other => {
-            return Err(error::base_error(format!(
-                "unknown disk format {other:?} (expected qcow2/raw/vmdk)"
-            )))
-        }
+    // Delegate the qcow2/raw/vmdk mapping to the core's `FromStr` (single source
+    // of truth) but keep the friendlier, option-listing error message.
+    s.parse::<DiskImageFormat>().map_err(|_| {
+        error::base_error(format!(
+            "unknown disk format {s:?} (expected qcow2/raw/vmdk)"
+        ))
     })
 }
 
@@ -1096,10 +1082,9 @@ fn parse_secret(h: RHash) -> Result<SecretSpec, Error> {
             "secret requires at least one allowed host (:host, :hosts, or :host_patterns)",
         ));
     }
-    let on_violation = match conv::opt::<Value>(h, "on_violation")? {
-        Some(v) => Some(parse_violation_spec(v)?),
-        None => None,
-    };
+    let on_violation = conv::opt::<Value>(h, "on_violation")?
+        .map(parse_violation_spec)
+        .transpose()?;
     Ok(SecretSpec {
         env,
         value,

--- a/ext/microsandbox/src/snapshot.rs
+++ b/ext/microsandbox/src/snapshot.rs
@@ -5,7 +5,7 @@
 //! singleton functions returning plain Hashes/Arrays (shaped into value objects
 //! by the Ruby layer) — there is no long-lived handle to own.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use magnus::{function, prelude::*, Error, RArray, RHash, RModule, Ruby};
 use microsandbox::snapshot::{
@@ -22,6 +22,38 @@ fn format_str(format: SnapshotFormat) -> &'static str {
         SnapshotFormat::Raw => "raw",
         SnapshotFormat::Qcow2 => "qcow2",
     }
+}
+
+/// Parse a manifest's RFC 3339 `created_at` into epoch-ms (nil if unparseable).
+fn created_at_ms(rfc3339: &str) -> Option<i64> {
+    chrono::DateTime::parse_from_rfc3339(rfc3339)
+        .ok()
+        .map(|dt| dt.timestamp_millis())
+}
+
+/// Convert a fully-opened `Snapshot` into the `SnapshotInfo` Hash. Unlike a
+/// `SnapshotHandle` (a lightweight index row), an opened snapshot carries the
+/// full manifest, so this is the richest shape — `create`/`open`/`list_dir`
+/// and the `SandboxHandle#snapshot`/`#snapshot_to` shortcuts all funnel here.
+pub(crate) fn snapshot_to_hash(snap: &Snapshot) -> RHash {
+    let m = snap.manifest();
+    let hash = ruby().hash_new();
+    let _ = hash.aset("digest", snap.digest().to_string());
+    let _ = hash.aset("path", snap.path().to_string_lossy().into_owned());
+    let _ = hash.aset("size_bytes", snap.size_bytes());
+    let _ = hash.aset("image_ref", m.image.reference.clone());
+    let _ = hash.aset("image_manifest_digest", m.image.manifest_digest.clone());
+    let _ = hash.aset("format", format_str(m.format));
+    let _ = hash.aset("fstype", m.fstype.clone());
+    let _ = hash.aset("parent_digest", m.parent.clone());
+    let _ = hash.aset("created_at_ms", created_at_ms(&m.created_at));
+    let _ = hash.aset("source_sandbox", m.source_sandbox.clone());
+    let labels = ruby().hash_new();
+    for (k, v) in &m.labels {
+        let _ = labels.aset(k.as_str(), v.as_str());
+    }
+    let _ = hash.aset("labels", labels);
+    hash
 }
 
 /// Create a snapshot of a stopped sandbox. `opts`: name | path (destination),
@@ -48,11 +80,42 @@ fn create(source_sandbox: String, opts: RHash) -> Result<RHash, Error> {
     }
 
     let snap = block_on(b.create()).map_err(error::to_ruby)?;
-    let hash = ruby().hash_new();
-    hash.aset("digest", snap.digest().to_string())?;
-    hash.aset("path", snap.path().to_string_lossy().into_owned())?;
-    hash.aset("size_bytes", snap.size_bytes())?;
-    Ok(hash)
+    Ok(snapshot_to_hash(&snap))
+}
+
+/// Open an existing snapshot artifact by bare name or path. Cheap metadata
+/// validation only (does not read the upper file). Returns a full SnapshotInfo
+/// Hash — the only way to inspect an artifact addressed by path (`get`/`list`
+/// read the local index, which path-addressed artifacts are absent from).
+fn open(path_or_name: String) -> Result<RHash, Error> {
+    let snap = block_on(Snapshot::open(&path_or_name)).map_err(error::to_ruby)?;
+    Ok(snapshot_to_hash(&snap))
+}
+
+/// Walk `dir` and parse each subdirectory's `manifest.json` without touching the
+/// local index — for enumerating external/un-imported snapshot collections.
+fn list_dir(dir: String) -> Result<RArray, Error> {
+    let snaps = block_on(Snapshot::list_dir(Path::new(&dir))).map_err(error::to_ruby)?;
+    let arr = ruby().ary_new();
+    for snap in &snaps {
+        arr.push(snapshot_to_hash(snap))?;
+    }
+    Ok(arr)
+}
+
+/// Rebuild the local snapshot index from `dir` (defaults to the configured
+/// snapshots directory). Returns the number of indexed snapshots — the repair
+/// for index drift or out-of-band imports that `get`/`list` can't see.
+fn reindex(dir: Option<String>) -> Result<u64, Error> {
+    let dir: PathBuf = match dir {
+        Some(d) => PathBuf::from(d),
+        None => microsandbox::default_backend()
+            .as_local()
+            .map(|l| l.snapshots_dir())
+            .unwrap_or_else(|| PathBuf::from(".")),
+    };
+    let n = block_on(Snapshot::reindex(&dir)).map_err(error::to_ruby)?;
+    Ok(n as u64)
 }
 
 /// Metadata for one snapshot by name or digest.
@@ -148,8 +211,11 @@ fn verify_report_to_hash(report: &SnapshotVerifyReport) -> RHash {
 pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     let class = native.define_class("Snapshot", ruby.class_object())?;
     class.define_singleton_method("create", function!(create, 2))?;
+    class.define_singleton_method("open", function!(open, 1))?;
     class.define_singleton_method("get", function!(get, 1))?;
     class.define_singleton_method("list", function!(list, 0))?;
+    class.define_singleton_method("list_dir", function!(list_dir, 1))?;
+    class.define_singleton_method("reindex", function!(reindex, 1))?;
     class.define_singleton_method("remove", function!(remove, 2))?;
     class.define_singleton_method("verify", function!(verify, 1))?;
     class.define_singleton_method("export", function!(export, 3))?;

--- a/ext/microsandbox/src/volume.rs
+++ b/ext/microsandbox/src/volume.rs
@@ -3,12 +3,17 @@
 //! Mirrors `sdk/python/src/volume.rs`. Static async CRUD over the volume store;
 //! results are returned as plain Ruby Hashes/Arrays.
 
-use magnus::{function, prelude::*, Error, RArray, RHash, RModule, Ruby};
-use microsandbox::volume::VolumeHandle;
+use std::sync::Arc;
 
+use magnus::{function, method, prelude::*, Error, RArray, RHash, RModule, RString, Ruby};
+use microsandbox::volume::VolumeHandle;
+use microsandbox::Backend;
+
+use crate::backend::local_backend;
 use crate::conv;
 use crate::error;
 use crate::runtime::{block_on, ruby};
+use crate::sandbox::{fs_entry_to_hash, fs_metadata_to_hash};
 
 fn handle_to_hash(h: &VolumeHandle) -> RHash {
     let hash = ruby().hash_new();
@@ -92,11 +97,118 @@ fn remove(name: String) -> Result<(), Error> {
     block_on(microsandbox::Volume::remove(&name)).map_err(error::to_ruby)
 }
 
+/// A host-side filesystem view over a named volume — read/write its contents
+/// without a running sandbox. Mirrors the Python `VolumeFs` / Node `VolumeFs`.
+/// The core `VolumeFs<'a>` borrows the volume name, so (like the Python binding)
+/// each operation rebuilds it from the stored backend + name.
+#[magnus::wrap(class = "Microsandbox::Native::VolumeFs", free_immediately, size)]
+pub struct VolumeFs {
+    backend: Arc<dyn Backend>,
+    name: String,
+}
+
+impl VolumeFs {
+    /// Resolve the (local) backend once and bind it to `name`.
+    fn for_volume(name: String) -> Result<VolumeFs, Error> {
+        Ok(VolumeFs {
+            backend: local_backend().map_err(error::to_ruby)?,
+            name,
+        })
+    }
+
+    fn fs(&self) -> microsandbox::volume::VolumeFs<'_> {
+        microsandbox::volume::VolumeFs::with_backend(self.backend.clone(), &self.name)
+    }
+
+    fn read(&self, path: String) -> Result<RString, Error> {
+        let fs = self.fs();
+        let bytes = block_on(fs.read(&path)).map_err(error::to_ruby)?;
+        Ok(ruby().str_from_slice(bytes.as_ref()))
+    }
+
+    fn read_text(&self, path: String) -> Result<String, Error> {
+        let fs = self.fs();
+        block_on(fs.read_to_string(&path)).map_err(error::to_ruby)
+    }
+
+    fn write(&self, path: String, data: RString) -> Result<(), Error> {
+        // Copy the bytes out while the GVL is held (GC.compact could move them).
+        let bytes = unsafe { data.as_slice() }.to_vec();
+        let fs = self.fs();
+        block_on(fs.write(&path, &bytes)).map_err(error::to_ruby)
+    }
+
+    fn list(&self, path: String) -> Result<RArray, Error> {
+        let fs = self.fs();
+        let entries = block_on(fs.list(&path)).map_err(error::to_ruby)?;
+        let arr = ruby().ary_new();
+        for entry in &entries {
+            arr.push(fs_entry_to_hash(entry))?;
+        }
+        Ok(arr)
+    }
+
+    fn mkdir(&self, path: String) -> Result<(), Error> {
+        let fs = self.fs();
+        block_on(fs.mkdir(&path)).map_err(error::to_ruby)
+    }
+
+    fn remove_file(&self, path: String) -> Result<(), Error> {
+        let fs = self.fs();
+        block_on(fs.remove(&path)).map_err(error::to_ruby)
+    }
+
+    fn remove_dir(&self, path: String) -> Result<(), Error> {
+        let fs = self.fs();
+        block_on(fs.remove_dir(&path)).map_err(error::to_ruby)
+    }
+
+    fn exists(&self, path: String) -> Result<bool, Error> {
+        let fs = self.fs();
+        block_on(fs.exists(&path)).map_err(error::to_ruby)
+    }
+
+    fn copy(&self, from: String, to: String) -> Result<(), Error> {
+        let fs = self.fs();
+        block_on(fs.copy(&from, &to)).map_err(error::to_ruby)
+    }
+
+    fn rename(&self, from: String, to: String) -> Result<(), Error> {
+        let fs = self.fs();
+        block_on(fs.rename(&from, &to)).map_err(error::to_ruby)
+    }
+
+    fn stat(&self, path: String) -> Result<RHash, Error> {
+        let fs = self.fs();
+        let meta = block_on(fs.stat(&path)).map_err(error::to_ruby)?;
+        Ok(fs_metadata_to_hash(&meta))
+    }
+}
+
+/// Open a host-side filesystem view over a named volume.
+fn fs(name: String) -> Result<VolumeFs, Error> {
+    VolumeFs::for_volume(name)
+}
+
 pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     let class = native.define_class("Volume", ruby.class_object())?;
     class.define_singleton_method("create", function!(create, 2))?;
     class.define_singleton_method("get", function!(get, 1))?;
     class.define_singleton_method("list", function!(list, 0))?;
     class.define_singleton_method("remove", function!(remove, 1))?;
+    class.define_singleton_method("fs", function!(fs, 1))?;
+
+    let vfs = native.define_class("VolumeFs", ruby.class_object())?;
+    vfs.define_method("read", method!(VolumeFs::read, 1))?;
+    vfs.define_method("read_text", method!(VolumeFs::read_text, 1))?;
+    vfs.define_method("write", method!(VolumeFs::write, 2))?;
+    vfs.define_method("list", method!(VolumeFs::list, 1))?;
+    vfs.define_method("mkdir", method!(VolumeFs::mkdir, 1))?;
+    vfs.define_method("remove_file", method!(VolumeFs::remove_file, 1))?;
+    vfs.define_method("remove_dir", method!(VolumeFs::remove_dir, 1))?;
+    vfs.define_method("exists", method!(VolumeFs::exists, 1))?;
+    vfs.define_method("copy", method!(VolumeFs::copy, 2))?;
+    vfs.define_method("rename", method!(VolumeFs::rename, 2))?;
+    vfs.define_method("stat", method!(VolumeFs::stat, 1))?;
     Ok(())
 }

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -202,6 +202,19 @@ module Microsandbox
       Native.all_sandbox_metrics.transform_values { |m| Metrics.new(m) }
     end
 
+    # Coerce write data to a binary-safe String, or raise. Centralizes the
+    # contract every `#write` shares (FS/SftpClient/VolumeFs/ExecStdin/
+    # FsWriteSink): accept a String and reject anything else loudly, instead of
+    # silently writing its `to_s` form (e.g. a StringIO's inspect or "42").
+    # @api private
+    # @param data [Object]
+    # @return [String]
+    # @raise [TypeError] unless +data+ is a String
+    def coerce_write_bytes(data)
+      String.try_convert(data) or
+        raise TypeError, "data must be a String (got #{data.class})"
+    end
+
     private
 
     # Auto-provisioning is on by default; any non-empty, non-"0"/"false" value

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -69,6 +69,25 @@ module Microsandbox
       nil
     end
 
+    # Customizable install via the core `Setup` builder. Like {install} but with
+    # control over where and what to install — mirrors the Node `Setup` builder.
+    #
+    # @param base_dir [String, nil] install root (default `~/.microsandbox`)
+    # @param version [String, nil] pin the runtime version to download
+    # @param force [Boolean] re-download even if binaries already exist — the way
+    #   to repair a corrupt/incomplete `~/.microsandbox`
+    # @param skip_verify [Boolean] skip the post-install verification step
+    # @return [nil]
+    def setup(base_dir: nil, version: nil, force: false, skip_verify: false)
+      opts = {}
+      opts["base_dir"] = base_dir.to_s if base_dir
+      opts["version"] = version.to_s if version
+      opts["force"] = true if force
+      opts["skip_verify"] = true if skip_verify
+      Native.setup(opts)
+      nil
+    end
+
     # @return [Boolean] whether the runtime is installed and resolvable
     def installed?
       Native.installed?
@@ -111,7 +130,9 @@ module Microsandbox
     end
 
     # Override the `msb` runtime path (highest-priority SDK tier of the
-    # resolver, below only the `MSB_PATH` environment variable).
+    # resolver, below only the `MSB_PATH` environment variable). Process-level
+    # and set-once: a second call is silently ignored, and the `MSB_PATH`
+    # environment variable still wins. Mirrors {libkrunfw_path=}.
     # @param path [String]
     # @return [void]
     def runtime_path=(path)

--- a/lib/microsandbox/agent.rb
+++ b/lib/microsandbox/agent.rb
@@ -100,7 +100,9 @@ module Microsandbox
       # Connect to a running sandbox by name (max 128 UTF-8 bytes). With a block,
       # the client is yielded and closed when the block returns.
       # @param name [String]
-      # @param timeout [Numeric, nil] handshake timeout in seconds (default ~10s)
+      # @param timeout [Numeric, nil] handshake timeout in seconds. nil (the
+      #   default) uses the core default (~10s); 0 fails fast (an immediate
+      #   deadline); a negative or non-finite value raises {Error}.
       # @yieldparam client [AgentClient]
       # @return [AgentClient, Object]
       def connect_sandbox(name, timeout: nil, &block)

--- a/lib/microsandbox/exec_handle.rb
+++ b/lib/microsandbox/exec_handle.rb
@@ -20,9 +20,10 @@ module Microsandbox
       @data = event["data"]
     end
 
-    # @return [String, nil] {#data} decoded as UTF-8 (lenient)
+    # @return [String, nil] {#data} decoded as UTF-8 (lossy — invalid byte
+    #   sequences are replaced with U+FFFD, so the result is always valid UTF-8)
     def text
-      @data&.dup&.force_encoding(Encoding::UTF_8)
+      @data&.dup&.force_encoding(Encoding::UTF_8)&.scrub
     end
 
     def started? = @type == :started
@@ -62,9 +63,13 @@ module Microsandbox
     end
 
     # Write data to the process stdin.
+    # @param data [String] raw bytes to write (binary-safe)
+    # @raise [TypeError] if +data+ is not a String
     # @return [self]
     def write(data)
-      @native.write(data.to_s)
+      bytes = String.try_convert(data) or
+        raise TypeError, "data must be a String (got #{data.class})"
+      @native.write(bytes)
       self
     end
 

--- a/lib/microsandbox/exec_handle.rb
+++ b/lib/microsandbox/exec_handle.rb
@@ -67,8 +67,7 @@ module Microsandbox
     # @raise [TypeError] if +data+ is not a String
     # @return [self]
     def write(data)
-      bytes = String.try_convert(data) or
-        raise TypeError, "data must be a String (got #{data.class})"
+      bytes = Microsandbox.coerce_write_bytes(data)
       @native.write(bytes)
       self
     end

--- a/lib/microsandbox/exec_output.rb
+++ b/lib/microsandbox/exec_output.rb
@@ -3,9 +3,9 @@
 module Microsandbox
   # The result of a completed `exec`/`shell` call.
   #
-  # `stdout`/`stderr` return the captured bytes decoded as UTF-8 (lenient — the
-  # bytes are preserved even if they are not valid UTF-8); use `stdout_bytes`/
-  # `stderr_bytes` for the raw ASCII-8BIT bytes.
+  # `stdout`/`stderr` return the captured bytes decoded as UTF-8 (lossy —
+  # invalid byte sequences are replaced with U+FFFD, so the result is always
+  # valid UTF-8); use `stdout_bytes`/`stderr_bytes` for the raw ASCII-8BIT bytes.
   class ExecOutput
     # @return [Integer] the process exit code
     attr_reader :exit_code
@@ -32,14 +32,14 @@ module Microsandbox
       !@success
     end
 
-    # @return [String] stdout decoded as UTF-8
+    # @return [String] stdout decoded as UTF-8 (lossy)
     def stdout
-      @stdout ||= @stdout_bytes.dup.force_encoding(Encoding::UTF_8)
+      @stdout ||= @stdout_bytes.dup.force_encoding(Encoding::UTF_8).scrub
     end
 
-    # @return [String] stderr decoded as UTF-8
+    # @return [String] stderr decoded as UTF-8 (lossy)
     def stderr
-      @stderr ||= @stderr_bytes.dup.force_encoding(Encoding::UTF_8)
+      @stderr ||= @stderr_bytes.dup.force_encoding(Encoding::UTF_8).scrub
     end
 
     # @return [String] stdout decoded as UTF-8 (alias for {#stdout})

--- a/lib/microsandbox/fs.rb
+++ b/lib/microsandbox/fs.rb
@@ -96,10 +96,15 @@ module Microsandbox
       @native.fs_read_text(path.to_s)
     end
 
-    # Write data (a String) to a file, creating or truncating it.
+    # Write data to a file, creating or truncating it.
+    # @param data [String] raw bytes to write (binary-safe; ASCII-8BIT is fine)
+    # @raise [TypeError] if +data+ is not a String (rather than silently writing
+    #   its +to_s+ form, e.g. the inspect string of a StringIO or "42")
     # @return [nil]
     def write(path, data)
-      @native.fs_write(path.to_s, data.to_s)
+      bytes = String.try_convert(data) or
+        raise TypeError, "data must be a String (got #{data.class})"
+      @native.fs_write(path.to_s, bytes)
       nil
     end
 
@@ -166,6 +171,85 @@ module Microsandbox
     # @return [nil]
     def copy_to_host(guest_path, host_path)
       @native.fs_copy_to_host(guest_path.to_s, host_path.to_s)
+      nil
+    end
+
+    # Open a streaming reader over a guest file — for files too large to read
+    # into memory at once (unlike {#read}, which buffers the whole file).
+    # @return [FsReadStream] an {Enumerable} of byte chunks (ASCII-8BIT)
+    def read_stream(path)
+      FsReadStream.new(@native.fs_read_stream(path.to_s))
+    end
+
+    # Open a streaming writer to a guest file. With a block, the sink is yielded
+    # and closed (flushed) when the block returns.
+    # @yieldparam sink [FsWriteSink]
+    # @return [FsWriteSink, Object]
+    def write_stream(path)
+      sink = FsWriteSink.new(@native.fs_write_stream(path.to_s))
+      return sink unless block_given?
+
+      begin
+        yield sink
+      ensure
+        sink.close
+      end
+    end
+  end
+
+  # A streaming reader over a guest file, from {FS#read_stream}. Iterate it (it
+  # is {Enumerable}) to consume byte chunks (ASCII-8BIT) as they arrive, or call
+  # {#read} to drain it into one String.
+  class FsReadStream
+    include Enumerable
+
+    def initialize(native)
+      @native = native
+    end
+
+    # Yield each chunk of bytes until the stream ends. Returns an Enumerator when
+    # called without a block.
+    # @yieldparam chunk [String] raw bytes (ASCII-8BIT)
+    # @return [self, Enumerator]
+    def each
+      return enum_for(:each) unless block_given?
+
+      while (chunk = @native.recv)
+        yield chunk
+      end
+      self
+    end
+
+    # Drain the stream into a single byte String.
+    # @return [String] raw bytes (ASCII-8BIT)
+    def read
+      buffer = +"".b
+      each { |chunk| buffer << chunk }
+      buffer
+    end
+  end
+
+  # A streaming writer to a guest file, from {FS#write_stream}.
+  class FsWriteSink
+    def initialize(native)
+      @native = native
+    end
+
+    # Write a chunk of bytes.
+    # @param data [String] raw bytes (binary-safe)
+    # @raise [TypeError] if +data+ is not a String
+    # @return [self]
+    def write(data)
+      bytes = String.try_convert(data) or
+        raise TypeError, "data must be a String (got #{data.class})"
+      @native.write(bytes)
+      self
+    end
+
+    # Flush and close the sink. Idempotent.
+    # @return [nil]
+    def close
+      @native.close
       nil
     end
   end

--- a/lib/microsandbox/fs.rb
+++ b/lib/microsandbox/fs.rb
@@ -102,8 +102,7 @@ module Microsandbox
     #   its +to_s+ form, e.g. the inspect string of a StringIO or "42")
     # @return [nil]
     def write(path, data)
-      bytes = String.try_convert(data) or
-        raise TypeError, "data must be a String (got #{data.class})"
+      bytes = Microsandbox.coerce_write_bytes(data)
       @native.fs_write(path.to_s, bytes)
       nil
     end
@@ -240,8 +239,7 @@ module Microsandbox
     # @raise [TypeError] if +data+ is not a String
     # @return [self]
     def write(data)
-      bytes = String.try_convert(data) or
-        raise TypeError, "data must be a String (got #{data.class})"
+      bytes = Microsandbox.coerce_write_bytes(data)
       @native.write(bytes)
       self
     end

--- a/lib/microsandbox/image.rb
+++ b/lib/microsandbox/image.rb
@@ -35,7 +35,8 @@ module Microsandbox
   class ImageDetail
     # @return [ImageInfo]
     attr_reader :handle
-    # @return [Hash, nil] OCI config (digest, env, cmd, entrypoint, working_dir, user, stop_signal)
+    # @return [Hash, nil] OCI config (digest, env, cmd, entrypoint, working_dir,
+    #   user, labels, stop_signal). `labels` is a Hash (or nil) of OCI config labels.
     attr_reader :config
     # @return [Array<Hash>] layer descriptors
     attr_reader :layers

--- a/lib/microsandbox/log_entry.rb
+++ b/lib/microsandbox/log_entry.rb
@@ -25,9 +25,11 @@ module Microsandbox
       Time.at(@timestamp_ms / 1000.0)
     end
 
-    # @return [String] the captured bytes decoded as UTF-8 (lenient)
+    # @return [String] the captured bytes decoded as UTF-8 (lossy — invalid byte
+    #   sequences are replaced with U+FFFD, so the result is always valid UTF-8;
+    #   use {#data} for the raw ASCII-8BIT bytes)
     def text
-      @data.dup.force_encoding(Encoding::UTF_8)
+      @data.dup.force_encoding(Encoding::UTF_8).scrub
     end
 
     def inspect

--- a/lib/microsandbox/metrics.rb
+++ b/lib/microsandbox/metrics.rb
@@ -24,6 +24,12 @@ module Microsandbox
     attr_reader :net_rx_bytes
     # @return [Integer] cumulative bytes transmitted over the network
     attr_reader :net_tx_bytes
+    # @return [Integer, nil] bytes used in the writable OCI upper layer
+    attr_reader :upper_used_bytes
+    # @return [Integer, nil] bytes free in the writable OCI upper layer
+    attr_reader :upper_free_bytes
+    # @return [Integer, nil] host bytes allocated to back the upper layer
+    attr_reader :upper_host_allocated_bytes
     # @return [Float] sandbox uptime in seconds
     attr_reader :uptime_secs
 
@@ -38,6 +44,9 @@ module Microsandbox
       @disk_write_bytes = data["disk_write_bytes"]
       @net_rx_bytes = data["net_rx_bytes"]
       @net_tx_bytes = data["net_tx_bytes"]
+      @upper_used_bytes = data["upper_used_bytes"]
+      @upper_free_bytes = data["upper_free_bytes"]
+      @upper_host_allocated_bytes = data["upper_host_allocated_bytes"]
       @uptime_secs = data["uptime_secs"]
       @timestamp_ms = data["timestamp_ms"]
     end

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -198,6 +198,11 @@ module Microsandbox
   #     sb.stop
   #   end
   class Sandbox
+    # Recognized disk-image rootfs extensions, mirroring the upstream
+    # `DiskImageFormat::from_extension`/`FromStr` set. Used by {disk_image_rootfs?}
+    # to gate the `fstype:`-vs-OCI check; keep in sync on a runtime-tag bump.
+    DISK_IMAGE_EXTENSIONS = %w[raw qcow2 vmdk].freeze
+
     class << self
       # Create and boot a sandbox.
       #
@@ -575,12 +580,23 @@ module Microsandbox
             normalize_violation_action(spec)
           end
         when Hash
+          hosts = Array(spec[:passthrough_hosts] || spec["passthrough_hosts"]).map(&:to_s)
+          patterns = Array(spec[:passthrough_host_patterns] || spec["passthrough_host_patterns"]).map(&:to_s)
+          all = !!(spec[:passthrough_all_hosts] || spec["passthrough_all_hosts"])
+          # An empty passthrough (no hosts, no patterns, not all) passes nothing
+          # through — a no-op the native builder silently degrades to its default
+          # action. Reject it with actionable guidance rather than accept a spec
+          # that does nothing the caller intended.
+          if hosts.empty? && patterns.empty? && !all
+            raise ArgumentError,
+              "passthrough on_violation needs at least one of :passthrough_hosts, " \
+              ":passthrough_host_patterns, or :passthrough_all_hosts (use \"block\" " \
+              "if blocking is the intent)"
+          end
           out = {}
-          ph = spec[:passthrough_hosts] || spec["passthrough_hosts"]
-          out["passthrough_hosts"] = Array(ph).map(&:to_s) if ph
-          pp = spec[:passthrough_host_patterns] || spec["passthrough_host_patterns"]
-          out["passthrough_host_patterns"] = Array(pp).map(&:to_s) if pp
-          out["passthrough_all_hosts"] = true if spec[:passthrough_all_hosts] || spec["passthrough_all_hosts"]
+          out["passthrough_hosts"] = hosts unless hosts.empty?
+          out["passthrough_host_patterns"] = patterns unless patterns.empty?
+          out["passthrough_all_hosts"] = true if all
           out
         else
           raise ArgumentError, "on_violation must be a String or a Hash (got #{spec.inspect})"
@@ -644,13 +660,17 @@ module Microsandbox
 
       # True when `image` names a disk-image rootfs the way the core auto-detects
       # one: a local-path-looking string (`/`, `./`, `../` prefix) whose extension
-      # is a recognized disk-image format. Mirrors the upstream
-      # `looks_like_local_path_text` + `DiskImageFormat::from_extension` so a bare
-      # OCI ref or a bind directory is not mistaken for a disk image.
+      # is a recognized disk-image format. This re-implements two upstream
+      # heuristics the native layer can't reach from here (the `microsandbox`
+      # crate re-exports neither): `looks_like_local_path_text`
+      # (microsandbox/crates/utils/lib/lib.rs) and `DiskImageFormat::from_extension`
+      # / `FromStr` (microsandbox/packages/microsandbox-types/rust/lib/domain.rs,
+      # qcow2/raw/vmdk). Keep both in sync when bumping the pinned runtime tag —
+      # the "disk_image_rootfs? contract" examples in sandbox_spec.rb pin it.
       def disk_image_rootfs?(image)
         s = image.to_s
         return false unless s.start_with?("/", "./", "../")
-        %w[raw qcow2 vmdk].include?(File.extname(s).delete_prefix(".").downcase)
+        DISK_IMAGE_EXTENSIONS.include?(File.extname(s).delete_prefix(".").downcase)
       end
 
       # Normalize volumes (Hash of guest_path => spec) into per-mount string-keyed

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -280,15 +280,16 @@ module Microsandbox
       #   `placeholder:`, `require_tls:`, injection toggles `inject_headers:` /
       #   `inject_basic_auth:` / `inject_query:` / `inject_body:`, and `on_violation:`.
       # @param on_secret_violation [String, Symbol, Hash, nil] sandbox-wide
-      #   secret-leak policy: "block", "block_and_log", "block_and_terminate", or a
-      #   Hash `{ passthrough_hosts:, passthrough_host_patterns:, passthrough_all_hosts: }`
+      #   secret-leak policy: "block", "block_and_log", "block_and_terminate",
+      #   "passthrough" (passthrough-all-hosts), or a Hash
+      #   `{ passthrough_hosts:, passthrough_host_patterns:, passthrough_all_hosts: }`
       # @param detached [Boolean] keep running after this process exits
       # @param replace [Boolean] replace an existing sandbox with the same name
       # @param replace_with_timeout [Numeric, nil] replace, waiting up to N seconds
       # @yieldparam sandbox [Sandbox]
       # @return [Sandbox, Object] the sandbox, or the block's return value
       def create(name, **kwargs, &block)
-        opts = build_create_opts(name, **kwargs)
+        opts = build_create_opts(**kwargs)
         sandbox = new(Native::Sandbox.create(name.to_s, opts))
         return sandbox unless block_given?
 
@@ -310,14 +311,22 @@ module Microsandbox
       # `create_with_progress` / Node `createWithPullProgress`.
       # @return [PullSession]
       def create_with_progress(name, **kwargs)
-        opts = build_create_opts(name, **kwargs)
+        # Unlike {create}, this has no block form: the booted sandbox is reached
+        # via {PullSession#sandbox} (after iterating progress) and stopped by the
+        # caller. A block would be silently dropped — and the sandbox leaked — so
+        # reject it loudly rather than let a `create`-style block call misfire.
+        if block_given?
+          raise ArgumentError,
+            "create_with_progress takes no block; iterate the returned PullSession " \
+            "for progress, then call #sandbox and stop it when done"
+        end
+        opts = build_create_opts(**kwargs)
         PullSession.new(Native::Sandbox.create_with_progress(name.to_s, opts))
       end
 
       # @api private
       # Shared keyword-option builder for {create}/{create_with_progress}.
-      def build_create_opts(name,
-        image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
+      def build_create_opts(image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
         shell: nil, user: nil, hostname: nil, labels: nil, scripts: nil,
         entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
         dns: nil, tls: nil, ipv4_pool: nil, ipv6_pool: nil,
@@ -372,7 +381,7 @@ module Microsandbox
         opts["ipv4_pool"] = ipv4_pool.to_s if ipv4_pool
         opts["ipv6_pool"] = ipv6_pool.to_s if ipv6_pool
         opts["max_connections"] = Integer(max_connections) if max_connections
-        opts["trust_host_cas"] = (trust_host_cas ? true : false) unless trust_host_cas.nil?
+        set_bool(opts, "trust_host_cas", trust_host_cas)
         opts["log_level"] = log_level.to_s if log_level
         opts["quiet_logs"] = true if quiet_logs
         opts["security"] = security.to_s if security
@@ -527,8 +536,7 @@ module Microsandbox
         # Booleans must honor an explicit `false` (to disable a default-on toggle),
         # so probe key presence rather than truthiness.
         %i[require_tls inject_headers inject_basic_auth inject_query inject_body].each do |k|
-          v = fetch_opt(spec, k)
-          out[k.to_s] = (v ? true : false) unless v.nil?
+          set_bool(out, k.to_s, fetch_opt(spec, k))
         end
         ov = spec[:on_violation] || spec["on_violation"]
         out["on_violation"] = normalize_violation(ov) if ov
@@ -542,6 +550,15 @@ module Microsandbox
         spec[sym.to_s]
       end
 
+      # Write a boolean option onto `out`, honoring an explicit `false` (to
+      # disable a default-on toggle) while leaving an absent (`nil`) value unset.
+      # Centralizes the "probe presence, not truthiness" rule for all the boolean
+      # toggles (require_tls/inject_*/verify_upstream/block_quic/rebind_protection/
+      # trust_host_cas) so a future toggle can't silently drop a `false`.
+      def set_bool(out, key, value)
+        out[key] = (value ? true : false) unless value.nil?
+      end
+
       # Normalize an `on_violation`/`on_secret_violation` spec for the native
       # layer: a String/Symbol block variant ("block"/"block_and_log"/
       # "block_and_terminate"), or a Hash describing a passthrough action
@@ -549,7 +566,14 @@ module Microsandbox
       def normalize_violation(spec)
         case spec
         when String, Symbol
-          normalize_violation_action(spec)
+          # The bare "passthrough" string maps to passthrough-all-hosts, matching
+          # the Python/Node SDKs (so a string-form policy copied from another SDK
+          # ports over unchanged); block variants stay as their action string.
+          if spec.to_s.strip.downcase.tr("-", "_") == "passthrough"
+            {"passthrough_all_hosts" => true}
+          else
+            normalize_violation_action(spec)
+          end
         when Hash
           out = {}
           ph = spec[:passthrough_hosts] || spec["passthrough_hosts"]
@@ -574,7 +598,7 @@ module Microsandbox
           raise ArgumentError,
             "unknown on_violation #{spec.inspect} (expected block, " \
             "block_and_log/block-and-log, block_and_terminate/block-and-terminate, " \
-            "or a Hash with :passthrough_hosts/:passthrough_host_patterns/:passthrough_all_hosts)"
+            "passthrough, or a Hash with :passthrough_hosts/:passthrough_host_patterns/:passthrough_all_hosts)"
         end
         action
       end
@@ -585,8 +609,7 @@ module Microsandbox
         out = {}
         ns = dns[:nameservers] || dns["nameservers"]
         out["nameservers"] = Array(ns).map(&:to_s) if ns
-        rp = fetch_opt(dns, :rebind_protection)
-        out["rebind_protection"] = (rp ? true : false) unless rp.nil?
+        set_bool(out, "rebind_protection", fetch_opt(dns, :rebind_protection))
         qt = dns[:query_timeout_ms] || dns["query_timeout_ms"]
         out["query_timeout_ms"] = Integer(qt) if qt
         out
@@ -598,12 +621,10 @@ module Microsandbox
         out = {}
         bypass = tls[:bypass] || tls["bypass"]
         out["bypass"] = Array(bypass).map(&:to_s) if bypass
-        vu = fetch_opt(tls, :verify_upstream)
-        out["verify_upstream"] = (vu ? true : false) unless vu.nil?
+        set_bool(out, "verify_upstream", fetch_opt(tls, :verify_upstream))
         ports = tls[:intercepted_ports] || tls["intercepted_ports"]
         out["intercepted_ports"] = Array(ports).map { |p| Integer(p) } if ports
-        bq = fetch_opt(tls, :block_quic)
-        out["block_quic"] = (bq ? true : false) unless bq.nil?
+        set_bool(out, "block_quic", fetch_opt(tls, :block_quic))
         %i[upstream_ca_cert intercept_ca_cert intercept_ca_key].each do |k|
           v = tls[k] || tls[k.to_s]
           out[k.to_s] = v.to_s if v
@@ -709,13 +730,18 @@ module Microsandbox
         Array(spec[:options] || spec["options"]).each do |opt|
           case opt.to_s
           when "ro", "readonly" then mount["readonly"] = true
+          # "rw" is read-write, the default — accepted as a no-op (the pre-0.7.0
+          # native validator and the upstream wire form both treat it that way).
+          # Dropping it would break a previously-valid `options:` array, which the
+          # CHANGELOG promises is still honored.
+          when "rw" then nil
           when "noexec" then mount["noexec"] = true
           when "nosuid" then mount["nosuid"] = true
           when "nodev" then mount["nodev"] = true
           else
             raise ArgumentError,
               "unknown mount option #{opt.inspect} in options: — use " \
-              "ro/readonly, noexec, nosuid, or nodev (or the matching boolean keys)"
+              "ro/readonly, rw, noexec, nosuid, or nodev (or the matching boolean keys)"
           end
         end
       end

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "json"
+
 module Microsandbox
   # A controllable handle to a sandbox, returned by {Sandbox.get}, {Sandbox.list},
   # and {Sandbox.list_with}. Carries a metadata snapshot (captured when fetched)
@@ -99,6 +101,37 @@ module Microsandbox
       SandboxStopResult.new(@native.wait_until_stopped)
     end
 
+    # The sandbox's stored configuration as a raw JSON string (synchronous — the
+    # handle already carries it, no runtime round-trip). Mirrors the Python/Node
+    # `config_json`.
+    # @return [String]
+    def config_json
+      @native.config_json
+    end
+
+    # The sandbox's stored configuration, parsed into a Hash (image, cpus,
+    # memory, mounts, …). Mirrors the Python/Node `config`.
+    # @return [Hash]
+    def config
+      JSON.parse(@native.config_json)
+    end
+
+    # Snapshot this (stopped) sandbox under a bare name, resolved under the
+    # snapshots dir. Convenience equivalent of
+    # `Snapshot.create(name, name: <snapshot-name>)` addressed by this handle.
+    # @param name [String] destination snapshot name
+    # @return [SnapshotInfo]
+    def snapshot(name)
+      SnapshotInfo.new(@native.snapshot(name.to_s))
+    end
+
+    # Snapshot this (stopped) sandbox to an explicit filesystem path.
+    # @param path [String] destination directory
+    # @return [SnapshotInfo]
+    def snapshot_to(path)
+      SnapshotInfo.new(@native.snapshot_to(path.to_s))
+    end
+
     def inspect
       "#<Microsandbox::SandboxHandle name=#{name.inspect} status=#{status}>"
     end
@@ -186,12 +219,40 @@ module Microsandbox
       # @param entrypoint [Array<String>, nil] image entrypoint override
       # @param ports [Hash, nil] host_port => guest_port TCP publications
       # @param ports_udp [Hash, nil] host_port => guest_port UDP publications
+      # @param volumes [Hash, nil] guest_path => mount spec. Each value is a host
+      #   path String (a bind mount), or a Hash: `{ bind: "/host" }`,
+      #   `{ named: "vol" }`, `{ tmpfs: true, size_mib: 64 }`, or
+      #   `{ disk: "/img.raw", format: "raw", fstype: "ext4" }`. Any mount may add
+      #   flags `ro:`/`readonly:`, `noexec:`, `nosuid:`, `nodev:`, and (bind/named
+      #   only) `stat_virtualization:` (:strict/:relaxed/:off) and
+      #   `host_permissions:` (:private/:mirror).
       # @param network [String, Symbol, NetworkPolicy, Hash, nil] network policy.
       #   A preset name ("public_only" (default), "none", "allow_all",
       #   "non_local"), a {NetworkPolicy} (e.g. {NetworkPolicy.custom}), or a Hash
       #   describing a custom policy (`default_egress:`, `default_ingress:`,
       #   `rules:`, `deny_domains:`, `deny_domain_suffixes:`). See {NetworkPolicy}
       #   and {Rule}.
+      # @param dns [Hash, nil] custom DNS: `{ nameservers: [...],
+      #   rebind_protection: true, query_timeout_ms: 2000 }`
+      # @param tls [Hash, nil] TLS-interception tuning: `{ bypass: [...patterns],
+      #   verify_upstream: true, intercepted_ports: [443, 8443], block_quic: true,
+      #   upstream_ca_cert:, intercept_ca_cert:, intercept_ca_key: }` (paths). Use
+      #   this to inject `secrets:` on non-443 ports or to trust a private CA.
+      # @param ipv4_pool [String, nil] guest IPv4 address pool CIDR (e.g. "10.0.0.0/24")
+      # @param ipv6_pool [String, nil] guest IPv6 address pool CIDR
+      # @param max_connections [Integer, nil] cap on concurrent proxied connections
+      # @param trust_host_cas [Boolean, nil] trust the host's CA bundle for upstream TLS
+      # @param from_snapshot [String, nil] boot from a snapshot name or digest
+      #   instead of an image (mutually exclusive with `image:`)
+      # @param fstype [String, nil] inner filesystem type (e.g. "ext4") when
+      #   `image:` is a disk-image rootfs path whose filesystem can't be
+      #   auto-probed; ignored for OCI images
+      # @param init [String, Hash, nil] hand guest PID 1 to an init system: a
+      #   command path (e.g. "/lib/systemd/systemd" or "auto"), or a Hash
+      #   `{ cmd:, args:, env: }` when the init binary takes argv/extra env
+      # @param ephemeral [Boolean] auto-remove the sandbox's stored state (DB
+      #   row, disk, logs, captured output) once it reaches a terminal state
+      #   (default: state is persisted until {.remove})
       # @param patches [Array<Hash>, nil] rootfs patches applied before boot, each
       #   built with the {Patch} factory (e.g. `Patch.text(...)`, `Patch.mkdir(...)`).
       #   Not compatible with disk-image roots.
@@ -212,23 +273,61 @@ module Microsandbox
       #   instead of HTTPS (for local/self-hosted registries)
       # @param registry_ca_certs [String, Array<String>, nil] extra PEM-encoded CA
       #   root certificate(s) to trust (for a registry with a private CA)
-      # @param secrets [Array<Hash>, nil] placeholder-protected secrets, each
-      #   { env:, value:, host: } — the value is substituted by the TLS proxy only
-      #   for the allowed host (auto-enables TLS interception)
+      # @param secrets [Array<Hash>, nil] placeholder-protected secrets injected by
+      #   the TLS proxy (auto-enables TLS interception). Each Hash needs `env:` and
+      #   `value:` plus an allow list — `host:` (single), `hosts:` (Array), and/or
+      #   `host_patterns:` (wildcards like "*.stripe.com"). Optional per-secret:
+      #   `placeholder:`, `require_tls:`, injection toggles `inject_headers:` /
+      #   `inject_basic_auth:` / `inject_query:` / `inject_body:`, and `on_violation:`.
+      # @param on_secret_violation [String, Symbol, Hash, nil] sandbox-wide
+      #   secret-leak policy: "block", "block_and_log", "block_and_terminate", or a
+      #   Hash `{ passthrough_hosts:, passthrough_host_patterns:, passthrough_all_hosts: }`
       # @param detached [Boolean] keep running after this process exits
       # @param replace [Boolean] replace an existing sandbox with the same name
       # @param replace_with_timeout [Numeric, nil] replace, waiting up to N seconds
       # @yieldparam sandbox [Sandbox]
       # @return [Sandbox, Object] the sandbox, or the block's return value
-      def create(name,
+      def create(name, **kwargs, &block)
+        opts = build_create_opts(name, **kwargs)
+        sandbox = new(Native::Sandbox.create(name.to_s, opts))
+        return sandbox unless block_given?
+
+        begin
+          yield sandbox
+        ensure
+          begin
+            sandbox.stop
+          rescue Microsandbox::Error
+            # best-effort cleanup; ignore stop failures during teardown
+          end
+        end
+      end
+
+      # Create a sandbox while streaming image-pull progress. Accepts the same
+      # options as {create}; returns a {PullSession} — iterate it (an
+      # {Enumerable} of progress-event Hashes, each with a "kind"), then call
+      # {PullSession#sandbox} for the booted {Sandbox}. Mirrors the Python
+      # `create_with_progress` / Node `createWithPullProgress`.
+      # @return [PullSession]
+      def create_with_progress(name, **kwargs)
+        opts = build_create_opts(name, **kwargs)
+        PullSession.new(Native::Sandbox.create_with_progress(name.to_s, opts))
+      end
+
+      # @api private
+      # Shared keyword-option builder for {create}/{create_with_progress}.
+      def build_create_opts(name,
         image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
         shell: nil, user: nil, hostname: nil, labels: nil, scripts: nil,
         entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
+        dns: nil, tls: nil, ipv4_pool: nil, ipv6_pool: nil,
+        max_connections: nil, trust_host_cas: nil,
         patches: nil,
-        from_snapshot: nil, log_level: nil, quiet_logs: false, security: nil,
+        from_snapshot: nil, fstype: nil, init: nil, ephemeral: false,
+        log_level: nil, quiet_logs: false, security: nil,
         oci_upper_size: nil, max_duration: nil, idle_timeout: nil, rlimits: nil,
         pull_policy: nil, registry_auth: nil, registry_insecure: false,
-        registry_ca_certs: nil, secrets: nil,
+        registry_ca_certs: nil, secrets: nil, on_secret_violation: nil,
         detached: false, replace: false, replace_with_timeout: nil)
         # A sandbox boots from exactly one rootfs source. The core would reject a
         # contradictory pair, but only after a runtime round-trip; fail fast and
@@ -240,6 +339,7 @@ module Microsandbox
         opts = {}
         opts["image"] = image.to_s if image
         opts["from_snapshot"] = from_snapshot.to_s if from_snapshot
+        opts["fstype"] = fstype.to_s if fstype
         opts["cpus"] = Integer(cpus) if cpus
         opts["memory"] = Integer(memory) if memory
         opts["workdir"] = workdir.to_s if workdir
@@ -255,6 +355,12 @@ module Microsandbox
         opts["volumes"] = normalize_volumes(volumes) if volumes
         opts["patches"] = normalize_patches(patches) if patches
         apply_network_opts(opts, network) unless network.nil?
+        opts["dns"] = normalize_dns(dns) if dns
+        opts["tls"] = normalize_tls(tls) if tls
+        opts["ipv4_pool"] = ipv4_pool.to_s if ipv4_pool
+        opts["ipv6_pool"] = ipv6_pool.to_s if ipv6_pool
+        opts["max_connections"] = Integer(max_connections) if max_connections
+        opts["trust_host_cas"] = (trust_host_cas ? true : false) unless trust_host_cas.nil?
         opts["log_level"] = log_level.to_s if log_level
         opts["quiet_logs"] = true if quiet_logs
         opts["security"] = security.to_s if security
@@ -265,6 +371,9 @@ module Microsandbox
         opts["pull_policy"] = pull_policy.to_s if pull_policy
         apply_registry_opts(opts, registry_auth, registry_insecure, registry_ca_certs)
         opts["secrets"] = normalize_secrets(secrets) if secrets
+        opts["on_secret_violation"] = normalize_violation(on_secret_violation) if on_secret_violation
+        opts["init"] = normalize_init(init) unless init.nil?
+        opts["ephemeral"] = true if ephemeral
         opts["detached"] = true if detached
         if replace_with_timeout
           opts["replace_with_timeout"] = coerce_duration(replace_with_timeout, "replace_with_timeout")
@@ -272,18 +381,7 @@ module Microsandbox
           opts["replace"] = true
         end
 
-        sandbox = new(Native::Sandbox.create(name.to_s, opts))
-        return sandbox unless block_given?
-
-        begin
-          yield sandbox
-        ensure
-          begin
-            sandbox.stop
-          rescue Microsandbox::Error
-            # best-effort cleanup; ignore stop failures during teardown
-          end
-        end
+        opts
       end
 
       # Restart a previously-defined sandbox by name.
@@ -343,6 +441,28 @@ module Microsandbox
         ports.each_with_object({}) { |(k, v), acc| acc[Integer(k)] = Integer(v) }
       end
 
+      # Normalize the `init:` option into the native { "cmd" =>, "args" =>,
+      # "env" => } shape. Accepts a bare command (String/Symbol — an init binary
+      # path or the literal "auto") or a Hash { cmd:, args:, env: }, mirroring the
+      # Python InitConfig / Node init options.
+      def normalize_init(init)
+        case init
+        when String, Symbol
+          {"cmd" => init.to_s}
+        when Hash
+          cmd = init[:cmd] || init["cmd"]
+          raise ArgumentError, "init: requires a :cmd" unless cmd
+          spec = {"cmd" => cmd.to_s}
+          args = init[:args] || init["args"]
+          spec["args"] = Array(args).map(&:to_s) if args
+          env = init[:env] || init["env"]
+          spec["env"] = stringify(env) if env
+          spec
+        else
+          raise ArgumentError, "init: must be a String command or a Hash {cmd:, args:, env:}"
+        end
+      end
+
       # Flatten the registry options into the native layer's `registry_*` keys.
       # `auth` is a Hash { username:, password: } (string or symbol keys); both
       # are required when given. `ca_certs` accepts one PEM string or an Array.
@@ -362,18 +482,105 @@ module Microsandbox
         opts["registry_ca_certs"] = Array(ca_certs).map(&:to_s) if ca_certs
       end
 
-      # Normalize secrets into [env, value, host] triples for the native layer.
-      # Each entry is a Hash { env:, value:, host: } (string or symbol keys).
+      # Normalize secrets into per-secret string-keyed Hashes for the native
+      # layer. Each entry is a Hash (string or symbol keys); required :env and
+      # :value, plus at least one allowed host via :host (single), :hosts (Array),
+      # or :host_patterns (Array of wildcards like "*.stripe.com"). Optional:
+      # :placeholder, :require_tls, the injection toggles :inject_headers /
+      # :inject_basic_auth / :inject_query / :inject_body, and :on_violation (see
+      # {#normalize_violation}).
       def normalize_secrets(secrets)
-        Array(secrets).map do |spec|
-          env = spec[:env] || spec["env"]
-          value = spec[:value] || spec["value"]
-          host = spec[:host] || spec["host"]
-          unless env && value && host
-            raise ArgumentError, "secret spec needs :env, :value, and :host (got #{spec.inspect})"
-          end
-          [env.to_s, value.to_s, host.to_s]
+        Array(secrets).map { |spec| normalize_secret(spec) }
+      end
+
+      def normalize_secret(spec)
+        env = spec[:env] || spec["env"]
+        value = spec[:value] || spec["value"]
+        unless env && value
+          raise ArgumentError, "secret spec needs :env and :value (got #{spec.inspect})"
         end
+        out = {"env" => env.to_s, "value" => value.to_s}
+        hosts = Array(spec[:hosts] || spec["hosts"]).map(&:to_s)
+        single = spec[:host] || spec["host"]
+        hosts << single.to_s if single
+        patterns = Array(spec[:host_patterns] || spec["host_patterns"]).map(&:to_s)
+        if hosts.empty? && patterns.empty?
+          raise ArgumentError,
+            "secret spec needs :host, :hosts, or :host_patterns (got #{spec.inspect})"
+        end
+        out["hosts"] = hosts unless hosts.empty?
+        out["host_patterns"] = patterns unless patterns.empty?
+        pl = spec[:placeholder] || spec["placeholder"]
+        out["placeholder"] = pl.to_s if pl
+        # Booleans must honor an explicit `false` (to disable a default-on toggle),
+        # so probe key presence rather than truthiness.
+        %i[require_tls inject_headers inject_basic_auth inject_query inject_body].each do |k|
+          v = fetch_opt(spec, k)
+          out[k.to_s] = (v ? true : false) unless v.nil?
+        end
+        ov = spec[:on_violation] || spec["on_violation"]
+        out["on_violation"] = normalize_violation(ov) if ov
+        out
+      end
+
+      # Read a symbol-or-string key from a Hash, distinguishing an explicit
+      # `false`/`nil` value from an absent key.
+      def fetch_opt(spec, sym)
+        return spec[sym] if spec.key?(sym)
+        spec[sym.to_s]
+      end
+
+      # Normalize an `on_violation`/`on_secret_violation` spec for the native
+      # layer: a String/Symbol block variant ("block"/"block_and_log"/
+      # "block_and_terminate"), or a Hash describing a passthrough action
+      # ({ passthrough_hosts:, passthrough_host_patterns:, passthrough_all_hosts: }).
+      def normalize_violation(spec)
+        case spec
+        when String, Symbol
+          spec.to_s
+        when Hash
+          out = {}
+          ph = spec[:passthrough_hosts] || spec["passthrough_hosts"]
+          out["passthrough_hosts"] = Array(ph).map(&:to_s) if ph
+          pp = spec[:passthrough_host_patterns] || spec["passthrough_host_patterns"]
+          out["passthrough_host_patterns"] = Array(pp).map(&:to_s) if pp
+          out["passthrough_all_hosts"] = true if spec[:passthrough_all_hosts] || spec["passthrough_all_hosts"]
+          out
+        else
+          raise ArgumentError, "on_violation must be a String or a Hash (got #{spec.inspect})"
+        end
+      end
+
+      # Normalize the `dns:` config Hash for the native layer.
+      def normalize_dns(dns)
+        raise ArgumentError, "dns: must be a Hash" unless dns.is_a?(Hash)
+        out = {}
+        ns = dns[:nameservers] || dns["nameservers"]
+        out["nameservers"] = Array(ns).map(&:to_s) if ns
+        rp = fetch_opt(dns, :rebind_protection)
+        out["rebind_protection"] = (rp ? true : false) unless rp.nil?
+        qt = dns[:query_timeout_ms] || dns["query_timeout_ms"]
+        out["query_timeout_ms"] = Integer(qt) if qt
+        out
+      end
+
+      # Normalize the `tls:` interception-tuning Hash for the native layer.
+      def normalize_tls(tls)
+        raise ArgumentError, "tls: must be a Hash" unless tls.is_a?(Hash)
+        out = {}
+        bypass = tls[:bypass] || tls["bypass"]
+        out["bypass"] = Array(bypass).map(&:to_s) if bypass
+        vu = fetch_opt(tls, :verify_upstream)
+        out["verify_upstream"] = (vu ? true : false) unless vu.nil?
+        ports = tls[:intercepted_ports] || tls["intercepted_ports"]
+        out["intercepted_ports"] = Array(ports).map { |p| Integer(p) } if ports
+        bq = fetch_opt(tls, :block_quic)
+        out["block_quic"] = (bq ? true : false) unless bq.nil?
+        %i[upstream_ca_cert intercept_ca_cert intercept_ca_key].each do |k|
+          v = tls[k] || tls[k.to_s]
+          out[k.to_s] = v.to_s if v
+        end
+        out
       end
 
       # Normalize an rlimits Hash into [resource, soft, hard] triples for the
@@ -386,49 +593,70 @@ module Microsandbox
         end
       end
 
-      # Normalize volumes (Hash of guest_path => spec) into [guest, kind, source]
-      # triples (or [guest, kind, source, options] quads) for the native layer. A
-      # spec is a host path String (read-write bind mount), or a Hash
-      # { bind: "/host" } / { named: "volume-name" } optionally carrying mount
-      # options: { bind: "/host", ro: true } / { named: "v", options: %w[ro noexec] }.
+      # Normalize volumes (Hash of guest_path => spec) into per-mount string-keyed
+      # Hashes for the native layer. A spec is a host path String (a read-write
+      # bind mount) or a Hash describing the mount:
+      #   { bind: "/host", ro: true, noexec: true }            # host bind mount
+      #   { named: "vol" }                                       # named volume
+      #   { tmpfs: true, size_mib: 64 }                          # memory-backed
+      #   { disk: "/img.raw", format: "raw", fstype: "ext4" }   # disk-image mount
+      # Any mount may also carry stat_virtualization: (:strict/:relaxed/:off) and
+      # host_permissions: (:private/:mirror).
       def normalize_volumes(volumes)
         volumes.map do |guest, spec|
-          guest = guest.to_s
+          mount = {"guest" => guest.to_s}
           case spec
           when String
-            [guest, "bind", spec]
+            mount["kind"] = "bind"
+            mount["source"] = spec
           when Hash
-            triple =
-              if (named = spec[:named] || spec["named"])
-                [guest, "named", named.to_s]
-              elsif (bind = spec[:bind] || spec["bind"])
-                [guest, "bind", bind.to_s]
-              else
-                raise ArgumentError, "volume spec for #{guest.inspect} needs :bind or :named"
-              end
-            # Optional 4th element: comma-joined mount options. Omitted when empty
-            # so existing [guest,kind,source] consumers and the common read-write
-            # case are byte-for-byte unchanged.
-            opts = mount_options(spec)
-            opts.empty? ? triple : triple + [opts.join(",")]
+            apply_mount_kind(mount, spec, guest)
+            apply_mount_flags(mount, spec)
           else
             raise ArgumentError, "invalid volume spec for #{guest.inspect}: #{spec.inspect}"
           end
+          mount
         end
       end
 
-      # Collect mount options from a volume spec Hash. `ro:`/`readonly:` makes the
-      # mount read-only (host virtiofs rejects writes + guest kernel returns EROFS);
-      # `noexec:`/`nosuid:`/`nodev:` set the matching flags; an explicit `options:`
-      # array passes through verbatim. Unknown options are rejected natively.
-      def mount_options(spec)
-        opts = []
-        opts << "ro" if spec[:ro] || spec["ro"] || spec[:readonly] || spec["readonly"]
-        opts << "noexec" if spec[:noexec] || spec["noexec"]
-        opts << "nosuid" if spec[:nosuid] || spec["nosuid"]
-        opts << "nodev" if spec[:nodev] || spec["nodev"]
-        Array(spec[:options] || spec["options"]).each { |o| opts << o.to_s }
-        opts.uniq
+      # Resolve a volume spec Hash's mount kind + source/size/format/fstype.
+      def apply_mount_kind(mount, spec, guest)
+        if (bind = spec[:bind] || spec["bind"])
+          mount["kind"] = "bind"
+          mount["source"] = bind.to_s
+        elsif (named = spec[:named] || spec["named"])
+          mount["kind"] = "named"
+          mount["source"] = named.to_s
+        elsif spec[:tmpfs] || spec["tmpfs"]
+          mount["kind"] = "tmpfs"
+        elsif (disk = spec[:disk] || spec["disk"])
+          mount["kind"] = "disk"
+          mount["source"] = disk.to_s
+          fmt = spec[:format] || spec["format"]
+          mount["format"] = fmt.to_s if fmt
+        else
+          raise ArgumentError,
+            "volume spec for #{guest.inspect} needs :bind, :named, :tmpfs, or :disk"
+        end
+        size = spec[:size_mib] || spec["size_mib"]
+        mount["size_mib"] = Integer(size) if size
+        fstype = spec[:fstype] || spec["fstype"]
+        mount["fstype"] = fstype.to_s if fstype
+      end
+
+      # Apply a volume spec Hash's mount flags. `ro:`/`readonly:` makes the mount
+      # read-only; `noexec:`/`nosuid:`/`nodev:` set the matching flags;
+      # `stat_virtualization:`/`host_permissions:` set the passthrough policies
+      # (only valid on bind/named — the core rejects them on tmpfs/disk).
+      def apply_mount_flags(mount, spec)
+        mount["readonly"] = true if spec[:ro] || spec["ro"] || spec[:readonly] || spec["readonly"]
+        mount["noexec"] = true if spec[:noexec] || spec["noexec"]
+        mount["nosuid"] = true if spec[:nosuid] || spec["nosuid"]
+        mount["nodev"] = true if spec[:nodev] || spec["nodev"]
+        sv = spec[:stat_virtualization] || spec["stat_virtualization"]
+        mount["stat_virtualization"] = sv.to_s if sv
+        hp = spec[:host_permissions] || spec["host_permissions"]
+        mount["host_permissions"] = hp.to_s if hp
       end
 
       # Normalize a list of patches (each a Hash from the {Patch} factory, or a
@@ -600,7 +828,7 @@ module Microsandbox
     # Stream captured logs as they appear.
     #
     # @param sources [Array<String,Symbol>, nil] filter by source
-    #   ("stdout"/"stderr"/"output"/"system")
+    #   ("stdout"/"stderr"/"output"/"system"/"all")
     # @param since_ms [Numeric, nil] start at the first entry at/after this Unix ms
     # @param from_cursor [String, nil] resume exactly after a prior {LogEntry#cursor}
     #   (mutually exclusive with since_ms; takes precedence if both given)
@@ -692,15 +920,20 @@ module Microsandbox
       opts["env"] = env.each_with_object({}) { |(k, v), a| a[k.to_s] = v.to_s } if env
       opts["timeout"] = coerce_duration(timeout, "timeout") if timeout
       opts["tty"] = true if tty
-      # `stdin: :pipe` opens a streaming stdin pipe — write to it via
-      # {ExecHandle#stdin} and close to send EOF. It is only meaningful for the
-      # streaming variants (which return an ExecHandle); a blocking exec/shell
-      # collects to completion and has nowhere to hand back the sink, so a piped
-      # process that reads stdin would block forever waiting for EOF. Reject it
-      # there. Any other truthy value is fed as a fixed byte buffer (closed
-      # automatically). nil means no stdin.
+      # stdin is a closed set of modes, mirroring the official SDKs:
+      #   nil / :null  — no stdin (the guest sees /dev/null)
+      #   :pipe        — open a streaming stdin pipe; write via {ExecHandle#stdin}
+      #                  and close to send EOF. Only meaningful for the streaming
+      #                  variants (which return an ExecHandle); a blocking
+      #                  exec/shell collects to completion and has nowhere to hand
+      #                  back the sink, so a piped process reading stdin would
+      #                  block forever waiting for EOF — rejected there.
+      #   a String     — fed as a fixed byte buffer (closed automatically).
+      # An unrecognized Symbol is a loud error rather than being fed as its bytes
+      # (so a typo'd or mistaken `stdin: :null`-style mode never silently sends
+      # the literal characters of the mode name to the process).
       case stdin
-      when nil then nil
+      when nil, :null then nil
       when :pipe
         unless pipe_ok
           raise ArgumentError,
@@ -708,7 +941,14 @@ module Microsandbox
             "exec/shell cannot expose a writable stdin sink; pass a String to feed bytes"
         end
         opts["stdin_pipe"] = true
-      else opts["stdin"] = stdin.to_s
+      when Symbol
+        raise ArgumentError,
+          "unknown stdin mode #{stdin.inspect}; expected nil or :null (no stdin), " \
+          ":pipe (exec_stream/shell_stream only), or a String of bytes to feed"
+      else
+        bytes = String.try_convert(stdin) or
+          raise TypeError, "stdin must be nil, :null, :pipe, or a String (got #{stdin.class})"
+        opts["stdin"] = bytes
       end
       if rlimits
         opts["rlimits"] = rlimits.map do |resource, limit|
@@ -717,6 +957,50 @@ module Microsandbox
         end
       end
       opts
+    end
+  end
+
+  # A streaming image-pull + create session, from {Sandbox.create_with_progress}.
+  # Iterate it (it is {Enumerable}) to consume progress-event Hashes as the image
+  # pulls, then call {#sandbox} to get the booted {Sandbox}. Each event Hash has a
+  # "kind" key (e.g. "resolving", "resolved", "layer_download_progress",
+  # "layer_materialize_progress", "complete") plus kind-specific fields.
+  #
+  # @example
+  #   session = Microsandbox::Sandbox.create_with_progress("box", image: "python")
+  #   session.each { |ev| puts "#{ev["kind"]} #{ev["downloaded_bytes"]}" }
+  #   sb = session.sandbox
+  #   begin
+  #     sb.exec("python", ["-V"])
+  #   ensure
+  #     sb.stop
+  #   end
+  class PullSession
+    include Enumerable
+
+    def initialize(native)
+      @native = native
+    end
+
+    # Yield each progress-event Hash until the pull finishes. Returns an
+    # Enumerator when called without a block.
+    # @yieldparam event [Hash]
+    # @return [self, Enumerator]
+    def each
+      return enum_for(:each) unless block_given?
+
+      while (event = @native.recv)
+        yield event
+      end
+      self
+    end
+
+    # The booted sandbox. Joins the create task (draining any remaining pull
+    # progress first), so call it after iterating progress. The returned
+    # {Sandbox} is live — stop it when done. Memoized; callable once.
+    # @return [Sandbox]
+    def sandbox
+      @sandbox ||= Sandbox.new(@native.result)
     end
   end
 end

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -336,6 +336,18 @@ module Microsandbox
           raise ArgumentError, "provide either image: or from_snapshot:, not both"
         end
         Microsandbox.ensure_runtime!
+        # `fstype:` names the inner filesystem of a disk-image rootfs, so it only
+        # applies when `image:` is a disk-image path (a local path ending in
+        # .raw/.qcow2/.vmdk). Routing an OCI ref (e.g. "python") through the
+        # disk-image builder would make the core treat it as a host disk path and
+        # fail at boot, so reject the combination up front instead of forwarding a
+        # value the native layer can't honour.
+        if fstype && !disk_image_rootfs?(image)
+          raise ArgumentError,
+            "fstype: only applies to a disk-image rootfs; image: must be a local " \
+            "path ending in .raw, .qcow2, or .vmdk (got #{image.inspect}). " \
+            "OCI references auto-detect their filesystem — drop fstype:."
+        end
         opts = {}
         opts["image"] = image.to_s if image
         opts["from_snapshot"] = from_snapshot.to_s if from_snapshot
@@ -537,7 +549,7 @@ module Microsandbox
       def normalize_violation(spec)
         case spec
         when String, Symbol
-          spec.to_s
+          normalize_violation_action(spec)
         when Hash
           out = {}
           ph = spec[:passthrough_hosts] || spec["passthrough_hosts"]
@@ -549,6 +561,22 @@ module Microsandbox
         else
           raise ArgumentError, "on_violation must be a String or a Hash (got #{spec.inspect})"
         end
+      end
+
+      # Map a block-variant action onto the canonical underscore spelling the
+      # native layer expects. Also accepts the upstream kebab-case wire spellings
+      # ("block-and-log"/"block-and-terminate") used by the CLI, Go SDK, and
+      # sandbox config files, so a policy copied from another SDK ports over
+      # unchanged instead of being rejected.
+      def normalize_violation_action(spec)
+        action = spec.to_s.strip.downcase.tr("-", "_")
+        unless %w[block block_and_log block_and_terminate].include?(action)
+          raise ArgumentError,
+            "unknown on_violation #{spec.inspect} (expected block, " \
+            "block_and_log/block-and-log, block_and_terminate/block-and-terminate, " \
+            "or a Hash with :passthrough_hosts/:passthrough_host_patterns/:passthrough_all_hosts)"
+        end
+        action
       end
 
       # Normalize the `dns:` config Hash for the native layer.
@@ -591,6 +619,17 @@ module Microsandbox
           soft, hard = limit.is_a?(Array) ? [limit[0], limit[1]] : [limit, limit]
           [resource.to_s, Integer(soft), Integer(hard)]
         end
+      end
+
+      # True when `image` names a disk-image rootfs the way the core auto-detects
+      # one: a local-path-looking string (`/`, `./`, `../` prefix) whose extension
+      # is a recognized disk-image format. Mirrors the upstream
+      # `looks_like_local_path_text` + `DiskImageFormat::from_extension` so a bare
+      # OCI ref or a bind directory is not mistaken for a disk image.
+      def disk_image_rootfs?(image)
+        s = image.to_s
+        return false unless s.start_with?("/", "./", "../")
+        %w[raw qcow2 vmdk].include?(File.extname(s).delete_prefix(".").downcase)
       end
 
       # Normalize volumes (Hash of guest_path => spec) into per-mount string-keyed
@@ -653,10 +692,32 @@ module Microsandbox
         mount["noexec"] = true if spec[:noexec] || spec["noexec"]
         mount["nosuid"] = true if spec[:nosuid] || spec["nosuid"]
         mount["nodev"] = true if spec[:nodev] || spec["nodev"]
+        apply_legacy_mount_options(mount, spec)
         sv = spec[:stat_virtualization] || spec["stat_virtualization"]
         mount["stat_virtualization"] = sv.to_s if sv
         hp = spec[:host_permissions] || spec["host_permissions"]
         mount["host_permissions"] = hp.to_s if hp
+      end
+
+      # Translate the pre-0.7.0 `options:` array form (e.g. options: %w[ro noexec])
+      # onto the discrete boolean flags the native layer now consumes. Kept for
+      # backward compatibility with configs written against 0.5.11–0.6.0. Unknown
+      # tokens raise rather than being silently dropped: a mount requested
+      # read-only/noexec that quietly mounted read-write/executable would be a
+      # security regression, not a cosmetic one.
+      def apply_legacy_mount_options(mount, spec)
+        Array(spec[:options] || spec["options"]).each do |opt|
+          case opt.to_s
+          when "ro", "readonly" then mount["readonly"] = true
+          when "noexec" then mount["noexec"] = true
+          when "nosuid" then mount["nosuid"] = true
+          when "nodev" then mount["nodev"] = true
+          else
+            raise ArgumentError,
+              "unknown mount option #{opt.inspect} in options: — use " \
+              "ro/readonly, noexec, nosuid, or nodev (or the matching boolean keys)"
+          end
+        end
       end
 
       # Normalize a list of patches (each a Hash from the {Patch} factory, or a

--- a/lib/microsandbox/snapshot.rb
+++ b/lib/microsandbox/snapshot.rb
@@ -1,12 +1,16 @@
 # frozen_string_literal: true
 
 module Microsandbox
-  # Metadata for a snapshot artifact, returned by {Snapshot.create}/{Snapshot.get}/
-  # {Snapshot.list}/{Snapshot.import}.
+  # Metadata for a snapshot artifact, returned by {Snapshot.create}/{Snapshot.open}/
+  # {Snapshot.get}/{Snapshot.list}/{Snapshot.list_dir}/{Snapshot.import}.
   #
-  # `digest` and `path` are always present. `create` additionally populates
-  # `size_bytes`; `get`/`list`/`import` additionally populate `name`,
-  # `parent_digest`, `image_ref`, `format`, and `created_at`.
+  # `digest` and `path` are always present. The artifact-opening paths
+  # (`create`/`open`/`list_dir`, and {SandboxHandle#snapshot}) carry the full
+  # manifest — `size_bytes`, `image_ref`, `image_manifest_digest`, `format`,
+  # `fstype`, `parent_digest`, `created_at`, `source_sandbox`, and `labels`. The
+  # index paths (`get`/`list`/`import`) populate `name`, `parent_digest`,
+  # `image_ref`, `format`, `size_bytes`, and `created_at` (manifest-only fields
+  # such as `fstype`/`source_sandbox`/`labels` are nil/empty there).
   class SnapshotInfo
     # @return [String] manifest digest ("sha256:…") — the canonical identity
     attr_reader :digest
@@ -18,6 +22,14 @@ module Microsandbox
     attr_reader :parent_digest
     # @return [String, nil] source OCI image reference
     attr_reader :image_ref
+    # @return [String, nil] OCI manifest digest of the pinned image (manifest paths)
+    attr_reader :image_manifest_digest
+    # @return [String, nil] upper-layer filesystem type, e.g. "ext4" (manifest paths)
+    attr_reader :fstype
+    # @return [String, nil] best-effort source-sandbox name, if recorded
+    attr_reader :source_sandbox
+    # @return [Hash{String=>String}] user labels ({} for index-only entries)
+    attr_reader :labels
     # @return [Integer, nil] artifact size in bytes
     attr_reader :size_bytes
 
@@ -27,6 +39,10 @@ module Microsandbox
       @name = data["name"]
       @parent_digest = data["parent_digest"]
       @image_ref = data["image_ref"]
+      @image_manifest_digest = data["image_manifest_digest"]
+      @fstype = data["fstype"]
+      @source_sandbox = data["source_sandbox"]
+      @labels = data["labels"] || {}
       @format = data["format"]
       @size_bytes = data["size_bytes"]
       @created_at_ms = data["created_at_ms"]
@@ -40,6 +56,21 @@ module Microsandbox
     # @return [Time, nil]
     def created_at
       @created_at_ms && Time.at(@created_at_ms / 1000.0)
+    end
+
+    # Re-open this snapshot's artifact (cheap metadata validation), returning a
+    # fully-populated {SnapshotInfo}. Addresses by path, so it works even for
+    # artifacts that were never added to the local index.
+    # @return [SnapshotInfo]
+    def open
+      Snapshot.open(@path || @digest)
+    end
+
+    # Remove this snapshot's artifact and its index row.
+    # @param force [Boolean] remove even if it has indexed children
+    # @return [nil]
+    def remove(force: false)
+      Snapshot.remove(@path || @digest, force: force)
     end
 
     def inspect
@@ -98,16 +129,42 @@ module Microsandbox
         SnapshotInfo.new(Native::Snapshot.create(source_sandbox.to_s, opts))
       end
 
+      # Open a snapshot artifact by bare name or path (cheap metadata
+      # validation; does not read the upper layer). Unlike {get}, this also
+      # works for artifacts addressed by path that were never indexed, and it
+      # returns the full manifest.
+      # @return [SnapshotInfo]
+      def open(name_or_path)
+        SnapshotInfo.new(Native::Snapshot.open(name_or_path.to_s))
+      end
+
       # Metadata for a snapshot by name or digest.
       # @return [SnapshotInfo]
       def get(name_or_digest)
         SnapshotInfo.new(Native::Snapshot.get(name_or_digest.to_s))
       end
 
-      # All snapshots.
+      # All snapshots indexed in the local cache.
       # @return [Array<SnapshotInfo>]
       def list
         Native::Snapshot.list.map { |info| SnapshotInfo.new(info) }
+      end
+
+      # Enumerate snapshot artifacts under a directory by parsing each
+      # subdirectory's `manifest.json`, without touching the local index — for
+      # inspecting external/un-imported collections (e.g. a mounted volume).
+      # @return [Array<SnapshotInfo>]
+      def list_dir(dir)
+        Native::Snapshot.list_dir(dir.to_s).map { |info| SnapshotInfo.new(info) }
+      end
+
+      # Rebuild the local snapshot index from a directory (defaults to the
+      # configured snapshots dir). The repair for index drift or out-of-band
+      # imports that {list}/{get} can't otherwise see.
+      # @param dir [String, nil]
+      # @return [Integer] number of indexed snapshots
+      def reindex(dir = nil)
+        Native::Snapshot.reindex(dir&.to_s)
       end
 
       # Remove a snapshot artifact by name or path.

--- a/lib/microsandbox/ssh.rb
+++ b/lib/microsandbox/ssh.rb
@@ -2,8 +2,9 @@
 
 module Microsandbox
   # The result of an {SshClient#exec} call. Like {ExecOutput}, `stdout`/`stderr`
-  # are the captured bytes decoded as UTF-8 (lenient); use `stdout_bytes`/
-  # `stderr_bytes` for the raw ASCII-8BIT bytes.
+  # are the captured bytes decoded as UTF-8 (lossy — invalid byte sequences are
+  # replaced with U+FFFD); use `stdout_bytes`/`stderr_bytes` for the raw
+  # ASCII-8BIT bytes.
   class SshOutput
     # @return [Integer] the remote command's exit status
     attr_reader :status
@@ -25,14 +26,14 @@ module Microsandbox
     # @return [Boolean] whether the command exited non-zero
     def failure? = !@success
 
-    # @return [String] stdout decoded as UTF-8
+    # @return [String] stdout decoded as UTF-8 (lossy)
     def stdout
-      @stdout ||= @stdout_bytes.dup.force_encoding(Encoding::UTF_8)
+      @stdout ||= @stdout_bytes.dup.force_encoding(Encoding::UTF_8).scrub
     end
 
-    # @return [String] stderr decoded as UTF-8
+    # @return [String] stderr decoded as UTF-8 (lossy)
     def stderr
-      @stderr ||= @stderr_bytes.dup.force_encoding(Encoding::UTF_8)
+      @stderr ||= @stderr_bytes.dup.force_encoding(Encoding::UTF_8).scrub
     end
 
     def to_s = stdout
@@ -56,16 +57,21 @@ module Microsandbox
       @native.read(path.to_s)
     end
 
-    # Read a file and decode it as UTF-8 (lenient).
+    # Read a file and decode it as UTF-8 (lossy — invalid byte sequences are
+    # replaced with U+FFFD).
     # @return [String]
     def read_text(path)
-      read(path).force_encoding(Encoding::UTF_8)
+      read(path).force_encoding(Encoding::UTF_8).scrub
     end
 
     # Write a file, creating or truncating it.
+    # @param data [String] raw bytes to write (binary-safe)
+    # @raise [TypeError] if +data+ is not a String
     # @return [nil]
     def write(path, data)
-      @native.write(path.to_s, data.to_s)
+      bytes = String.try_convert(data) or
+        raise TypeError, "data must be a String (got #{data.class})"
+      @native.write(path.to_s, bytes)
       nil
     end
 

--- a/lib/microsandbox/ssh.rb
+++ b/lib/microsandbox/ssh.rb
@@ -69,8 +69,7 @@ module Microsandbox
     # @raise [TypeError] if +data+ is not a String
     # @return [nil]
     def write(path, data)
-      bytes = String.try_convert(data) or
-        raise TypeError, "data must be a String (got #{data.class})"
+      bytes = Microsandbox.coerce_write_bytes(data)
       @native.write(path.to_s, bytes)
       nil
     end

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -15,5 +15,5 @@ module Microsandbox
   # ext/microsandbox/Cargo.toml. Exposed at runtime as
   # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
   # sync with the Cargo tag so it can't silently drift out of date.
-  RUNTIME_VERSION = "v0.5.9"
+  RUNTIME_VERSION = "v0.5.8"
 end

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -15,5 +15,5 @@ module Microsandbox
   # ext/microsandbox/Cargo.toml. Exposed at runtime as
   # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
   # sync with the Cargo tag so it can't silently drift out of date.
-  RUNTIME_VERSION = "v0.5.8"
+  RUNTIME_VERSION = "v0.5.9"
 end

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,7 +8,7 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.6.0"
+  VERSION = "0.7.0"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in

--- a/lib/microsandbox/volume.rb
+++ b/lib/microsandbox/volume.rb
@@ -71,8 +71,7 @@ module Microsandbox
     # @raise [TypeError] if +data+ is not a String
     # @return [nil]
     def write(path, data)
-      bytes = String.try_convert(data) or
-        raise TypeError, "data must be a String (got #{data.class})"
+      bytes = Microsandbox.coerce_write_bytes(data)
       @native.write(path.to_s, bytes)
       nil
     end

--- a/lib/microsandbox/volume.rb
+++ b/lib/microsandbox/volume.rb
@@ -22,7 +22,8 @@ module Microsandbox
       @created_at_ms = data["created_at_ms"]
     end
 
-    # @return [Symbol, nil] :directory or :disk
+    # @return [Symbol, nil] :dir or :disk (matches the {Volume.create} `kind:`
+    #   input and the core's canonical names)
     def kind
       @kind&.to_sym
     end
@@ -32,8 +33,100 @@ module Microsandbox
       @created_at_ms && Time.at(@created_at_ms / 1000.0)
     end
 
+    # A host-side filesystem view over this volume (read/write its contents
+    # without a running sandbox).
+    # @return [VolumeFs]
+    def fs
+      @fs ||= VolumeFs.new(Native::Volume.fs(@name.to_s))
+    end
+
     def inspect
       "#<Microsandbox::VolumeInfo name=#{@name.inspect}#{" kind=#{@kind}" if @kind}>"
+    end
+  end
+
+  # A host-side filesystem view over a named volume, from {Volume.fs} or
+  # {VolumeInfo#fs}. Reads and writes the volume's contents directly on the host,
+  # without booting a sandbox. All paths are relative to the volume root. Mirrors
+  # the `VolumeFs` of the official Python/Node SDKs.
+  class VolumeFs
+    def initialize(native)
+      @native = native
+    end
+
+    # Read a file as raw bytes (ASCII-8BIT).
+    # @return [String]
+    def read(path)
+      @native.read(path.to_s)
+    end
+
+    # Read a file as a UTF-8 string.
+    # @return [String]
+    def read_text(path)
+      @native.read_text(path.to_s)
+    end
+
+    # Write data to a file, creating parent directories as needed.
+    # @param data [String] raw bytes (binary-safe)
+    # @raise [TypeError] if +data+ is not a String
+    # @return [nil]
+    def write(path, data)
+      bytes = String.try_convert(data) or
+        raise TypeError, "data must be a String (got #{data.class})"
+      @native.write(path.to_s, bytes)
+      nil
+    end
+
+    # List the entries of a directory.
+    # @return [Array<FsEntry>]
+    def list(path)
+      @native.list(path.to_s).map { |entry| FsEntry.new(entry) }
+    end
+
+    # Create a directory (and any missing parents).
+    # @return [nil]
+    def mkdir(path)
+      @native.mkdir(path.to_s)
+      nil
+    end
+
+    # Remove a single file.
+    # @return [nil]
+    def remove_file(path)
+      @native.remove_file(path.to_s)
+      nil
+    end
+
+    # Remove a directory recursively.
+    # @return [nil]
+    def remove_dir(path)
+      @native.remove_dir(path.to_s)
+      nil
+    end
+
+    # @return [Boolean] whether the path exists in the volume
+    def exists?(path)
+      @native.exists(path.to_s)
+    end
+
+    # Copy a file within the volume.
+    # @return [nil]
+    def copy(src, dst)
+      @native.copy(src.to_s, dst.to_s)
+      nil
+    end
+
+    # Rename/move a file or directory within the volume.
+    # @return [nil]
+    def rename(src, dst)
+      @native.rename(src.to_s, dst.to_s)
+      nil
+    end
+
+    # Stat a path.
+    # @return [FsMetadata]
+    def stat(path)
+      FsMetadata.new(@native.stat(path.to_s))
     end
   end
 
@@ -73,6 +166,13 @@ module Microsandbox
       def remove(name)
         Native::Volume.remove(name.to_s)
         nil
+      end
+
+      # A host-side filesystem view over a named volume (read/write its contents
+      # without a running sandbox). The volume need not be mounted.
+      # @return [VolumeFs]
+      def fs(name)
+        VolumeFs.new(Native::Volume.fs(name.to_s))
       end
     end
   end

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -208,15 +208,15 @@ module Microsandbox
 
     def name: () -> String
     def exec: (String command, ?Array[String] args, ?cwd: String?, ?user: String?,
-               ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: String?,
+               ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: (String | :null)?,
                ?rlimits: Hash[untyped, untyped]?) -> ExecOutput
     def shell: (String script, ?cwd: String?, ?user: String?, ?env: Hash[untyped, untyped]?,
-                ?timeout: Numeric?, ?tty: bool, ?stdin: String?, ?rlimits: Hash[untyped, untyped]?) -> ExecOutput
+                ?timeout: Numeric?, ?tty: bool, ?stdin: (String | :null)?, ?rlimits: Hash[untyped, untyped]?) -> ExecOutput
     def exec_stream: (String command, ?Array[String] args, ?cwd: String?, ?user: String?,
-                      ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: (String | :pipe)?,
+                      ?env: Hash[untyped, untyped]?, ?timeout: Numeric?, ?tty: bool, ?stdin: (String | :pipe | :null)?,
                       ?rlimits: Hash[untyped, untyped]?) -> ExecHandle
     def shell_stream: (String script, ?cwd: String?, ?user: String?, ?env: Hash[untyped, untyped]?,
-                       ?timeout: Numeric?, ?tty: bool, ?stdin: (String | :pipe)?, ?rlimits: Hash[untyped, untyped]?) -> ExecHandle
+                       ?timeout: Numeric?, ?tty: bool, ?stdin: (String | :pipe | :null)?, ?rlimits: Hash[untyped, untyped]?) -> ExecHandle
     def attach: (String command, ?Array[String] args, ?cwd: String?, ?user: String?,
                  ?env: Hash[untyped, untyped]?, ?detach_keys: String?,
                  ?rlimits: Hash[untyped, untyped]?) -> Integer
@@ -280,7 +280,7 @@ module Microsandbox
   end
 
   class ExecStdin
-    def write: (untyped data) -> self
+    def write: (String data) -> self
     def close: () -> nil
   end
 

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -7,6 +7,7 @@ module Microsandbox
   def self.version: () -> String
   def self.runtime_version: () -> String
   def self.install: () -> nil
+  def self.setup: (?base_dir: String?, ?version: String?, ?force: bool, ?skip_verify: bool) -> nil
   def self.installed?: () -> bool
   def self.ensure_runtime!: () -> nil
   def self.runtime_path: () -> String
@@ -97,6 +98,20 @@ module Microsandbox
     def stat: (String path) -> FsMetadata
     def copy_from_host: (String host_path, String guest_path) -> nil
     def copy_to_host: (String guest_path, String host_path) -> nil
+    def read_stream: (String path) -> FsReadStream
+    def write_stream: (String path) ?{ (FsWriteSink) -> untyped } -> untyped
+  end
+
+  class FsReadStream
+    include Enumerable[String]
+    def each: () { (String) -> void } -> self
+            | () -> Enumerator[String, self]
+    def read: () -> String
+  end
+
+  class FsWriteSink
+    def write: (String data) -> self
+    def close: () -> nil
   end
 
   class Metrics
@@ -110,6 +125,9 @@ module Microsandbox
     def disk_write_bytes: () -> Integer
     def net_rx_bytes: () -> Integer
     def net_tx_bytes: () -> Integer
+    def upper_used_bytes: () -> Integer?
+    def upper_free_bytes: () -> Integer?
+    def upper_host_allocated_bytes: () -> Integer?
     def uptime_secs: () -> Float
     def timestamp: () -> Time
   end
@@ -138,6 +156,10 @@ module Microsandbox
     def request_kill: () -> nil
     def request_drain: () -> nil
     def wait_until_stopped: () -> SandboxStopResult
+    def config_json: () -> String
+    def config: () -> Hash[String, untyped]
+    def snapshot: (String name) -> SnapshotInfo
+    def snapshot_to: (String path) -> SnapshotInfo
   end
 
   # Deprecated alias for SandboxHandle (was a read-only metadata type pre-v0.5.8).
@@ -161,15 +183,23 @@ module Microsandbox
                       ?scripts: Hash[untyped, untyped]?, ?entrypoint: Array[String]?,
                       ?ports: Hash[untyped, untyped]?, ?ports_udp: Hash[untyped, untyped]?,
                       ?volumes: Hash[untyped, untyped]?, ?network: untyped?,
+                      ?dns: Hash[untyped, untyped]?, ?tls: Hash[untyped, untyped]?,
+                      ?ipv4_pool: String?, ?ipv6_pool: String?,
+                      ?max_connections: Integer?, ?trust_host_cas: bool?,
                       ?patches: Array[Hash[untyped, untyped]]?, ?from_snapshot: String?,
+                      ?fstype: String?, ?init: (String | Symbol | Hash[untyped, untyped])?, ?ephemeral: bool,
                       ?log_level: (String | Symbol)?, ?quiet_logs: bool, ?security: (String | Symbol)?,
                       ?oci_upper_size: Integer?, ?max_duration: Integer?, ?idle_timeout: Integer?,
                       ?rlimits: Hash[untyped, untyped]?, ?pull_policy: (String | Symbol)?,
                       ?registry_auth: Hash[untyped, untyped]?, ?registry_insecure: bool,
                       ?registry_ca_certs: (String | Array[String])?,
-                      ?secrets: Array[Hash[untyped, untyped]]?, ?detached: bool,
+                      ?secrets: Array[Hash[untyped, untyped]]?,
+                      ?on_secret_violation: (String | Symbol | Hash[untyped, untyped])?,
+                      ?detached: bool,
                       ?replace: bool, ?replace_with_timeout: Numeric?)
                       ?{ (Sandbox) -> untyped } -> untyped
+    # Accepts the same keyword options as {create}.
+    def self.create_with_progress: (String name, **untyped) -> PullSession
     def self.start: (String name, ?detached: bool) -> Sandbox
     def self.get: (String name) -> SandboxHandle
     def self.list: () -> Array[SandboxHandle]
@@ -207,6 +237,14 @@ module Microsandbox
     def status: () -> Symbol
     def owns_lifecycle?: () -> bool
     def detach: () -> nil
+  end
+
+  class PullSession
+    include Enumerable[Hash[String, untyped]]
+    def initialize: (untyped native) -> void
+    def each: () { (Hash[String, untyped]) -> void } -> self
+            | () -> Enumerator[Hash[String, untyped], self]
+    def sandbox: () -> Sandbox
   end
 
   class LogStream
@@ -305,6 +343,22 @@ module Microsandbox
     def disk_fstype: () -> String?
     def labels: () -> Hash[String, String]
     def created_at: () -> Time?
+    def fs: () -> VolumeFs
+  end
+
+  class VolumeFs
+    def initialize: (untyped native) -> void
+    def read: (String path) -> String
+    def read_text: (String path) -> String
+    def write: (String path, String data) -> nil
+    def list: (String path) -> Array[FsEntry]
+    def mkdir: (String path) -> nil
+    def remove_file: (String path) -> nil
+    def remove_dir: (String path) -> nil
+    def exists?: (String path) -> bool
+    def copy: (String src, String dst) -> nil
+    def rename: (String src, String dst) -> nil
+    def stat: (String path) -> FsMetadata
   end
 
   class Volume
@@ -313,6 +367,7 @@ module Microsandbox
     def self.get: (String name) -> VolumeInfo
     def self.list: () -> Array[VolumeInfo]
     def self.remove: (String name) -> nil
+    def self.fs: (String name) -> VolumeFs
   end
 
   class SnapshotInfo
@@ -321,9 +376,15 @@ module Microsandbox
     def name: () -> String?
     def parent_digest: () -> String?
     def image_ref: () -> String?
+    def image_manifest_digest: () -> String?
+    def fstype: () -> String?
+    def source_sandbox: () -> String?
+    def labels: () -> Hash[String, String]
     def size_bytes: () -> Integer?
     def format: () -> Symbol?
     def created_at: () -> Time?
+    def open: () -> SnapshotInfo
+    def remove: (?force: bool) -> nil
   end
 
   class SnapshotVerifyReport
@@ -339,8 +400,11 @@ module Microsandbox
   class Snapshot
     def self.create: (String source_sandbox, ?name: String?, ?path: String?,
                       ?labels: Hash[untyped, untyped]?, ?force: bool, ?record_integrity: bool) -> SnapshotInfo
+    def self.open: (String name_or_path) -> SnapshotInfo
     def self.get: (String name_or_digest) -> SnapshotInfo
     def self.list: () -> Array[SnapshotInfo]
+    def self.list_dir: (String dir) -> Array[SnapshotInfo]
+    def self.reindex: (?String? dir) -> Integer
     def self.remove: (String name_or_path, ?force: bool) -> nil
     def self.verify: (String name_or_path) -> SnapshotVerifyReport
     def self.export: (String name_or_path, String out_path, ?with_parents: bool,

--- a/spec/integration/patches_network_spec.rb
+++ b/spec/integration/patches_network_spec.rb
@@ -41,6 +41,24 @@ RSpec.describe "patches and network", :integration do
         end
       end
     end
+
+    # The binary `file` patch is the only variant with a distinct native byte
+    # path (RString::as_slice copy) and no Python analogue, so the end-to-end
+    # round-trip — NUL-containing bytes through the guest filesystem — is only
+    # exercised here. (The pure-Ruby factory bytes are asserted in patch_spec.rb.)
+    it "writes a binary file patch with NUL bytes, byte-exact" do
+      blob = "\x00\xff\x01\x02\x00\x80".b
+      Microsandbox::Sandbox.create(
+        unique_sandbox_name, image: image,
+        patches: [Microsandbox::Patch.file("/opt/blob.bin", blob, mode: 0o600)]
+      ) do |sb|
+        got = sb.fs.read("/opt/blob.bin")
+        expect(got.b).to eq(blob)
+        # Cross-check the byte count via a shell probe (guards against truncation).
+        size = sb.shell("wc -c < /opt/blob.bin").stdout.strip
+        expect(size).to eq(blob.bytesize.to_s)
+      end
+    end
   end
 
   describe "custom network policy" do

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe "raw agent client" do
       expect { Microsandbox::AgentClient.connect_sandbox("nope", timeout: Float::INFINITY) }
         .to raise_error(Microsandbox::Error, /timeout/)
     end
+
+    it "rejects a finite-but-out-of-range timeout instead of panicking" do
+      # Float::MAX is finite and positive, so it passes the finite/non-negative
+      # guard but overflows Duration::from_secs_f64; the binding must surface a
+      # clean Microsandbox::Error (via try_from_secs_f64), not a Rust panic.
+      expect { Microsandbox::AgentClient.connect_sandbox("nope", timeout: Float::MAX) }
+        .to raise_error(Microsandbox::Error, /timeout/)
+    end
   end
 
   describe Microsandbox::AgentFrame do

--- a/spec/unit/agent_spec.rb
+++ b/spec/unit/agent_spec.rb
@@ -4,6 +4,22 @@
 # stream iteration, client wrapper). The native transport is stubbed; the real
 # socket round-trip is exercised by the integration specs.
 RSpec.describe "raw agent client" do
+  # The timeout is validated (in the native binding) before any socket I/O, so
+  # a bad value raises deterministically without a running sandbox. Mirrors the
+  # Python SDK, which rejects negative/non-finite timeouts instead of silently
+  # falling back to the default (and treats 0 as an immediate deadline, not nil).
+  describe ".connect_sandbox timeout validation" do
+    it "rejects a negative timeout with a clear error (not a silent default)" do
+      expect { Microsandbox::AgentClient.connect_sandbox("nope", timeout: -1) }
+        .to raise_error(Microsandbox::Error, /timeout/)
+    end
+
+    it "rejects a non-finite timeout" do
+      expect { Microsandbox::AgentClient.connect_sandbox("nope", timeout: Float::INFINITY) }
+        .to raise_error(Microsandbox::Error, /timeout/)
+    end
+  end
+
   describe Microsandbox::AgentFrame do
     it "exposes id/flags/body and decodes the flag bits" do
       f = described_class.new("id" => 7, "flags" => 0b0000_0011, "body" => "xx".b)

--- a/spec/unit/roadmap_spec.rb
+++ b/spec/unit/roadmap_spec.rb
@@ -130,21 +130,45 @@ RSpec.describe "streaming exec, images, volumes" do
       Microsandbox::Sandbox.create(
         "box",
         from_snapshot: "snap-1",
-        volumes: {"/data" => "/host/data", "/cache" => {named: "cache-vol"}}
+        volumes: {"/data" => "/host/data", "/cache" => {named: "cache-vol", ro: true}}
       )
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box",
         hash_including(
           "from_snapshot" => "snap-1",
-          "volumes" => [["/data", "bind", "/host/data"], ["/cache", "named", "cache-vol"]]
+          "volumes" => [
+            {"guest" => "/data", "kind" => "bind", "source" => "/host/data"},
+            {"guest" => "/cache", "kind" => "named", "source" => "cache-vol", "readonly" => true}
+          ]
         )
+      )
+    end
+
+    it "normalizes tmpfs and disk-image mounts with policies" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        volumes: {
+          "/scratch" => {tmpfs: true, size_mib: 64},
+          "/disk" => {disk: "/img.raw", format: "raw", fstype: "ext4"},
+          "/data" => {bind: "/host", stat_virtualization: :relaxed, host_permissions: :mirror}
+        }
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("volumes" => [
+          {"guest" => "/scratch", "kind" => "tmpfs", "size_mib" => 64},
+          {"guest" => "/disk", "kind" => "disk", "source" => "/img.raw",
+           "format" => "raw", "fstype" => "ext4"},
+          {"guest" => "/data", "kind" => "bind", "source" => "/host",
+           "stat_virtualization" => "relaxed", "host_permissions" => "mirror"}
+        ])
       )
     end
 
     it "raises on a malformed volume spec" do
       expect do
         Microsandbox::Sandbox.create("box", image: "x", volumes: {"/data" => {wrong: 1}})
-      end.to raise_error(ArgumentError, /:bind or :named/)
+      end.to raise_error(ArgumentError, /:bind, :named, :tmpfs, or :disk/)
     end
 
     it "wraps exec_stream in an ExecHandle" do

--- a/spec/unit/roadmap_spec.rb
+++ b/spec/unit/roadmap_spec.rb
@@ -185,6 +185,19 @@ RSpec.describe "streaming exec, images, volumes" do
       )
     end
 
+    it "accepts the legacy \"rw\" token as a no-op (the read-write default)" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        volumes: {"/repo" => {bind: "/repo", options: %w[ro rw]}}
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("volumes" => [
+          {"guest" => "/repo", "kind" => "bind", "source" => "/repo", "readonly" => true}
+        ])
+      )
+    end
+
     it "raises on an unknown legacy mount option instead of dropping it" do
       expect do
         Microsandbox::Sandbox.create(

--- a/spec/unit/roadmap_spec.rb
+++ b/spec/unit/roadmap_spec.rb
@@ -171,6 +171,29 @@ RSpec.describe "streaming exec, images, volumes" do
       end.to raise_error(ArgumentError, /:bind, :named, :tmpfs, or :disk/)
     end
 
+    it "translates the legacy options: array onto the native boolean flags" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        volumes: {"/repo" => {bind: "/repo", options: %w[ro noexec]}}
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("volumes" => [
+          {"guest" => "/repo", "kind" => "bind", "source" => "/repo",
+           "readonly" => true, "noexec" => true}
+        ])
+      )
+    end
+
+    it "raises on an unknown legacy mount option instead of dropping it" do
+      expect do
+        Microsandbox::Sandbox.create(
+          "box", image: "x",
+          volumes: {"/repo" => {bind: "/repo", options: %w[ro bogus]}}
+        )
+      end.to raise_error(ArgumentError, /unknown mount option "bogus"/)
+    end
+
     it "wraps exec_stream in an ExecHandle" do
       stream = instance_double(Microsandbox::Native::ExecHandle)
       allow(native).to receive(:exec_stream).and_return(stream)

--- a/spec/unit/runtime_spec.rb
+++ b/spec/unit/runtime_spec.rb
@@ -16,20 +16,19 @@ RSpec.describe "Microsandbox runtime helpers" do
   end
 
   describe ".runtime_path=" do
-    around do |example|
-      original = begin
-        Microsandbox.runtime_path
-      rescue Microsandbox::Error
-        nil
-      end
-      example.run
-    ensure
-      Microsandbox.runtime_path = original if original
-    end
-
-    it "overrides the resolved path (SDK tier)" do
+    it "forwards the stringified path to the native set-once setter" do
+      # Stub the native setter so we (a) actually verify the binding forwards,
+      # and (b) never consume the real process-wide set-once OnceLock — it has no
+      # getter and cannot be restored, so writing a fake path here would leak
+      # into the rest of the process (e.g. a combined unit+integration run with
+      # :random order, where a later real-microVM example would then resolve the
+      # bogus msb path and fail with an order-dependent boot error). The previous
+      # around-hook "restore" was a silent no-op for exactly that reason.
+      # Mirrors the .libkrunfw_path= spec below.
+      allow(Microsandbox::Native).to receive(:set_runtime_msb_path)
       Microsandbox.runtime_path = "/custom/path/to/msb"
-      expect(Microsandbox.runtime_path).to eq("/custom/path/to/msb")
+      expect(Microsandbox::Native).to have_received(:set_runtime_msb_path)
+        .with("/custom/path/to/msb")
     end
   end
 

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -177,6 +177,36 @@ RSpec.describe Microsandbox::Sandbox do
       )
     end
 
+    it "rejects fstype: paired with an OCI image reference" do
+      expect do
+        Microsandbox::Sandbox.create("box", image: "python", fstype: "ext4")
+      end.to raise_error(ArgumentError, /fstype: only applies to a disk-image rootfs/)
+    end
+
+    it "accepts the upstream kebab-case violation spellings" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        secrets: [{env: "K", value: "v", hosts: ["api.example.com"],
+                   on_violation: "block-and-terminate"}],
+        on_secret_violation: "block-and-log"
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "secrets" => [hash_including("on_violation" => "block_and_terminate")],
+          "on_secret_violation" => "block_and_log"
+        )
+      )
+    end
+
+    it "raises on an unknown violation action string" do
+      expect do
+        Microsandbox::Sandbox.create(
+          "box", image: "x", on_secret_violation: "nope"
+        )
+      end.to raise_error(ArgumentError, /unknown on_violation "nope"/)
+    end
+
     it "normalizes a Hash init with args and env" do
       Microsandbox::Sandbox.create(
         "box", image: "x",

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -191,6 +191,29 @@ RSpec.describe Microsandbox::Sandbox do
       end.to raise_error(ArgumentError, /fstype: only applies to a disk-image rootfs/)
     end
 
+    # Pins the disk_image_rootfs? heuristic that gates the fstype:-vs-OCI check.
+    # It hand-mirrors upstream's looks_like_local_path_text (path prefix) +
+    # DiskImageFormat::from_extension (qcow2/raw/vmdk); this guards against drift
+    # if a runtime-tag bump changes either set. Expectations are hardcoded here
+    # (not derived from the constant) so a wrong constant value is caught.
+    describe "disk_image_rootfs? contract" do
+      def disk?(image) = Microsandbox::Sandbox.send(:disk_image_rootfs?, image)
+
+      it "accepts a local-path-looking disk image (any recognized extension, any case)" do
+        expect(disk?("/img/alpine.raw")).to be(true)
+        expect(disk?("./disk.qcow2")).to be(true)
+        expect(disk?("../vm.vmdk")).to be(true)
+        expect(disk?("/img/alpine.RAW")).to be(true) # extension match is case-insensitive
+      end
+
+      it "rejects an OCI ref, a path without a local prefix, and a non-disk extension" do
+        expect(disk?("python")).to be(false)           # bare OCI reference
+        expect(disk?("alpine.raw")).to be(false)        # no /, ./, ../ prefix
+        expect(disk?("/img/rootfs.tar")).to be(false)   # unrecognized extension
+        expect(disk?("/img/rootfs")).to be(false)       # no extension
+      end
+    end
+
     it "accepts the upstream kebab-case violation spellings" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
@@ -228,6 +251,14 @@ RSpec.describe Microsandbox::Sandbox do
           "box", image: "x", on_secret_violation: "nope"
         )
       end.to raise_error(ArgumentError, /unknown on_violation "nope"/)
+    end
+
+    it "rejects an effectively-empty passthrough Hash (a no-op spec)" do
+      expect do
+        Microsandbox::Sandbox.create(
+          "box", image: "x", on_secret_violation: {passthrough_hosts: []}
+        )
+      end.to raise_error(ArgumentError, /passthrough on_violation needs at least one/)
     end
 
     it "normalizes a Hash init with args and env" do

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -61,6 +61,14 @@ RSpec.describe Microsandbox::Sandbox do
         .with("box", hash_including("image" => "python", "cpus" => 2))
     end
 
+    it "create_with_progress rejects a block (which would silently leak the sandbox)" do
+      allow(Microsandbox::Native::Sandbox).to receive(:create_with_progress)
+      expect do
+        Microsandbox::Sandbox.create_with_progress("box", image: "python") { |sb| sb }
+      end.to raise_error(ArgumentError, /takes no block/)
+      expect(Microsandbox::Native::Sandbox).not_to have_received(:create_with_progress)
+    end
+
     it "flattens registry_auth into registry_username/registry_password" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
@@ -195,6 +203,21 @@ RSpec.describe Microsandbox::Sandbox do
         hash_including(
           "secrets" => [hash_including("on_violation" => "block_and_terminate")],
           "on_secret_violation" => "block_and_log"
+        )
+      )
+    end
+
+    it "maps the bare \"passthrough\" string to passthrough-all-hosts (SDK parity)" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        secrets: [{env: "K", value: "v", hosts: ["api.example.com"], on_violation: "passthrough"}],
+        on_secret_violation: "passthrough"
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "secrets" => [hash_including("on_violation" => {"passthrough_all_hosts" => true})],
+          "on_secret_violation" => {"passthrough_all_hosts" => true}
         )
       )
     end

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -51,6 +51,16 @@ RSpec.describe Microsandbox::Sandbox do
       expect(Microsandbox).to have_received(:ensure_runtime!)
     end
 
+    it "create_with_progress forwards the same options and returns a PullSession" do
+      session_native = instance_double(Microsandbox::Native::PullSession)
+      allow(Microsandbox::Native::Sandbox).to receive(:create_with_progress)
+        .and_return(session_native)
+      session = Microsandbox::Sandbox.create_with_progress("box", image: "python", cpus: 2)
+      expect(session).to be_a(Microsandbox::PullSession)
+      expect(Microsandbox::Native::Sandbox).to have_received(:create_with_progress)
+        .with("box", hash_including("image" => "python", "cpus" => 2))
+    end
+
     it "flattens registry_auth into registry_username/registry_password" do
       Microsandbox::Sandbox.create(
         "box", image: "x",
@@ -101,7 +111,7 @@ RSpec.describe Microsandbox::Sandbox do
       end.to raise_error(ArgumentError, /:username and :password/)
     end
 
-    it "maps pull_policy and normalizes secrets into [env, value, host] triples" do
+    it "maps pull_policy and normalizes a simple secret (host -> hosts)" do
       Microsandbox::Sandbox.create(
         "box", image: "x", pull_policy: "never",
         secrets: [{env: "OPENAI_API_KEY", value: "sk-123", host: "api.openai.com"}]
@@ -110,21 +120,111 @@ RSpec.describe Microsandbox::Sandbox do
         "box",
         hash_including(
           "pull_policy" => "never",
-          "secrets" => [["OPENAI_API_KEY", "sk-123", "api.openai.com"]]
+          "secrets" => [{"env" => "OPENAI_API_KEY", "value" => "sk-123",
+                         "hosts" => ["api.openai.com"]}]
         )
       )
     end
 
-    it "raises on a malformed secret spec" do
+    it "normalizes the full secret surface (patterns, injection, violation)" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        secrets: [{
+          env: "STRIPE_KEY", value: "sk_live", hosts: ["api.stripe.com"],
+          host_patterns: ["*.stripe.com"], placeholder: "$STRIPE", require_tls: true,
+          inject_headers: true, inject_query: false, inject_body: true,
+          on_violation: "block_and_terminate"
+        }],
+        on_secret_violation: {passthrough_hosts: ["10.0.0.1"]}
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "secrets" => [{
+            "env" => "STRIPE_KEY", "value" => "sk_live", "hosts" => ["api.stripe.com"],
+            "host_patterns" => ["*.stripe.com"], "placeholder" => "$STRIPE",
+            "require_tls" => true, "inject_headers" => true, "inject_query" => false,
+            "inject_body" => true, "on_violation" => "block_and_terminate"
+          }],
+          "on_secret_violation" => {"passthrough_hosts" => ["10.0.0.1"]}
+        )
+      )
+    end
+
+    it "raises on a secret spec missing env/value" do
       expect do
         Microsandbox::Sandbox.create("box", image: "x", secrets: [{env: "X"}])
-      end.to raise_error(ArgumentError, /:env, :value, and :host/)
+      end.to raise_error(ArgumentError, /:env and :value/)
+    end
+
+    it "raises on a secret spec with no allowed host" do
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", secrets: [{env: "X", value: "y"}])
+      end.to raise_error(ArgumentError, /:host, :hosts, or :host_patterns/)
+    end
+
+    it "maps fstype, a String init, and ephemeral" do
+      Microsandbox::Sandbox.create(
+        "box", image: "/img/alpine.raw", fstype: "ext4",
+        init: "/sbin/init", ephemeral: true
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "image" => "/img/alpine.raw", "fstype" => "ext4",
+          "init" => {"cmd" => "/sbin/init"}, "ephemeral" => true
+        )
+      )
+    end
+
+    it "normalizes a Hash init with args and env" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        init: {cmd: "/lib/systemd/systemd", args: ["--unit=multi-user.target"],
+               env: {container: "microsandbox"}}
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("init" => {
+          "cmd" => "/lib/systemd/systemd",
+          "args" => ["--unit=multi-user.target"],
+          "env" => {"container" => "microsandbox"}
+        })
+      )
+    end
+
+    it "raises on a Hash init without :cmd" do
+      expect { Microsandbox::Sandbox.create("box", image: "x", init: {args: ["a"]}) }
+        .to raise_error(ArgumentError, /:cmd/)
     end
 
     it "passes the network policy preset string through" do
       Microsandbox::Sandbox.create("box", image: "x", network: :allow_all)
       expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
         "box", hash_including("network" => "allow_all")
+      )
+    end
+
+    it "normalizes dns/tls/pools/max_connections/trust_host_cas" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        dns: {nameservers: ["1.1.1.1"], rebind_protection: true, query_timeout_ms: 2000},
+        tls: {bypass: ["pinned.example.com"], verify_upstream: false,
+              intercepted_ports: [443, 8443], block_quic: true, intercept_ca_cert: "/ca.pem"},
+        ipv4_pool: "10.0.0.0/24", ipv6_pool: "fd00::/64",
+        max_connections: 128, trust_host_cas: true
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including(
+          "dns" => {"nameservers" => ["1.1.1.1"], "rebind_protection" => true,
+                    "query_timeout_ms" => 2000},
+          "tls" => {"bypass" => ["pinned.example.com"], "verify_upstream" => false,
+                    "intercepted_ports" => [443, 8443], "block_quic" => true,
+                    "intercept_ca_cert" => "/ca.pem"},
+          "ipv4_pool" => "10.0.0.0/24", "ipv6_pool" => "fd00::/64",
+          "max_connections" => 128, "trust_host_cas" => true
+        )
       )
     end
 

--- a/spec/unit/value_objects_spec.rb
+++ b/spec/unit/value_objects_spec.rb
@@ -94,6 +94,46 @@ RSpec.describe "value objects" do
       expect(metrics.uptime_secs).to eq(9.5)
       expect(metrics.timestamp).to be_a(Time)
     end
+
+    it "exposes the OCI upper-layer fields (nil when absent)" do
+      expect(metrics.upper_used_bytes).to be_nil
+      with_upper = described_class.new(
+        "cpu_percent" => 0.0, "vcpu_time_ns" => 0, "memory_bytes" => 0,
+        "memory_limit_bytes" => 0, "disk_read_bytes" => 0, "disk_write_bytes" => 0,
+        "net_rx_bytes" => 0, "net_tx_bytes" => 0, "uptime_secs" => 0.0,
+        "timestamp_ms" => 1, "upper_used_bytes" => 100, "upper_free_bytes" => 900,
+        "upper_host_allocated_bytes" => 1_000
+      )
+      expect(with_upper.upper_used_bytes).to eq(100)
+      expect(with_upper.upper_free_bytes).to eq(900)
+      expect(with_upper.upper_host_allocated_bytes).to eq(1_000)
+    end
+  end
+
+  describe Microsandbox::SnapshotInfo do
+    it "parses the full manifest shape (create/open/list_dir path)" do
+      info = described_class.new(
+        "digest" => "sha256:abc", "path" => "/snaps/x", "size_bytes" => 4096,
+        "image_ref" => "alpine:latest", "image_manifest_digest" => "sha256:img",
+        "format" => "raw", "fstype" => "ext4", "parent_digest" => nil,
+        "created_at_ms" => 1_700_000_000_000, "source_sandbox" => "base",
+        "labels" => {"team" => "infra"}
+      )
+      expect(info.digest).to eq("sha256:abc")
+      expect(info.image_manifest_digest).to eq("sha256:img")
+      expect(info.fstype).to eq("ext4")
+      expect(info.format).to eq(:raw)
+      expect(info.source_sandbox).to eq("base")
+      expect(info.labels).to eq({"team" => "infra"})
+      expect(info.created_at).to be_a(Time)
+    end
+
+    it "defaults labels to {} on the index path (get/list/import)" do
+      info = described_class.new("digest" => "sha256:abc", "path" => "/snaps/x", "name" => "x")
+      expect(info.labels).to eq({})
+      expect(info.fstype).to be_nil
+      expect(info.source_sandbox).to be_nil
+    end
   end
 
   describe Microsandbox::LogEntry do
@@ -111,6 +151,96 @@ RSpec.describe "value objects" do
       expect(entry.text).to eq("line\n")
       expect(entry.data.encoding).to eq(Encoding::ASCII_8BIT)
       expect(entry.timestamp).to be_a(Time)
+    end
+  end
+
+  # Captured process output is arbitrary bytes: invalid UTF-8 is common (binary
+  # output, or a relay boundary that splits a multibyte sequence). The text/
+  # stdout/stderr accessors must decode losslessly to *valid* UTF-8 (matching
+  # Python's from_utf8_lossy and Node's TextDecoder{fatal:false}); otherwise
+  # downstream regex/concat/JSON.generate raise Encoding::CompatibilityError.
+  describe "lossy UTF-8 decoding of captured bytes" do
+    # 0xff is never a valid UTF-8 byte; "\xe4\xb8" is a truncated 3-byte char.
+    let(:invalid) { "ok\xff\xe4\xb8".b }
+
+    it "scrubs invalid bytes in LogEntry#text" do
+      entry = Microsandbox::LogEntry.new(
+        "timestamp_ms" => 1, "source" => "stdout", "session_id" => nil,
+        "cursor" => "", "data" => invalid
+      )
+      expect(entry.text.encoding).to eq(Encoding::UTF_8)
+      expect(entry.text).to be_valid_encoding
+      expect(entry.data.encoding).to eq(Encoding::ASCII_8BIT) # raw bytes untouched
+    end
+
+    it "scrubs invalid bytes in ExecOutput#stdout/#stderr" do
+      out = Microsandbox::ExecOutput.new(
+        "exit_code" => 0, "success" => true, "stdout" => invalid, "stderr" => invalid
+      )
+      expect(out.stdout).to be_valid_encoding
+      expect(out.stderr).to be_valid_encoding
+      expect(out.stdout_bytes.encoding).to eq(Encoding::ASCII_8BIT)
+    end
+
+    it "scrubs invalid bytes in ExecEvent#text (and keeps nil for non-data events)" do
+      ev = Microsandbox::ExecEvent.new("type" => "stdout", "data" => invalid)
+      expect(ev.text).to be_valid_encoding
+      exited = Microsandbox::ExecEvent.new("type" => "exited", "code" => 0, "data" => nil)
+      expect(exited.text).to be_nil
+    end
+
+    it "scrubs invalid bytes in SshOutput#stdout/#stderr" do
+      out = Microsandbox::SshOutput.new(
+        "status" => 0, "success" => true, "stdout" => invalid, "stderr" => invalid
+      )
+      expect(out.stdout).to be_valid_encoding
+      expect(out.stderr).to be_valid_encoding
+    end
+  end
+
+  describe Microsandbox::PullSession do
+    let(:native) { instance_double(Microsandbox::Native::PullSession) }
+    subject(:session) { described_class.new(native) }
+
+    it "iterates progress-event Hashes until recv returns nil" do
+      allow(native).to receive(:recv).and_return(
+        {"kind" => "resolving", "reference" => "python"},
+        {"kind" => "complete", "reference" => "python", "layer_count" => 3},
+        nil
+      )
+      expect(session.map { |ev| ev["kind"] }).to eq(%w[resolving complete])
+    end
+
+    it "wraps #result in a live Sandbox" do
+      native_sandbox = instance_double(Microsandbox::Native::Sandbox, name: "box")
+      allow(native).to receive(:result).and_return(native_sandbox)
+      expect(session.sandbox).to be_a(Microsandbox::Sandbox)
+      expect(session.sandbox.name).to eq("box")
+    end
+  end
+
+  describe Microsandbox::FsReadStream do
+    it "iterates byte chunks until recv returns nil, and #read drains them" do
+      native = instance_double(Microsandbox::Native::FsReadStream)
+      allow(native).to receive(:recv).and_return("ab".b, "cd".b, nil)
+      expect(described_class.new(native).read).to eq("abcd".b)
+    end
+  end
+
+  describe Microsandbox::FsWriteSink do
+    let(:native) { instance_double(Microsandbox::Native::FsWriteSink) }
+    subject(:sink) { described_class.new(native) }
+
+    it "writes String bytes (chainable) and rejects non-String" do
+      allow(native).to receive(:write)
+      expect(sink.write("x".b)).to equal(sink)
+      expect(native).to have_received(:write).with("x")
+      expect { sink.write(42) }.to raise_error(TypeError, /must be a String/)
+    end
+
+    it "closes returning nil" do
+      allow(native).to receive(:close)
+      expect(sink.close).to be_nil
     end
   end
 

--- a/spec/unit/volume_fs_spec.rb
+++ b/spec/unit/volume_fs_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Unit coverage for the host-side VolumeFs pure-Ruby wrapper (delegation, value
+# wrapping, write type-checking). The native VolumeFs is stubbed; the real
+# host-filesystem round-trip is exercised by the integration specs.
+RSpec.describe Microsandbox::VolumeFs do
+  let(:native) { instance_double(Microsandbox::Native::VolumeFs) }
+  subject(:fs) { described_class.new(native) }
+
+  it "reads bytes and text" do
+    allow(native).to receive(:read).with("/a").and_return("xx".b)
+    allow(native).to receive(:read_text).with("/a").and_return("hi")
+    expect(fs.read("/a")).to eq("xx")
+    expect(fs.read_text("/a")).to eq("hi")
+  end
+
+  it "wraps list entries in FsEntry and stat in FsMetadata" do
+    allow(native).to receive(:list).with("/d").and_return(
+      [{"path" => "/d/f", "type" => "file", "size" => 1, "mode" => 0o644, "modified_ms" => nil}]
+    )
+    allow(native).to receive(:stat).with("/d").and_return(
+      {"type" => "directory", "size" => 0, "mode" => 0o755,
+       "readonly" => false, "modified_ms" => nil, "created_ms" => nil}
+    )
+    expect(fs.list("/d").first).to be_a(Microsandbox::FsEntry)
+    expect(fs.stat("/d")).to be_a(Microsandbox::FsMetadata)
+  end
+
+  it "rejects non-String writes (no silent to_s)" do
+    expect { fs.write("/a", 42) }.to raise_error(TypeError, /must be a String/)
+  end
+
+  it "delegates a String write (binary-safe)" do
+    allow(native).to receive(:write)
+    fs.write("/a", "data".b)
+    expect(native).to have_received(:write).with("/a", "data")
+  end
+
+  it "returns exists? as a boolean and nil from the mutators" do
+    allow(native).to receive(:exists).with("/a").and_return(true)
+    allow(native).to receive(:mkdir)
+    expect(fs.exists?("/a")).to be(true)
+    expect(fs.mkdir("/a")).to be_nil
+  end
+end


### PR DESCRIPTION
## Summary

Audit-driven parity pass against the upstream Python/Node SDKs at the pinned
`v0.5.8` runtime. Closes the binding gaps a full-repo audit surfaced: 2 real
bug fixes plus the previously-unbound official-SDK surface. Runtime tag
unchanged; gem bumped **0.6.0 → 0.7.0**.

### Fixed
- **Lossy UTF-8 decode** — `LogEntry#text`, `ExecOutput#stdout`/`#stderr`,
  `ExecEvent#text`, `SshOutput#stdout`/`#stderr`, `SftpClient#read_text` now
  `.scrub` to always-valid UTF-8 (was re-tag-only → invalid-encoding strings
  that raised downstream on regex/concat/`JSON.generate`). Raw bytes still via
  `#data` / `#stdout_bytes` / `#stderr_bytes`.
- **`runtime_path=` spec** no longer pollutes the process-wide set-once
  `OnceLock` (an order-dependent failure in combined unit+integration runs).

### Added
- Streaming image-pull progress: `Sandbox.create_with_progress` → `PullSession`
- Host-side `VolumeFs` (`Volume.fs` / `VolumeInfo#fs`)
- Streaming guest fs: `FS#read_stream` / `#write_stream`
- Full secrets surface (multi-host / wildcard allow-lists, injection toggles,
  per-secret + sandbox-level violation policy)
- Network config: `dns:` / `tls:` / `ipv4_pool:` / `ipv6_pool:` /
  `max_connections:` / `trust_host_cas:`
- `init:` / `ephemeral:` / disk-image `fstype:` create options
- Full mount options: tmpfs / disk-image / `stat_virtualization` /
  `host_permissions`
- Snapshot `open`/`list_dir`/`reindex`, `SnapshotInfo#open`/`#remove` + manifest
  fields, `SandboxHandle#snapshot`/`#snapshot_to`/`#config`/`#config_json`
- Metrics `upper_*` fields, `ImageDetail#config["labels"]`, `Microsandbox.setup`

### Changed (minor-breaking)
- `exec` stdin: `:null` / unknown Symbol now errors (was fed as its bytes)
- `FS#write` / `SftpClient#write` / `ExecStdin#write` / `VolumeFs#write` /
  `FsWriteSink#write` raise `TypeError` on non-String (was silent `to_s`)
- agent connect `timeout: 0` = immediate deadline; negative/non-finite raises

### Deferred (documented in README/DESIGN)
- Per-published-port host bind address, network interface overrides, inline
  named-volume create-mode (use `Volume.create` + `{ named: }`)
- Runtime tag bump for upstream #1011 (heartbeat-kill removal) — no upstream
  tag past `v0.5.8`; wait for a release before pinning

### Verification
Gate green: `cargo fmt --check` · `cargo clippy -- -D warnings` · `standardrb` ·
**270 unit examples** (0 failures, +27 new). Real-microVM integration runs on
the CI KVM job at merge (can't boot a VM locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WLGnKZiTG96KUpGeaYYBDE
