### PR TITLE
feat(runtime): adopt upstream v0.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,34 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-25
+
+Adopts upstream runtime **`v0.5.10`** (up from the `v0.5.8` that `0.7.0` shipped).
+Runtime-only bump — no public Ruby API change.
+
+### Runtime
+
+- **Adopted upstream `v0.5.10`** — the `microsandbox`/`microsandbox-network` git
+  deps and `Microsandbox::RUNTIME_VERSION` now pin `v0.5.10`. This is the runtime
+  bump originally attempted against `v0.5.9` during the `0.7.0` cycle and reverted:
+  upstream's `v0.5.9` git tag predated its own crate-version bump, so the prebuilt
+  runtime-provisioning path (`PREBUILT_VERSION = env!("CARGO_PKG_VERSION")`)
+  resolved to `0.5.8` and downloaded a `msb` that rejected the new `--config-fd`
+  flag the SDK unconditionally passes — every `Sandbox.create` died at boot.
+  Upstream chose not to re-tag (most package registries forbid republishing a tag)
+  and instead cut a clean **`v0.5.10`** whose tag carries the matching crate
+  version `0.5.10` (upstream
+  [#1029](https://github.com/superradcompany/microsandbox/issues/1029)). The bump
+  carries two upstream improvements:
+  - **Heartbeat no longer reclaims busy sandboxes** (upstream #1011). The host
+    watchdog is now idle-detection only — a healthy sandbox with an active (or
+    briefly starved) `exec` session is never killed for a stale heartbeat, the
+    way it could be before.
+  - **Launch config moved off the process argv** (upstream #1006). Bulky and
+    secret-bearing config (the network blob, env) is handed to the sandbox over
+    an inherited, unlinked-tempfile fd instead of `--`-flags, so it no longer
+    leaks into `ps` / `/proc/<pid>/cmdline`.
+
 ## [0.7.0] - 2026-06-23
 
 A large parity release closing the binding gaps an audit against the upstream

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Runtime-only bump — no public Ruby API change.
   and instead cut a clean **`v0.5.10`** whose tag carries the matching crate
   version `0.5.10` (upstream
   [#1029](https://github.com/superradcompany/microsandbox/issues/1029)). The bump
-  carries two upstream improvements:
+  carries the following upstream changes:
   - **Heartbeat no longer reclaims busy sandboxes** (upstream #1011). The host
     watchdog is now idle-detection only — a healthy sandbox with an active (or
     briefly starved) `exec` session is never killed for a stale heartbeat, the
@@ -35,6 +35,20 @@ Runtime-only bump — no public Ruby API change.
     secret-bearing config (the network blob, env) is handed to the sandbox over
     an inherited, unlinked-tempfile fd instead of `--`-flags, so it no longer
     leaks into `ps` / `/proc/<pid>/cmdline`.
+
+### Changed
+
+- **Directory bind mounts now carry a default 4 GiB guest-write quota**
+  (upstream #1020). Any `volumes:` entry that binds a host directory (e.g.
+  `volumes: { "/out" => "/host/out" }`) is given a `DEFAULT_BIND_QUOTA_MIB`
+  (4096 MiB) guest-write budget by the v0.5.10 runtime when no explicit quota is
+  set, so a sandbox can no longer fill the host disk through a bind mount. This
+  is a **behavior change**: a workload that wrote more than 4 GiB to a bind mount
+  under the `v0.5.8` runtime (`0.7.0`) will now fail with `ENOSPC`. The gem does
+  not yet expose a per-bind quota override (named-volume `Volume.create` accepts
+  `quota_mib:`, but the inline bind-mount path does not) — that escape hatch is a
+  tracked follow-up. Until then, route large-write mounts through a named volume
+  with an explicit `quota_mib:`.
 
 ## [0.7.0] - 2026-06-23
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3003,8 +3003,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3056,8 +3056,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3069,8 +3069,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3081,8 +3081,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3094,8 +3094,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3120,8 +3120,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "chrono",
  "libc",
@@ -3131,8 +3131,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3140,8 +3140,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "base64",
  "bytes",
@@ -3180,8 +3180,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3195,8 +3195,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "bytes",
  "chrono",
@@ -3225,8 +3225,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "chrono",
  "serde",
@@ -3237,8 +3237,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.8"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.8#47d0cdf1ef3b4b41885eb3efd67b759fd5540e9e"
+version = "0.5.10"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
 dependencies = [
  "dirs",
  "libc",
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "chrono",
  "futures",

--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ Microsandbox.runtime_version   # => "v0.5.10"  (the embedded upstream runtime ta
 | `0.5.12` | `v0.5.8` | gem-only revision |
 | `0.6.0`  | `v0.5.8` | gem version decoupled from the upstream tag; adds `runtime_version` |
 | `0.7.0`  | `v0.5.8` | SDK parity release (large binding-gap closure) |
-| `0.8.0`  | `v0.5.10` | adopts upstream `v0.5.10` (idle-only heartbeat, config-fd hardening); supersedes the reverted `v0.5.9` attempt |
+| `0.8.0`  | `v0.5.10` | adopts upstream `v0.5.10` (idle-only heartbeat, config-fd hardening, **4 GiB default bind-mount quota**); supersedes the reverted `v0.5.9` attempt |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/README.md
+++ b/README.md
@@ -383,8 +383,8 @@ change diverged the two numbers — the gem version is **not** a reliable indica
 of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
-Microsandbox::VERSION          # => "0.6.0"  (the gem's own version)
-Microsandbox.runtime_version   # => "v0.5.8"  (the embedded upstream runtime tag)
+Microsandbox::VERSION          # => "0.8.0"  (the gem's own version)
+Microsandbox.runtime_version   # => "v0.5.10"  (the embedded upstream runtime tag)
 ```
 
 | Gem version | Upstream runtime | Notes |
@@ -396,6 +396,8 @@ Microsandbox.runtime_version   # => "v0.5.8"  (the embedded upstream runtime tag
 | `0.5.11` | `v0.5.8` | gem-only revision |
 | `0.5.12` | `v0.5.8` | gem-only revision |
 | `0.6.0`  | `v0.5.8` | gem version decoupled from the upstream tag; adds `runtime_version` |
+| `0.7.0`  | `v0.5.8` | SDK parity release (large binding-gap closure) |
+| `0.8.0`  | `v0.5.10` | adopts upstream `v0.5.10` (idle-only heartbeat, config-fd hardening); supersedes the reverted `v0.5.9` attempt |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,8 +6,8 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.5.8).
-version = "0.7.0"
+# The core-crate dependency below stays pinned at its own tag (v0.5.10).
+version = "0.8.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.8" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.10", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.10" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,12 +8,12 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in
   # ext/microsandbox/Cargo.toml. Exposed at runtime as
   # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
   # sync with the Cargo tag so it can't silently drift out of date.
-  RUNTIME_VERSION = "v0.5.8"
+  RUNTIME_VERSION = "v0.5.10"
 end


### PR DESCRIPTION
## What

Adopts upstream runtime **`v0.5.10`** (up from the `v0.5.8` that `0.7.0` shipped) and bumps the gem to **`0.8.0`**. Runtime-only change — no public Ruby API moved, so binding code, RBS, and unit behavior are untouched.

## Why this is v0.5.10 and not v0.5.9

This is the runtime bump originally attempted against `v0.5.9` (`0d46933`) and **reverted** (`b64a9fd`). Upstream's `v0.5.9` git tag predated its own crate-version bump, so the prebuilt provisioning path (`PREBUILT_VERSION = env!("CARGO_PKG_VERSION")`) resolved to `0.5.8` and downloaded a `msb` that rejected the new `--config-fd` flag `spawn.rs` unconditionally passes — every `Sandbox.create` died at boot.

Upstream declined to re-tag (registries forbid republishing a tag) and cut a clean **`v0.5.10`** whose tag carries the matching crate version `0.5.10` ([issue #1029](https://github.com/superradcompany/microsandbox/issues/1029), CLOSED). The broken `v0.5.9` tag is left untouched upstream; this PR skips it entirely and jumps `v0.5.8 → v0.5.10`.

## What the bump carries

- **Heartbeat no longer reclaims busy sandboxes** (upstream #1011) — the host watchdog is now idle-detection only.
- **Launch config moved off the process argv** (upstream #1006) — bulky/secret-bearing config (network blob, env) goes over an inherited unlinked-tempfile fd instead of `--`-flags, so it no longer leaks into `ps` / `/proc/<pid>/cmdline`.

## Changes

- `ext/microsandbox/Cargo.toml` — both git deps `tag` → `v0.5.10`; `[package] version` → `0.8.0`
- `lib/microsandbox/version.rb` — `VERSION` → `0.8.0`, `RUNTIME_VERSION` → `v0.5.10`
- `Cargo.lock` — regenerated against the **real git tag** (sibling path override disabled during regen); only microsandbox-family source revs + versions move, no transitive bumps
- `CHANGELOG.md` — new `[0.8.0]` Runtime section; `README.md` — version-map rows for `0.7.0` (restored) and `0.8.0`

## Verification

Local gate green: `cargo fmt --check`, `cargo clippy -D warnings`, `standardrb`, **287 unit examples** (incl. `version_spec` asserting `Native.version == 0.8.0` and `RUNTIME_VERSION == Cargo tag`). Full compile succeeds against the real `v0.5.10` git tag.

⚠️ The unit suite stubs the native layer and **cannot** catch boot failures — the exact gap that let the `v0.5.9` breakage stay unit-green. A **real-microVM integration `workflow_dispatch`** has been triggered against this branch (the `integration` job is gated off PR events). This PR should not merge until that run is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdXnrjRTiPfqg1YNqNrZwv