### PR TITLE
fix(runtime): re-provision a stale local msb instead of boot-failing (#18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+### Fixed
+
+- **Stale local runtime is now re-provisioned instead of boot-failing**
+  (issue #18). `Microsandbox.ensure_runtime!` short-circuited as soon as
+  `installed?` was true, but that check confirms only that the `msb`/`libkrunfw`
+  files *exist*, not that their version matches the runtime this gem build links.
+  An older `msb` left in `~/.microsandbox` by a previous gem version therefore
+  passed and then failed every `Sandbox.create` at boot on a host↔guest
+  wire-protocol mismatch (e.g. a `v0.5.8` `msb` rejecting the `--config-fd` flag
+  the `v0.5.10` runtime passes). `ensure_runtime!` now delegates to the
+  idempotent, version-correcting installer on first use even when the runtime is
+  present (a cheap `msb --version`; re-downloads only on absence/mismatch), so an
+  upgrade-over-stale-install self-heals. Source-gem installs were already
+  corrected at build time; this closes the gap for the precompiled-gem upgrade
+  path. `MICROSANDBOX_NO_AUTO_INSTALL` still fully opts out.
+
 ## [0.8.0] - 2026-06-25
 
 Adopts upstream runtime **`v0.5.10`** (up from the `v0.5.8` that `0.7.0` shipped).

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -93,16 +93,27 @@ module Microsandbox
       Native.installed?
     end
 
-    # Ensure the `msb` runtime + `libkrunfw` are present, provisioning them on
-    # first use if not. Called automatically by {Sandbox.create}/{Sandbox.start}
-    # so precompiled-gem users (who never ran the source build) get a working
-    # runtime without a manual {install} step.
+    # Ensure the `msb` runtime + `libkrunfw` are present *and version-matched*,
+    # provisioning them on first use if not. Called automatically by
+    # {Sandbox.create}/{Sandbox.start} so precompiled-gem users (who never ran the
+    # source build) get a working runtime without a manual {install} step.
     #
-    # The download is attempted at most once per process. Opt out by setting
+    # Runs at most once per process. Opt out by setting
     # `MICROSANDBOX_NO_AUTO_INSTALL` (e.g. air-gapped hosts that provision the
-    # runtime out of band); the subsequent operation then surfaces the missing
-    # runtime itself. Already-installed runtimes (e.g. source builds) skip
-    # straight through with only a cheap presence check.
+    # runtime out of band); the runtime is then left untouched and a missing or
+    # stale one surfaces at the operation itself.
+    #
+    # NOTE: this delegates to {install} even when {installed?} is already true,
+    # rather than short-circuiting on presence. {installed?} (upstream
+    # `verify_installation`) only confirms the `msb`/`libkrunfw` files *exist*, not
+    # that their version matches the runtime this gem build links. {install} is
+    # idempotent and *version-correcting*: it runs a cheap `msb --version` and
+    # re-downloads ONLY when the binary is absent or its version differs, then
+    # no-ops. A presence-only short-circuit would let a stale `msb` left in
+    # `~/.microsandbox` by an older gem pass, then fail every {Sandbox.create} on a
+    # host↔guest wire-protocol mismatch (e.g. a `v0.5.8` `msb` rejecting the
+    # `--config-fd` flag the `v0.5.10` runtime passes). Keep the {install} call on
+    # this path — do not "optimize" it back to skip-when-present.
     # @return [nil]
     def ensure_runtime!
       return if @runtime_ready
@@ -111,14 +122,18 @@ module Microsandbox
       # uses the same lazy env/profile/config ladder every operation already
       # consults, so this adds no work for local hosts (the common case).
       return if default_backend_kind == :cloud
-      if installed?
+      # Opted out: the caller manages the runtime out of band, so don't fetch,
+      # verify, or repair it here. Memoize the decision (the env var is stable for
+      # the process); the operation resolves `msb` itself and surfaces any problem.
+      if auto_install_disabled?
         @runtime_ready = true
         return
       end
-      return if auto_install_disabled?
 
-      warn "[microsandbox] runtime (msb + libkrunfw) not found; " \
-           "downloading to ~/.microsandbox (set MICROSANDBOX_NO_AUTO_INSTALL to skip)..."
+      unless installed?
+        warn "[microsandbox] runtime (msb + libkrunfw) not found; " \
+             "downloading to ~/.microsandbox (set MICROSANDBOX_NO_AUTO_INSTALL to skip)..."
+      end
       install
       @runtime_ready = true
       nil

--- a/spec/unit/runtime_spec.rb
+++ b/spec/unit/runtime_spec.rb
@@ -68,20 +68,30 @@ RSpec.describe "Microsandbox runtime helpers" do
       Microsandbox.instance_variable_set(:@runtime_ready, nil)
     end
 
-    it "is a no-op (no install) when the runtime is already present" do
+    it "still runs the version-correcting installer when the runtime is present" do
+      # Regression guard for the stale-runtime boot failure (issue #18):
+      # `installed?` checks file *presence* only, so a stale msb left by an older
+      # gem passes it. `install` is idempotent + version-correcting (cheap
+      # `msb --version`, re-downloads only on mismatch), so ensure_runtime! must
+      # delegate to it even when present rather than short-circuit. It must NOT
+      # warn in this case (nothing is missing).
       allow(Microsandbox).to receive(:installed?).and_return(true)
       allow(Microsandbox).to receive(:install)
+      allow(Microsandbox).to receive(:warn)
       Microsandbox.ensure_runtime!
-      expect(Microsandbox).not_to have_received(:install)
+      Microsandbox.ensure_runtime! # second call is memoized, not re-checked
+      expect(Microsandbox).to have_received(:install).once
+      expect(Microsandbox).not_to have_received(:warn)
     end
 
-    it "auto-installs once when the runtime is missing" do
+    it "auto-installs once (with a notice) when the runtime is missing" do
       allow(Microsandbox).to receive(:installed?).and_return(false)
       allow(Microsandbox).to receive(:install)
       allow(Microsandbox).to receive(:warn)
       Microsandbox.ensure_runtime!
       Microsandbox.ensure_runtime! # second call should be memoized, not re-install
       expect(Microsandbox).to have_received(:install).once
+      expect(Microsandbox).to have_received(:warn).once
     end
 
     it "does not auto-install when MICROSANDBOX_NO_AUTO_INSTALL is set" do
@@ -99,6 +109,17 @@ RSpec.describe "Microsandbox runtime helpers" do
       stub_const("ENV", ENV.to_h.merge("MICROSANDBOX_NO_AUTO_INSTALL" => "false"))
       Microsandbox.ensure_runtime!
       expect(Microsandbox).to have_received(:install)
+    end
+
+    it "skips the local-runtime check entirely under a cloud backend" do
+      # A cloud backend has no local msb/libkrunfw to provision, so neither the
+      # presence/version check nor a download should run.
+      allow(Microsandbox).to receive(:default_backend_kind).and_return(:cloud)
+      allow(Microsandbox).to receive(:installed?)
+      allow(Microsandbox).to receive(:install)
+      Microsandbox.ensure_runtime!
+      expect(Microsandbox).not_to have_received(:installed?)
+      expect(Microsandbox).not_to have_received(:install)
     end
   end
 end


### PR DESCRIPTION
Closes #18.

## Problem

`Microsandbox.ensure_runtime!` short-circuited as soon as `installed?` was true:

```ruby
if installed?
  @runtime_ready = true
  return
end
```

But `installed?` → upstream `verify_installation` confirms only that the `msb`/`libkrunfw` files **exist**, not that their version matches the runtime this gem build links. A stale `msb` left in `~/.microsandbox` by an older gem therefore passed the check, and `ensure_runtime!` never reached `install` — which *does* version-check and re-download on mismatch. With `0.8.0`'s `v0.5.10` runtime passing the new `--config-fd` flag, a stale `v0.5.8` `msb` rejects it and **every `Sandbox.create` dies at boot**. Same boot-failure class as the reverted `v0.5.9` adoption, re-entering through a stale local install instead of a broken upstream tag.

**Blast radius:** the **precompiled-gem upgrade path**. Source gems re-provision `~/.microsandbox` via `build.rs` at install time (version-checked), so they self-correct; precompiled gems skip the Rust build entirely and rely on this first-use path. Latent today (precompiled gems aren't tag-auto-published) — **must land before any precompiled-gem promotion.**

## Fix

`ensure_runtime!` now delegates to `install` on first use **even when the runtime is present**, rather than short-circuiting on presence. `install` (`setup::install`) is idempotent **and version-correcting**: it runs a cheap `msb --version` and re-downloads ONLY when the binary is absent or its version differs from the linked `PREBUILT_VERSION`, then no-ops.

Delegating to upstream's own check (rather than comparing versions in Ruby) is deliberate: it keeps a single source of truth and avoids the `"v"`-prefix trap between `RUNTIME_VERSION = "v0.5.10"` and the bare `"0.5.10"` that `msb --version` reports. The docstring spells out why the `install` call must stay on this path so a future change doesn't "optimize" it back to skip-when-present.

`MICROSANDBOX_NO_AUTO_INSTALL` still fully opts out (now memoized); a cloud backend still skips the local check entirely.

### Cost

One `msb --version` subprocess on the first `Sandbox.create` per process (memoized by `@runtime_ready`; inherited copy-on-write across `fork`, so no per-fork storm). No network when the runtime is already current. Detecting staleness *requires* reading the installed version, so this subprocess is unavoidable in any correct fix.

## Tests

- Replaced the `"no-op (no install) when present"` test — it asserted the buggy presence-only short-circuit — with one asserting `install` still runs (and no spurious warning) when present.
- Added a cloud-backend skip test (no presence check, no download).
- Gate green: `standardrb` + **288 unit examples, 0 failures**. Pure Ruby — no native/RBS change.

Staged under `[Unreleased]`; no version bump (release timing is a separate call — can bundle with #19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdXnrjRTiPfqg1YNqNrZwv