### PR TITLE
feat(volumes): expose a per-bind-mount guest-write quota override (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+### Added
+
+- **Per-bind-mount guest-write quota override** (issue #19). An inline `volumes:`
+  bind mount now accepts a `quota_mib:` key to override the runtime's default
+  guest-write budget (4 GiB as of `v0.5.10`, documented in `0.8.0`), e.g.
+  `volumes: { "/out" => { bind: "/host/out", quota_mib: 16_384 } }`. The runtime
+  still applies the 4 GiB default when unset; there is no unbounded option, so
+  raise the value if a workload writes more. Valid on bind mounts only — the core
+  rejects it on tmpfs/disk/named mounts (set a named volume's quota via
+  `Volume.create(quota_mib:)`).
+
 ## [0.8.0] - 2026-06-25
 
 Adopts upstream runtime **`v0.5.10`** (up from the `v0.5.8` that `0.7.0` shipped).

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -122,6 +122,10 @@ impl Sandbox {
                 .ok_or_else(|| error::base_error("volume mount is missing :kind"))?;
             let source = conv::opt_string(m, "source")?;
             let size_mib = conv::opt_u32(m, "size_mib")?;
+            // Bind-mount guest-write quota override (MiB). The core's MountBuilder
+            // applies it to bind mounts only and rejects it on tmpfs/disk/named at
+            // build(); we forward it as-is so that validation lives in one place.
+            let quota_mib = conv::opt_u32(m, "quota_mib")?;
             let fstype = conv::opt_string(m, "fstype")?;
             let readonly = conv::opt_bool(m, "readonly")?;
             let noexec = conv::opt_bool(m, "noexec")?;
@@ -160,6 +164,9 @@ impl Sandbox {
                 };
                 if let Some(n) = size_mib {
                     mb = mb.size(n);
+                }
+                if let Some(q) = quota_mib {
+                    mb = mb.quota(q);
                 }
                 if let Some(f) = format {
                     mb = mb.format(f);

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -230,7 +230,10 @@ module Microsandbox
       #   `{ disk: "/img.raw", format: "raw", fstype: "ext4" }`. Any mount may add
       #   flags `ro:`/`readonly:`, `noexec:`, `nosuid:`, `nodev:`, and (bind/named
       #   only) `stat_virtualization:` (:strict/:relaxed/:off) and
-      #   `host_permissions:` (:private/:mirror).
+      #   `host_permissions:` (:private/:mirror). A bind mount accepts
+      #   `quota_mib:` to override the runtime's default guest-write budget
+      #   (4 GiB as of `v0.5.10`); the core rejects it on tmpfs/disk/named (for a
+      #   named volume, set its quota via {Volume.create}).
       # @param network [String, Symbol, NetworkPolicy, Hash, nil] network policy.
       #   A preset name ("public_only" (default), "none", "allow_all",
       #   "non_local"), a {NetworkPolicy} (e.g. {NetworkPolicy.custom}), or a Hash
@@ -677,11 +680,12 @@ module Microsandbox
       # Hashes for the native layer. A spec is a host path String (a read-write
       # bind mount) or a Hash describing the mount:
       #   { bind: "/host", ro: true, noexec: true }            # host bind mount
+      #   { bind: "/host", quota_mib: 16_384 }                  # raise the 4 GiB cap
       #   { named: "vol" }                                       # named volume
       #   { tmpfs: true, size_mib: 64 }                          # memory-backed
       #   { disk: "/img.raw", format: "raw", fstype: "ext4" }   # disk-image mount
       # Any mount may also carry stat_virtualization: (:strict/:relaxed/:off) and
-      # host_permissions: (:private/:mirror).
+      # host_permissions: (:private/:mirror); a bind mount may carry quota_mib:.
       def normalize_volumes(volumes)
         volumes.map do |guest, spec|
           mount = {"guest" => guest.to_s}
@@ -722,6 +726,12 @@ module Microsandbox
         mount["size_mib"] = Integer(size) if size
         fstype = spec[:fstype] || spec["fstype"]
         mount["fstype"] = fstype.to_s if fstype
+        # Bind-mount guest-write quota (MiB). Overrides the runtime's default
+        # budget (4 GiB as of v0.5.10); the core applies it only to bind mounts
+        # and rejects it on tmpfs/disk/named. `0` is forwarded as-is (a zero
+        # budget), not treated as "unset".
+        quota = spec[:quota_mib] || spec["quota_mib"]
+        mount["quota_mib"] = Integer(quota) if quota
       end
 
       # Apply a volume spec Hash's mount flags. `ro:`/`readonly:` makes the mount

--- a/spec/unit/roadmap_spec.rb
+++ b/spec/unit/roadmap_spec.rb
@@ -165,6 +165,20 @@ RSpec.describe "streaming exec, images, volumes" do
       )
     end
 
+    it "forwards a bind-mount quota_mib override" do
+      Microsandbox::Sandbox.create(
+        "box", image: "x",
+        volumes: {"/out" => {bind: "/host/out", quota_mib: 16_384}}
+      )
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("volumes" => [
+          {"guest" => "/out", "kind" => "bind", "source" => "/host/out",
+           "quota_mib" => 16_384}
+        ])
+      )
+    end
+
     it "raises on a malformed volume spec" do
       expect do
         Microsandbox::Sandbox.create("box", image: "x", volumes: {"/data" => {wrong: 1}})


### PR DESCRIPTION
Closes #19.

## Background

`v0.5.10` (upstream #1020) gives every directory bind mount a default **4 GiB** guest-write budget (`DEFAULT_BIND_QUOTA_MIB`) when no explicit quota is set — so a sandbox can't fill the host disk through a bind mount. That default is documented in the `0.8.0` CHANGELOG, but the gem exposed **no way to raise it** on the inline `volumes:` bind path (only named-volume `Volume.create` accepts `quota_mib:`). A workload that wrote >4 GiB to a bind mount under `v0.5.8` (gem `0.7.0`) now fails with `ENOSPC` with no Ruby-side escape hatch.

## Change

An inline `volumes:` bind mount now accepts a `quota_mib:` key:

```ruby
volumes: { "/out" => { bind: "/host/out", quota_mib: 16_384 } }   # 16 GiB
```

- `normalize_volumes` forwards `quota_mib:` into the per-mount Hash; the native layer reads it and calls the core `MountBuilder::quota`.
- **Validation stays in one place**: the core applies the quota to bind mounts only and rejects it on tmpfs/disk/named at `build()`, so the gem forwards it as-is rather than re-checking in Ruby (consistent with how the other mount options defer to the core). For a named volume, set its quota via `Volume.create(quota_mib:)`.
- **No unbounded option**: the runtime always applies the 4 GiB default when the quota is unset, so the only lever is a higher number. `0` is forwarded as-is (a zero budget), not treated as "unset".

## Tests / docs

- New unit spec asserts `quota_mib:` reaches the normalized mount Hash.
- `volumes:` YARD + `normalize_volumes` comment updated; CHANGELOG `### Added`. RBS already types `volumes:` as `Hash[untyped, untyped]`.
- Gate green: `cargo fmt --check`, `cargo clippy -D warnings`, `standardrb`, **288 unit examples, 0 failures**. Native compiles against the `v0.5.10` API (`MountBuilder::quota`).

Staged under `[Unreleased]`; no version bump. **Independent of #18 (PR #20)** — both branch off `main` and touch disjoint code (only the `[Unreleased]` CHANGELOG section overlaps; trivial merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdXnrjRTiPfqg1YNqNrZwv