### PR TITLE
chore(release): 0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-06-25
+
+Gem-only release on the `v0.5.10` runtime (unchanged) — the two follow-ups to
+`0.8.0`'s runtime adoption that review surfaced.
+
 ### Added
 
 - **Per-bind-mount guest-write quota override** (issue #19). An inline `volumes:`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "chrono",
  "futures",

--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ Microsandbox.runtime_version   # => "v0.5.10"  (the embedded upstream runtime ta
 | `0.6.0`  | `v0.5.8` | gem version decoupled from the upstream tag; adds `runtime_version` |
 | `0.7.0`  | `v0.5.8` | SDK parity release (large binding-gap closure) |
 | `0.8.0`  | `v0.5.10` | adopts upstream `v0.5.10` (idle-only heartbeat, config-fd hardening, **4 GiB default bind-mount quota**); supersedes the reverted `v0.5.9` attempt |
+| `0.8.1`  | `v0.5.10` | gem-only: re-provision a stale local runtime; per-bind-mount `quota_mib:` override |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.10).
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,7 +8,7 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in


### PR DESCRIPTION
Cuts **0.8.1** — a gem-only release on the `v0.5.10` runtime (unchanged), shipping the two reviewed follow-ups to `0.8.0`'s runtime adoption (already merged under `[Unreleased]`):

- **Fixed (#18)** — `ensure_runtime!` re-provisions a stale local `msb` instead of boot-failing (the version-blind `installed?` short-circuit).
- **Added (#19)** — per-bind-mount `quota_mib:` override for `v0.5.10`'s 4 GiB default guest-write budget.

Patch bump per the gem's semver (`0.x`: breaking → minor, additions/fixes → patch; neither follow-up is breaking). Lock-step: `version.rb` + `ext/microsandbox/Cargo.toml` + `Cargo.lock` all → `0.8.1` (`version_spec` asserts `Native.version == VERSION == 0.8.1` and `RUNTIME_VERSION == Cargo tag == v0.5.10`); CHANGELOG `[Unreleased]` → `[0.8.1]`; README version-map row added.

Gate green locally: `cargo fmt --check`, `cargo clippy -D warnings`, `standardrb`, **289 unit examples, 0 failures**.

After merge, tag `v0.8.1` on the merge commit → `release.yml` publishes the source gem via OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AdXnrjRTiPfqg1YNqNrZwv