### PR TITLE
fix(security): redact secret values from errors; guard native duration parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+### Security
+
+- **Secret values no longer leak into `ArgumentError` messages** (issue #23).
+  `Sandbox.create(secrets:)` validation interpolated the whole secret spec via
+  `spec.inspect` into two error messages — and because the `:value`-present
+  guard runs first, the "needs `:host`/`:hosts`/`:host_patterns`" error *always*
+  embedded the cleartext secret value (and the env/value error did whenever a
+  value was supplied). Such messages routinely reach logs and error trackers.
+  Both messages now report the spec's keys only (`spec.keys.inspect`), mirroring
+  the existing `registry_auth` handling, with a unit spec asserting the value
+  is never present in the raised message.
+
+### Fixed
+
+- **Native duration parsing is panic-free regardless of the Ruby layer**
+  (issue #30). The native binding called `Duration::from_secs_f64` directly at
+  five sites (`exec`/`shell` timeout, `stop_with_timeout`, `kill_with_timeout`,
+  `metrics_stream` interval, `replace_with_timeout`); that panics on NaN/Inf/
+  negative *and on finite-but-out-of-range* values (e.g. `Float::MAX`), which
+  surfaced as an ugly panic-turned-exception. The Ruby `coerce_duration` guard
+  set no upper bound, so a large finite value still reached and panicked the
+  native layer. All five sites now route through a `secs_to_duration` helper
+  (`try_from_secs_f64` + a clean `Microsandbox::Error`), matching the existing
+  agent-client pattern — defense in depth so the native layer is panic-free on
+  its own.
+
 ## [0.8.1] - 2026-06-25
 
 Gem-only release on the `v0.5.10` runtime (unchanged) — the two follow-ups to

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -40,6 +40,21 @@ use crate::exec::ExecHandle;
 use crate::runtime::{block_on, ruby};
 use crate::stream::{LogStream, MetricsStream};
 
+/// Convert a seconds `f64` into a `Duration`, surfacing a clean Ruby error
+/// instead of the panic `Duration::from_secs_f64` raises on NaN/Inf/negative —
+/// *and on finite-but-out-of-range* values (e.g. `Float::MAX`). The Ruby
+/// `coerce_duration` already guards the public paths, but it sets no upper
+/// bound, so a large finite value would still reach (and panic) the native
+/// layer; this keeps the native layer panic-free regardless of the Ruby layer,
+/// mirroring `agent::dur`.
+fn secs_to_duration(secs: f64) -> Result<Duration, Error> {
+    Duration::try_from_secs_f64(secs).map_err(|e| {
+        error::base_error(format!(
+            "duration must be a non-negative, finite number of seconds in range (got {secs}: {e})"
+        ))
+    })
+}
+
 #[magnus::wrap(class = "Microsandbox::Native::Sandbox", free_immediately, size)]
 pub struct Sandbox {
     inner: microsandbox::Sandbox,
@@ -380,7 +395,7 @@ impl Sandbox {
             b = b.detached(true);
         }
         if let Some(secs) = conv::opt_f64(opts, "replace_with_timeout")? {
-            b = b.replace_with_timeout(Duration::from_secs_f64(secs));
+            b = b.replace_with_timeout(secs_to_duration(secs)?);
         } else if conv::opt_bool(opts, "replace")? {
             b = b.replace();
         }
@@ -579,14 +594,22 @@ impl Sandbox {
 
     /// Stream metrics snapshots at `interval` seconds. Returns a MetricsStream
     /// to pull snapshots from.
-    fn metrics_stream(&self, interval: f64) -> MetricsStream {
-        let dur = Duration::from_secs_f64(if interval <= 0.0 { 1.0 } else { interval });
+    fn metrics_stream(&self, interval: f64) -> Result<MetricsStream, Error> {
+        // `interval <= 0.0` (0 or negative) keeps the prior 1s-default behavior;
+        // NaN (for which `<= 0.0` is false) and finite-but-out-of-range values
+        // fall through to `secs_to_duration`, which errors cleanly rather than
+        // letting `from_secs_f64` panic across the FFI boundary.
+        let dur = if interval <= 0.0 {
+            Duration::from_secs(1)
+        } else {
+            secs_to_duration(interval)?
+        };
         // `metrics_stream` is synchronous but builds a `tokio::time::interval`,
         // which panics ("no reactor running") unless constructed inside the
         // runtime context — so build it under `block_on`. (`log_stream` is async
         // and already runs inside `block_on`, so it needs no such wrapper.)
         let stream = block_on(async { self.inner.metrics_stream(dur) });
-        MetricsStream::from_stream(stream)
+        Ok(MetricsStream::from_stream(stream))
     }
 
     /// Stream captured logs as they appear. `opts`: sources, since_ms,
@@ -1544,7 +1567,9 @@ impl ExecOpts {
             cwd: conv::opt_string(opts, "cwd")?,
             user: conv::opt_string(opts, "user")?,
             env: conv::opt_string_map(opts, "env")?,
-            timeout: conv::opt_f64(opts, "timeout")?.map(Duration::from_secs_f64),
+            timeout: conv::opt_f64(opts, "timeout")?
+                .map(secs_to_duration)
+                .transpose()?,
             tty: conv::opt_bool(opts, "tty")?,
             stdin,
             stdin_pipe: conv::opt_bool(opts, "stdin_pipe")?,
@@ -1907,8 +1932,7 @@ impl SbHandle {
 
     /// Graceful stop with a custom escalation timeout (seconds).
     fn stop_with_timeout(&self, secs: f64) -> Result<(), Error> {
-        block_on(self.inner.stop_with_timeout(Duration::from_secs_f64(secs)))
-            .map_err(error::to_ruby)
+        block_on(self.inner.stop_with_timeout(secs_to_duration(secs)?)).map_err(error::to_ruby)
     }
 
     /// Force kill (SIGKILL) and wait.
@@ -1918,8 +1942,7 @@ impl SbHandle {
 
     /// Force kill, waiting up to `secs` for the process to disappear.
     fn kill_with_timeout(&self, secs: f64) -> Result<(), Error> {
-        block_on(self.inner.kill_with_timeout(Duration::from_secs_f64(secs)))
-            .map_err(error::to_ruby)
+        block_on(self.inner.kill_with_timeout(secs_to_duration(secs)?)).map_err(error::to_ruby)
     }
 
     /// Send the graceful-shutdown request and return without waiting.

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -526,7 +526,10 @@ module Microsandbox
         env = spec[:env] || spec["env"]
         value = spec[:value] || spec["value"]
         unless env && value
-          raise ArgumentError, "secret spec needs :env and :value (got #{spec.inspect})"
+          # Report only the keys given, never the values — a secret spec carries
+          # the cleartext :value, and exception messages routinely land in logs
+          # and error trackers. Mirrors apply_registry_opts above.
+          raise ArgumentError, "secret spec needs :env and :value (got keys: #{spec.keys.inspect})"
         end
         out = {"env" => env.to_s, "value" => value.to_s}
         hosts = Array(spec[:hosts] || spec["hosts"]).map(&:to_s)
@@ -534,8 +537,10 @@ module Microsandbox
         hosts << single.to_s if single
         patterns = Array(spec[:host_patterns] || spec["host_patterns"]).map(&:to_s)
         if hosts.empty? && patterns.empty?
+          # Keys only — this branch runs after :value is confirmed present, so
+          # spec.inspect would always embed the cleartext secret value.
           raise ArgumentError,
-            "secret spec needs :host, :hosts, or :host_patterns (got #{spec.inspect})"
+            "secret spec needs :host, :hosts, or :host_patterns (got keys: #{spec.keys.inspect})"
         end
         out["hosts"] = hosts unless hosts.empty?
         out["host_patterns"] = patterns unless patterns.empty?

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -165,10 +165,32 @@ RSpec.describe Microsandbox::Sandbox do
       end.to raise_error(ArgumentError, /:env and :value/)
     end
 
+    it "never embeds the cleartext secret value in the env/value error" do
+      # env missing but value present: the :env-and-:value guard fires while a
+      # value is in hand — the message must report keys only, not the secret.
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", secrets: [{value: "sk_live_LEAK"}])
+      end.to raise_error(ArgumentError) { |e|
+        expect(e.message).to match(/:env and :value/)
+        expect(e.message).not_to include("sk_live_LEAK")
+      }
+    end
+
     it "raises on a secret spec with no allowed host" do
       expect do
         Microsandbox::Sandbox.create("box", image: "x", secrets: [{env: "X", value: "y"}])
       end.to raise_error(ArgumentError, /:host, :hosts, or :host_patterns/)
+    end
+
+    it "never embeds the cleartext secret value in the host error" do
+      # The host guard runs only after :value is confirmed present, so a naive
+      # spec.inspect would always leak the live credential into the message.
+      expect do
+        Microsandbox::Sandbox.create("box", image: "x", secrets: [{env: "X", value: "sk_live_LEAK"}])
+      end.to raise_error(ArgumentError) { |e|
+        expect(e.message).to match(/:host, :hosts, or :host_patterns/)
+        expect(e.message).not_to include("sk_live_LEAK")
+      }
     end
 
     it "maps fstype, a String init, and ephemeral" do
@@ -675,5 +697,30 @@ RSpec.describe "Microsandbox.all_sandbox_metrics" do
     expect(metrics.keys).to eq(["box"])
     expect(metrics["box"]).to be_a(Microsandbox::Metrics)
     expect(metrics["box"].cpu_percent).to eq(12.5)
+  end
+end
+
+# The native binding parses durations with try_from_secs_f64, so a bad value is
+# rejected as a clean Microsandbox::Error *before* any microVM boot — never a
+# Rust panic across the FFI boundary. This exercises the REAL native layer (no
+# stub): build_builder validates replace_with_timeout while constructing the
+# builder, so it raises without ever calling .create(). Mirrors the agent
+# client's timeout-validation specs. (The other native duration sites — exec
+# timeout, stop/kill_with_timeout, metrics_stream interval — reach the same
+# secs_to_duration helper but only via a live Sandbox/SandboxHandle instance,
+# which the unit suite can't construct without a microVM, so they are covered by
+# the integration suite; the Ruby coerce_duration guard for them is unit-tested
+# above with the native layer stubbed. Note metrics_stream keeps a `<= 0.0`
+# branch that defaults 0/negative to 1s, so only NaN/out-of-range reach
+# secs_to_duration there — that NaN-specific branch is integration-only.)
+RSpec.describe "native duration validation (panic-free)" do
+  [Float::MAX, Float::INFINITY, -Float::INFINITY, Float::NAN].each do |bad|
+    it "rejects #{bad.inspect} replace_with_timeout as a clean error, never a panic" do
+      expect do
+        Microsandbox::Native::Sandbox.create(
+          "duration-probe", {"image" => "x", "replace_with_timeout" => bad}
+        )
+      end.to raise_error(Microsandbox::Error, /duration must be a non-negative, finite number/)
+    end
   end
 end


### PR DESCRIPTION
Adversarially re-verified two self-filed audit findings against the current source, then fixed both. Closes #23 and #30.

## #23 — Cleartext secret value leaked into `ArgumentError` (Security)

`normalize_secret` interpolated the whole secret spec via `spec.inspect` into two error messages. Because the `:value`-present guard (`unless env && value`) runs *first*, the "needs `:host`/`:hosts`/`:host_patterns`" message **always** embedded the cleartext secret value, and the env/value message did whenever a value was supplied. These messages routinely land in logs and error trackers (Sentry/Rollbar/stdout) — exactly the exposure the secrets feature exists to prevent.

**Fix:** report `spec.keys.inspect` only in both messages, mirroring the gem's own `apply_registry_opts` (`"never the values — auth carries secrets"`) and upstream's `impl Debug for SecretEntry` (`value: "[REDACTED]"`). New unit specs supply a sentinel value and assert it is **never** present in the raised message (the old code would have failed them).

## #30 — Native `Duration::from_secs_f64` panics on bad input (robustness)

Five native sites (`exec`/`shell` timeout, `stop_with_timeout`, `kill_with_timeout`, `metrics_stream` interval, `replace_with_timeout`) called `Duration::from_secs_f64` directly. That panics on NaN/Inf/negative **and on finite-but-out-of-range** values like `Float::MAX`. The Ruby `coerce_duration` guard rejects NaN/Inf/negative but sets **no upper bound**, so a large finite value passed the Ruby guard and panicked the native layer across the FFI boundary (surfacing as an ugly panic-turned-exception).

**Fix:** a `secs_to_duration` helper (`try_from_secs_f64` + clean `Microsandbox::Error`) now backs all five sites — the same pattern `agent.rs::dur` already used and explicitly documented. Defense in depth: the native layer is panic-free regardless of the Ruby layer. `metrics_stream`'s return type becomes `Result<MetricsStream, Error>` (transparent to the Ruby caller; magnus unwraps `Ok`/raises on `Err`); its `<= 0.0 → 1s` default for 0/negative is preserved unchanged.

A new spec exercises the **real** native layer (VM-free, via `build_builder`, which validates `replace_with_timeout` before `.create()`), confirming NaN/Inf/`Float::MAX`/negative are rejected as a clean error, never a panic. The remaining four sites reach the same helper but only via a live sandbox (integration-covered); their Ruby guard is unit-tested with the native layer stubbed.

## Verification

- `cargo fmt --check` ✅ · `cargo clippy -- -D warnings` ✅ · `standardrb` ✅
- `rspec spec/unit` → **295 examples, 0 failures** (+6 new)
- Adversarial diff review (independent agent): no blockers; confirmed all five `from_secs_f64` sites replaced, `None`/`Ok(None)` timeout case preserved, magnus `Result` handling transparent, no other secret-leaking `inspect` in the secret paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)