### PR TITLE
feat(errors): typed snapshot error classes (+ NetworkBuilder mapping)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 
 ## [Unreleased]
 
+### Added
+
+- **Typed snapshot error classes** (issue #28). The five core snapshot error
+  variants — reachable through the gem's fully-wired `Snapshot` API — previously
+  collapsed to the base `Microsandbox::Error`, forcing callers to string-match
+  the message. They now raise typed subclasses:
+  `SnapshotNotFoundError` (`snapshot-not-found`),
+  `SnapshotAlreadyExistsError` (`snapshot-already-exists`),
+  `SnapshotSandboxRunningError` (`snapshot-sandbox-running`),
+  `SnapshotImageMissingError` (`snapshot-image-missing`), and
+  `SnapshotIntegrityError` (`snapshot-integrity`). This goes **beyond** the
+  Python SDK mirror (which defines no snapshot classes), matching the Go SDK's
+  per-variant coverage — a deliberate divergence. Additionally, the previously
+  orphaned `NetworkPolicyError` now also carries the core's `NetworkBuilder`
+  build/validation error (a `network(|n| ...)` failure), which previously fell
+  through to the base `Error`. All additive — existing `rescue Microsandbox::Error`
+  handlers still catch them.
+
 ## [0.8.1] - 2026-06-25
 
 Gem-only release on the `v0.5.10` runtime (unchanged) — the two follow-ups to

--- a/ext/microsandbox/src/error.rs
+++ b/ext/microsandbox/src/error.rs
@@ -34,6 +34,22 @@ fn class_name(err: &MicrosandboxError) -> &'static str {
         // client's `UnsupportedOperation` above.
         CloudHttp { .. } => "CloudHttpError",
         Unsupported { .. } => "UnsupportedError",
+        // Snapshot operations, all reachable through the gem's fully-wired
+        // `Snapshot` API. Upstream raises these un-wrapped, so without a mapping
+        // they collapse to the base `Error` and callers must string-match the
+        // message. This goes BEYOND the Python mirror (which has no Snapshot
+        // classes and matches the Go SDK's per-variant coverage instead) — a
+        // deliberate divergence noted in `lib/microsandbox/errors.rb`.
+        SnapshotNotFound(_) => "SnapshotNotFoundError",
+        SnapshotAlreadyExists(_) => "SnapshotAlreadyExistsError",
+        SnapshotSandboxRunning(_) => "SnapshotSandboxRunningError",
+        SnapshotImageMissing(_) => "SnapshotImageMissingError",
+        SnapshotIntegrity(_) => "SnapshotIntegrityError",
+        // Give the already-defined-but-orphaned `NetworkPolicyError` a mapping:
+        // a builder parse/validation error from `network(|n| ...)`. The gem
+        // unconditionally enables the core's `net` feature (default-features),
+        // so this variant is always present.
+        NetworkBuilder(_) => "NetworkPolicyError",
         _ => "Error",
     }
 }

--- a/lib/microsandbox/errors.rb
+++ b/lib/microsandbox/errors.rb
@@ -51,7 +51,22 @@ module Microsandbox
   define_error(:ImageInUseError, "image-in-use")
   define_error(:ImagePullFailedError, "image-pull-failed")
 
+  # Snapshot errors ---------------------------------------------------------
+  # These go BEYOND the Python SDK mirror (which has no Snapshot classes and
+  # collapses all five to its base error) — a deliberate divergence matching the
+  # Go SDK's per-variant coverage, so callers can rescue a missing/duplicate/
+  # running-source/missing-image/corrupt snapshot specifically. The native layer
+  # (ext/microsandbox/src/error.rs) maps the five core Snapshot* variants here.
+  define_error(:SnapshotNotFoundError, "snapshot-not-found")
+  define_error(:SnapshotAlreadyExistsError, "snapshot-already-exists")
+  define_error(:SnapshotSandboxRunningError, "snapshot-sandbox-running")
+  define_error(:SnapshotImageMissingError, "snapshot-image-missing")
+  define_error(:SnapshotIntegrityError, "snapshot-integrity")
+
   # Networking / secrets errors ---------------------------------------------
+  # NetworkPolicyError now also carries the core's `NetworkBuilder` build/parse
+  # error (a `network(|n| ...)` validation failure), which was previously
+  # unmapped and fell through to the base Error.
   define_error(:NetworkPolicyError, "network-policy-error")
   define_error(:SecretViolationError, "secret-violation")
   define_error(:TlsError, "tls-error")

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -38,6 +38,11 @@ module Microsandbox
   class ImageNotFoundError < Error end
   class ImageInUseError < Error end
   class ImagePullFailedError < Error end
+  class SnapshotNotFoundError < Error end
+  class SnapshotAlreadyExistsError < Error end
+  class SnapshotSandboxRunningError < Error end
+  class SnapshotImageMissingError < Error end
+  class SnapshotIntegrityError < Error end
   class NetworkPolicyError < Error end
   class SecretViolationError < Error end
   class TlsError < Error end

--- a/spec/unit/errors_spec.rb
+++ b/spec/unit/errors_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe "Microsandbox error hierarchy" do
     "ImageNotFoundError" => "image-not-found",
     "ImageInUseError" => "image-in-use",
     "ImagePullFailedError" => "image-pull-failed",
+    "SnapshotNotFoundError" => "snapshot-not-found",
+    "SnapshotAlreadyExistsError" => "snapshot-already-exists",
+    "SnapshotSandboxRunningError" => "snapshot-sandbox-running",
+    "SnapshotImageMissingError" => "snapshot-image-missing",
+    "SnapshotIntegrityError" => "snapshot-integrity",
     "NetworkPolicyError" => "network-policy-error",
     "SecretViolationError" => "secret-violation",
     "TlsError" => "tls-error",
@@ -62,5 +67,24 @@ RSpec.describe "Microsandbox error hierarchy" do
     err = Microsandbox::SandboxNotFoundError.new("no such sandbox")
     expect(err.message).to eq("no such sandbox")
     expect(err).to be_a(StandardError)
+  end
+
+  # Exercises the REAL native error mapping (not just the Ruby class table):
+  # opening a snapshot at a path that cannot exist routes the core's
+  # SnapshotNotFound variant through ext/microsandbox/src/error.rs::class_name to
+  # the typed SnapshotNotFoundError. Disk-only, no microVM/runtime — deterministic
+  # in CI. Guards against the variant silently falling back to the base Error.
+  #
+  # Pin the local backend explicitly: snapshot ops require it, and on a non-local
+  # process-wide backend the open would raise UnsupportedError instead, masking
+  # the mapping under test.
+  it "maps a core Snapshot* variant to its typed class via the native layer" do
+    Microsandbox.with_backend(:local) do
+      expect do
+        Microsandbox::Snapshot.open("/nonexistent/microsandbox-rb-spec/snap-xyz.msbsnap")
+      end.to raise_error(Microsandbox::SnapshotNotFoundError) { |e|
+        expect(e.code).to eq("snapshot-not-found")
+      }
+    end
   end
 end


### PR DESCRIPTION
Adversarially re-verified issue #28 against current source, then implemented it. Closes #28.

## What

The five core snapshot error variants — `SnapshotNotFound`, `SnapshotAlreadyExists`, `SnapshotSandboxRunning`, `SnapshotImageMissing`, `SnapshotIntegrity` — are all reachable through the gem's fully-wired `Snapshot` API (`Snapshot.create/open/get/remove/verify`), but `ext/microsandbox/src/error.rs::class_name` had no arms for them, so they collapsed to the base `Microsandbox::Error`. Callers could only catch them as the base class and string-match the message.

This PR maps each to a typed subclass:

| variant | class | code |
|---|---|---|
| `SnapshotNotFound` | `SnapshotNotFoundError` | `snapshot-not-found` |
| `SnapshotAlreadyExists` | `SnapshotAlreadyExistsError` | `snapshot-already-exists` |
| `SnapshotSandboxRunning` | `SnapshotSandboxRunningError` | `snapshot-sandbox-running` |
| `SnapshotImageMissing` | `SnapshotImageMissingError` | `snapshot-image-missing` |
| `SnapshotIntegrity` | `SnapshotIntegrityError` | `snapshot-integrity` |

It also gives the **previously-orphaned** `NetworkPolicyError` a mapping: the core's `NetworkBuilder` build/validation variant (a `network(|n| ...)` failure) that was unmapped and fell through to the base `Error`.

## Parity note

This goes **beyond** the gem's stated Python-SDK mirror, which defines no snapshot classes and collapses them to its base error. It matches the **Go** SDK's per-variant coverage instead — a deliberate divergence, noted in a code comment in `errors.rb` and `error.rs`. (Verified during the audit: only the Go SDK distinguishes these variants.)

All additive — existing `rescue Microsandbox::Error` handlers still catch every one of them (the new classes subclass `Error`).

## Verification

- `cargo fmt --check` ✅ · `cargo clippy -- -D warnings` ✅ · `standardrb` ✅
- `rspec spec/unit` → **304 examples, 0 failures**; `errors_spec` → **91** (+16)
- Variant identifiers checked exactly against upstream `sdk/rust/lib/error.rs`; `net` feature confirmed unconditionally enabled (so `NetworkBuilder` is always present and the unguarded match compiles).
- The `errors_spec` exhaustiveness guard (`constants.grep(/Error\z/)` must equal `expected_codes.keys`) keeps `errors.rb` and the spec in lock-step — all 5 added to both.
- **A new spec exercises the REAL native mapping**, not just the Ruby class table: `Snapshot.open` on a nonexistent path raises the typed `SnapshotNotFoundError` (`code == "snapshot-not-found"`) — disk-only, VM-free, with the backend pinned to `:local` (snapshot ops require it; a non-local process-wide backend would otherwise raise `UnsupportedError` and mask the mapping).
- Adversarial diff review (independent agent): no blockers; the one should-fix it raised (backend pin for the native-mapping spec) is applied.

> Note: the `[Unreleased]` CHANGELOG section will conflict with the sibling audit-fix PRs on merge — expected for parallel PRs, trivial to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)