### PR TITLE
chore(release): 0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ All notable changes to this gem are documented here. The format is based on
 microsandbox runtime it embeds; each release notes the upstream runtime tag it
 wraps, and the README's Versioning section keeps the full gem→runtime map.
 
-## [Unreleased]
+## [0.8.2] - 2026-06-29
+
+Gem-only release on the `v0.5.10` runtime (unchanged). Bundles the post-`0.8.1`
+audit follow-ups: a secret-leak fix, typed snapshot errors, panic-free duration
+parsing, the precompiled fat-gem loader + `extconf` preflight corrections, and a
+sweep of threading/streaming/SSH documentation.
 
 ### Documentation
 
@@ -14,9 +19,12 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
   released during native calls so *other* threads keep running, but the
   *calling* thread blocks uninterruptibly until the call returns —
   `Timeout::timeout`/`Thread#kill`/Ctrl-C can't interrupt it. README and
-  DESIGN.md now state this and steer callers to the explicit `exec(timeout:)` /
-  `shell(timeout:)` / `AgentClient(timeout:)` knobs for bounding long or
-  unbounded/streaming calls, rather than `Timeout::timeout`.
+  DESIGN.md now state this and steer callers to the genuinely-bounding
+  `exec(timeout:)` / `shell(timeout:)` knobs, and clarify that
+  `AgentClient.connect_sandbox`/`connect_path`'s `timeout:` bounds only the
+  connect handshake while `AgentClient#request`/`#stream` and the streaming
+  paths have no timeout knob and can block indefinitely — rather than reaching
+  for `Timeout::timeout`.
 - **`exec` `timeout: 0` semantics clarified** (issue #29). The `@param timeout`
   doc now notes the asymmetry: omit or `nil` means *no* timeout, while `0` is an
   immediate (zero) deadline that kills the command before any output and raises
@@ -40,10 +48,13 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
 - **`DESIGN.md` refreshed** (issue #35). The stale runtime-pin references
   (`v0.5.7`/`v0.5.8`) now point at `v0.5.10` via `RUNTIME_VERSION`, and the
   hard-coded unit-example count is replaced with rot-proof phrasing.
-- **RBS `initialize` convention made consistent** (issue #36). Native-backed,
-  non-user-constructible value/handle/stream types no longer declare an internal
-  `initialize` in `sig/microsandbox.rbs` (previously declared on 11 of them,
-  omitted on peers of identical role); a top-of-file note records the convention.
+- **RBS gains a note on SDK-constructed types** (issue #36). `sig/microsandbox.rbs`
+  now carries a top-of-file note explaining that native-backed value/handle/stream
+  types are constructed by the SDK from an internal native handle or data hash, not
+  by user code. Their `initialize` signatures are kept: RBS derives `new` from
+  `initialize`, so omitting them would not hide the constructor — it would
+  synthesize a misleading zero-arg `() -> instance` that Ruby actually rejects.
+
 ### Fixed
 
 - **Precompiled fat-gem loader now finds the staged binary** (issue #25). The
@@ -55,16 +66,15 @@ wraps, and the README's Versioning section keeps the full gem→runtime map.
   failed at `require "microsandbox"` the moment precompiled gems are promoted.
   The loader now derives the subdir from `RUBY_VERSION[/\d+\.\d+/]` (`"3.4"`),
   matching the staged path; the flat-path rescue still covers source builds.
-- **`extconf` MSRV preflight probes the toolchain the build actually uses**
+- **`extconf` MSRV preflight probes the compiler the build actually runs**
   (issue #39). The preflight ran a bare `rustc --version` and hard-aborted when
-  `< 1.91`, but the build is driven by `cargo` — and a rustup `cargo` shim honors
-  this gem's `rust-toolchain.toml` (`stable`), which a bare `rustc` first on PATH
-  does not reflect. A non-rustup `rustc` shadowing a rustup `cargo` shim could
-  therefore false-abort a build that `cargo` would complete. The preflight now
-  probes the `rustc` sitting alongside the `cargo` that drives the build (from
-  the same directory, so the toolchain override is discovered the way the build
-  discovers it) — correctly mirroring both the false-abort case and the genuine
-  too-old case it still guards.
+  `< 1.91`, but the build is driven by `cargo`, which resolves its compiler from
+  `$RUSTC` if set, otherwise the bare `rustc` on PATH — it never uses the `rustc`
+  beside the `cargo` binary, and the rustup `cargo` shim neither sets `$RUSTC` nor
+  reorders PATH. The preflight now mirrors that exact resolution (`$RUSTC`, else
+  PATH `rustc`), so it neither false-passes when a stale non-rustup `rustc`
+  shadows a rustup `cargo` (the build would compile with that stale `rustc` and
+  fail deep in smoltcp) nor false-aborts when `$RUSTC` points at a newer compiler.
 
 ### Internal
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3249,7 +3249,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "chrono",
  "futures",

--- a/README.md
+++ b/README.md
@@ -406,6 +406,7 @@ Microsandbox.runtime_version   # => "v0.5.10"  (the embedded upstream runtime ta
 | `0.7.0`  | `v0.5.8` | SDK parity release (large binding-gap closure) |
 | `0.8.0`  | `v0.5.10` | adopts upstream `v0.5.10` (idle-only heartbeat, config-fd hardening, **4 GiB default bind-mount quota**); supersedes the reverted `v0.5.9` attempt |
 | `0.8.1`  | `v0.5.10` | gem-only: re-provision a stale local runtime; per-bind-mount `quota_mib:` override |
+| `0.8.2`  | `v0.5.10` | gem-only: redact secrets from errors, typed snapshot errors, panic-free durations, fat-gem loader + `extconf` preflight fixes, threading/streaming docs |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.5.10).
-version = "0.8.1"
+version = "0.8.2"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,7 +8,7 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in


### PR DESCRIPTION
Gem-only release on the **`v0.5.10`** runtime (unchanged). Cuts `0.8.1` → **`0.8.2`** (patch), bundling the post-`0.8.1` audit follow-ups already merged under `[Unreleased]`.

## Contents
- **Security** (#23) — redact secret values from `Sandbox.create(secrets:)` error messages.
- **Added** (#28) — typed snapshot error classes + `NetworkBuilder` error mapping (additive; existing `rescue Microsandbox::Error` still catches them).
- **Fixed** — panic-free native duration parsing (#30); precompiled fat-gem loader subdir (#25); `extconf` MSRV preflight now resolves rustc the way cargo does — `$RUSTC` else PATH `rustc` (#39).
- **Documentation** (#24/#29/#31/#33/#34) + **Internal** (#35/#36/#37/#38).

## Lock-step bump (5 files)
`lib/microsandbox/version.rb` + `ext/microsandbox/Cargo.toml` + root `Cargo.lock` → `0.8.2`; `CHANGELOG.md` `[Unreleased]` → `[0.8.2]`; README version-map row. `RUNTIME_VERSION` stays `v0.5.10` (no upstream adoption).

> CHANGELOG entries #24/#36/#39 were **reconciled to the as-merged behavior** after the Codex review follow-ups (the README dropped the non-existent `AgentClient(timeout:)` knob, the RBS `initialize` signatures were kept, and the preflight resolves `$RUSTC`→PATH `rustc` rather than the cargo sibling).

## Local gate
✅ `cargo fmt --check` · ✅ `clippy -D warnings` · ✅ `standardrb` · ✅ `rake spec` (312 examples, 0 failures; `version_spec` confirms the lock-step).

Merging then tagging `v0.8.2` triggers the OIDC source-gem publish (`release.yml`). Precompiled platform gems are **not** auto-published on tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)