### PR TITLE
feat(runtime): adopt upstream v0.6.1, bump gem to 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ All notable changes to this gem are documented here. The format is based on
 microsandbox runtime it embeds; each release notes the upstream runtime tag it
 wraps, and the README's Versioning section keeps the full gem→runtime map.
 
+## [0.9.0] - 2026-06-29
+
+Adopts upstream runtime **`v0.5.10` → `v0.6.1`** (spanning the upstream `v0.6.0`
+and `v0.6.1` releases). The upstream public SDK surface is purely additive — no
+items were removed or re-signatured — so the gem's Ruby API is unchanged and the
+existing bindings compile against `v0.6.1` untouched. Per the README's versioning
+policy, adopting a new upstream runtime moves the gem onto its own `0.9` line.
+
+### Changed
+
+- **Embedded runtime is now `v0.6.1`** (`Microsandbox::RUNTIME_VERSION` /
+  `Microsandbox.runtime_version`). Upstream fixes inherited by the synchronous
+  Ruby API:
+  - **Zombie sandbox runtimes no longer block** (upstream #1036): the SDK stops
+    waiting on a sandbox runtime that has already exited, so lifecycle calls
+    return promptly instead of hanging on a dead child.
+  - **Secrets are substituted through `CONNECT` proxies** (upstream #1022):
+    `microsandbox-network` now applies secret injection on tunnelled (HTTPS
+    `CONNECT`) requests, not only on plain-HTTP ones.
+  - **Stale sandboxes are stopped and cleaned up** (upstream #1050).
+  - Windows host support, `msb` CLI additions (`--no-tty`, self-downgrade,
+    cross-platform `doctor`), and the `msb_krun` `0.1.17 → 0.1.19` bump are
+    inherited but do not affect the macOS/Linux Ruby build or API surface.
+
+### Notes
+
+- The new upstream **host-directory bind rootfs** (`ImageBuilder::bind`, upstream
+  #1021) is intentionally **not** exposed in this release: it requires a real
+  microVM boot to exercise, and the Python SDK parity reference only stubs the
+  type without wiring it into the sandbox builder. Tracked as a possible
+  follow-up.
+
 ## [0.8.2] - 2026-06-29
 
 Gem-only release on the `v0.5.10` runtime (unchanged). Bundles the post-`0.8.1`
@@ -580,7 +612,11 @@ microsandbox runtime, aligned with the official Python/Node/Go SDKs.
   core crate has Apple-native deps). Until precompiled gems are published,
   installing from source requires a Rust toolchain (stable >= 1.91).
 
-[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.8.2...v0.9.0
+[0.8.2]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.8.0...v0.8.1
+[0.8.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.12...v0.6.0
 [0.5.12]: https://github.com/ya-luotao/microsandbox-rb/compare/v0.5.11...v0.5.12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,26 +2461,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "imago"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7cfee876c698a1a2ed9c705ab18f21acbed82110f19b51cc458de73426fe2c"
-dependencies = [
- "async-trait",
- "bincode",
- "cfg-if",
- "libc",
- "miniz_oxide",
- "nix 0.30.1",
- "page_size",
- "rustc_version",
- "tokio",
- "tracing",
- "vm-memory 0.18.0",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2876,15 +2856,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-loader"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "870c3814345f050991f99869417779f6062542bcf4ed81db7a1b926ad1306638"
-dependencies = [
- "vm-memory 0.16.2",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3003,8 +2974,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3052,12 +3023,13 @@ dependencies = [
  "tracing",
  "typed-builder",
  "which",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3069,8 +3041,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3081,8 +3053,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3094,8 +3066,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3115,24 +3087,25 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "xattr",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "chrono",
  "libc",
  "thiserror 2.0.18",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3140,8 +3113,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "base64",
  "bytes",
@@ -3159,6 +3132,7 @@ dependencies = [
  "microsandbox-protocol",
  "microsandbox-utils",
  "msb_krun",
+ "msb_krun_utils",
  "parking_lot",
  "pem",
  "percent-encoding",
@@ -3176,12 +3150,13 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3195,8 +3170,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "bytes",
  "chrono",
@@ -3221,12 +3196,13 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "microsandbox-types"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "chrono",
  "serde",
@@ -3237,19 +3213,20 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.5.10"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.5.10#a62c4e45da7320e89aafc44b8a44fc74ec49fb53"
+version = "0.6.1"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
 dependencies = [
  "dirs",
  "libc",
  "reflink-copy",
  "scopeguard",
  "ureq",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "chrono",
  "futures",
@@ -3322,10 +3299,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "msb_krun"
-version = "0.1.17"
+name = "msb-imago"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a554acf513be16b336fbcd4a9bab29a78b06a5ddf94e917481cfeafc1078f5"
+checksum = "16db000f7280d4c8a78b8b95f64a41006d447fd116ecd69d984d93774cb85d09"
+dependencies = [
+ "async-trait",
+ "bincode",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "nix 0.30.1",
+ "page_size",
+ "rustc_version",
+ "tokio",
+ "tracing",
+ "vm-memory",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "msb_krun"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fb3437734ef4103d3891d3cbd51a8726f196af350c68cb044a1860207c64d3"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3338,14 +3335,14 @@ dependencies = [
  "msb_krun_polly",
  "msb_krun_utils",
  "msb_krun_vmm",
- "vm-memory 0.16.2",
+ "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d270d914cee3125cf71734b9a5aa60fe7d9648f09511999199424e0fe1a88c6"
+checksum = "e25fe665643d66900ec9407ef0d3afdb5cd4ca97ad394c46b8243bfa6344bfc0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3353,21 +3350,20 @@ dependencies = [
  "msb_krun_arch_gen",
  "msb_krun_smbios",
  "msb_krun_utils",
- "vm-memory 0.16.2",
- "vmm-sys-util",
+ "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8372d1e4e8c853e20ffb5568a4cc3f930a2bf1ce25bc346812ac7b84e84639d4"
+checksum = "7e50dfac228ad088917f8ffb2920c4a56d762ebc5a90950ee7bf5414253b02aa"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "179542321455c65a8e4b14c09bc8443227a89cd46ef2c9c06f0ee1ab11f510ea"
+checksum = "fd5221749c0224858b075b61f3f2a0964dbfe367093e9ee650b6b0e3d690c3b2"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3376,37 +3372,39 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67350e76fd466e1a089b89fa548ba85a92f237c2d3dab179ba675cfd18eb9a39"
+checksum = "4fee50bfdf1a1258e33bcf0ee8631bb805db79b8d442161ab63d700689a992a8"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
  "caps",
  "crossbeam-channel",
- "imago",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "libloading",
  "log",
  "lru",
+ "msb-imago",
  "msb_krun_arch",
  "msb_krun_hvf",
  "msb_krun_polly",
  "msb_krun_utils",
  "nix 0.30.1",
  "rand 0.9.4",
+ "tokio",
  "virtio-bindings",
  "vm-fdt",
- "vm-memory 0.16.2",
+ "vm-memory",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13eaca12857149c3552007a18c7f863ccc6b4dddcf2863c0bcc8fbc2aa2d4c6e"
+checksum = "3f2300bbe4dbd56bdc3ffc2384baf82e299fff8a45e844f41c4a0be64210ed47"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -3416,19 +3414,19 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "514f7493860978b08819fdcc4ef3d1887fd4d2b5e26ad0a0eabcec005410df94"
+checksum = "3402b8879bd5b91f33d069fefa00fd0416f12cd660cfd7538da8e77201f2dda5"
 dependencies = [
  "msb_krun_utils",
- "vm-memory 0.16.2",
+ "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ebbb0336b9cd8dcffa9c47d01a729de4f83c39fc099620f4f9c4d8ef69f460"
+checksum = "da550bf268cb9217255ed152bfca9f61275a2796237fd180989958c7f54dc137"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3436,18 +3434,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25cb991386c6aca7c74d0bd8b327a807290830e439fbb473c5e1b62a7c66d32"
+checksum = "2c0737818e69346348f8ba2a7197cbec2336e807e5f7f094c80e0ca1635ca054"
 dependencies = [
- "vm-memory 0.16.2",
+ "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7104f87f235ef5cc320ffa760b7cd3635960b58cdc5e1ec89df852fc538f042"
+checksum = "fb370035195bfd6d60e0b4ad8b0d68dcf9d138f144d033087a960117920a126e"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3456,13 +3454,14 @@ dependencies = [
  "log",
  "nix 0.30.1",
  "vmm-sys-util",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.17"
+version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6742a7fba174849b924a370bfba0fe7be8435253bff26303aec34ac89641ae63"
+checksum = "68e9f485f720981fda9071b2711d4f8406b6c67ebf6bfa2bb8e83f3cc6c2aaea"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3470,7 +3469,7 @@ dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
- "linux-loader",
+ "libloading",
  "log",
  "msb_krun_arch",
  "msb_krun_arch_gen",
@@ -3481,8 +3480,8 @@ dependencies = [
  "msb_krun_polly",
  "msb_krun_utils",
  "nix 0.30.1",
- "vm-memory 0.16.2",
- "vmm-sys-util",
+ "vm-memory",
+ "windows-sys 0.61.2",
  "zstd",
 ]
 
@@ -6398,22 +6397,13 @@ checksum = "7e21282841a059bb62627ce8441c491f09603622cd5a21c43bfedc85a2952f23"
 
 [[package]]
 name = "vm-memory"
-version = "0.16.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd5e56d48353c5f54ef50bd158a0452fc82f5383da840f7b8efc31695dd3b9d"
-dependencies = [
- "libc",
- "thiserror 1.0.69",
- "winapi",
-]
-
-[[package]]
-name = "vm-memory"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b55e753c7725603745cb32b2287ef7ef3da05c03c7702cda3fa8abe25ae0465"
 dependencies = [
+ "libc",
  "thiserror 2.0.18",
+ "winapi",
 ]
 
 [[package]]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -106,7 +106,7 @@ out (air-gapped hosts that provision out of band). libkrunfw is `dlopen`'d by
 
 `ext/microsandbox/Cargo.toml` depends on the core crate via a **pinned git tag**
 (`microsandbox` / `microsandbox-network`, pinned to the same tag as
-`Microsandbox::RUNTIME_VERSION` — currently `v0.5.10`), so the gem builds anywhere
+`Microsandbox::RUNTIME_VERSION` — currently `v0.6.1`), so the gem builds anywhere
 — CI, `rake-compiler-dock` release containers, and end-user source installs —
 without an adjacent checkout. For fast local development against a sibling
 microsandbox checkout, copy `.cargo/config.toml.example` to `.cargo/config.toml`
@@ -211,7 +211,7 @@ create options, full mount options (tmpfs/disk + stat-virtualization/
 host-permissions), and snapshot inspection (`open`/`list_dir`/`reindex`).
 
 A few **secondary** upstream knobs remain unexposed (a genuine binding gap, not
-upstream-gated — they exist at the pinned `v0.5.10` runtime): per-published-port host
+upstream-gated — they exist at the pinned `v0.6.1` runtime): per-published-port host
 **bind address** (ports always bind loopback), network **interface overrides**,
 and inline **named-volume create-mode** (pre-create with `Volume.create`, then
 mount with `{ named: }`). These slot in module-by-module exactly as the existing

--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ Microsandbox.runtime_version   # => "v0.5.10"  (the embedded upstream runtime ta
 | `0.8.0`  | `v0.5.10` | adopts upstream `v0.5.10` (idle-only heartbeat, config-fd hardening, **4 GiB default bind-mount quota**); supersedes the reverted `v0.5.9` attempt |
 | `0.8.1`  | `v0.5.10` | gem-only: re-provision a stale local runtime; per-bind-mount `quota_mib:` override |
 | `0.8.2`  | `v0.5.10` | gem-only: redact secrets from errors, typed snapshot errors, panic-free durations, fat-gem loader + `extconf` preflight fixes, threading/streaming docs |
+| `0.9.0`  | `v0.6.1` | adopts upstream `v0.6.0`+`v0.6.1` (zombie-runtime wait fix, secret substitution through CONNECT proxies, stale-sandbox cleanup); upstream public API is additive — no Ruby surface change |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ end
 
 ```ruby
 Microsandbox::Sandbox.create("obs", image: "public.ecr.aws/docker/library/alpine:latest") do |sb|
+  # On the v0.6.1 runtime the metrics slot goes live a beat after create returns,
+  # so `metrics` can briefly raise "no live metrics slot" right after boot —
+  # retry for a few hundred ms rather than treating the first failure as fatal.
   m = sb.metrics                       # => Microsandbox::Metrics
   m.cpu_percent
   m.memory_bytes
@@ -390,8 +393,8 @@ change diverged the two numbers — the gem version is **not** a reliable indica
 of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
-Microsandbox::VERSION          # => "0.8.0"  (the gem's own version)
-Microsandbox.runtime_version   # => "v0.5.10"  (the embedded upstream runtime tag)
+Microsandbox::VERSION          # => "0.9.0"  (the gem's own version)
+Microsandbox.runtime_version   # => "v0.6.1"  (the embedded upstream runtime tag)
 ```
 
 | Gem version | Upstream runtime | Notes |

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,8 +6,8 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.5.10).
-version = "0.8.2"
+# The core-crate dependency below stays pinned at its own tag (v0.6.1).
+version = "0.9.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.10", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.5.10" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.1", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.1" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -928,6 +928,14 @@ module Microsandbox
     end
 
     # Latest resource-usage snapshot.
+    #
+    # Raises a {Microsandbox::Error} ("sandbox N has no live metrics slot") when
+    # called in the brief window right after {Sandbox.create} returns, before the
+    # runtime has registered the sandbox's metrics slot. On the `v0.6.1` runtime
+    # the spawn handshake no longer blocks create until the first sample is
+    # written, so the slot goes live a beat *after* boot (within a few hundred
+    # milliseconds); retry for that window rather than treating the first failure
+    # as fatal.
     # @return [Metrics]
     def metrics
       Metrics.new(@native.metrics)
@@ -952,6 +960,14 @@ module Microsandbox
 
     # Stream resource-usage snapshots, one per interval tick, until the sandbox
     # stops. Requires metrics to be enabled for the sandbox.
+    #
+    # The first tick fires immediately, so opening the stream right after
+    # {Sandbox.create} can hit the same metrics-slot startup window as {#metrics}
+    # and yield a transient "no live metrics slot" error on that first tick.
+    # Because the stream is single-pass (a drained or errored stream is spent),
+    # make sure the slot is live *before* opening it — e.g. retry {#metrics}
+    # until it succeeds (the slot goes live within a few hundred milliseconds of
+    # boot), then call {#metrics_stream}.
     # @param interval [Numeric] seconds between snapshots
     # @return [MetricsStream] an {Enumerable} of {Metrics}
     def metrics_stream(interval: 1.0)

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,12 +8,12 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.8.2"
+  VERSION = "0.9.0"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in
   # ext/microsandbox/Cargo.toml. Exposed at runtime as
   # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
   # sync with the Cargo tag so it can't silently drift out of date.
-  RUNTIME_VERSION = "v0.5.10"
+  RUNTIME_VERSION = "v0.6.1"
 end

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -58,6 +58,11 @@ RSpec.describe "lifecycle controls + streaming", :integration do
 
     it "streams metrics snapshots" do
       Microsandbox::Sandbox.create(unique_sandbox_name, image: image) do |sb|
+        # Wait out the post-create metrics-slot startup window before opening the
+        # stream: the stream's first tick fires immediately and would otherwise
+        # race the slot (and a single-pass stream can't be re-iterated once that
+        # first tick errors). See wait_for_metrics_slot.
+        wait_for_metrics_slot(sb)
         snapshot = sb.metrics_stream(interval: 0.2).first
         expect(snapshot).to be_a(Microsandbox::Metrics)
         expect(snapshot.uptime_secs).to be >= 0

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -49,10 +49,16 @@ RSpec.describe "lifecycle controls + streaming", :integration do
       name = unique_sandbox_name
       Microsandbox::Sandbox.create(name, image: image) do |sb|
         sb.exec("true")
+        # Wait out the post-create metrics-slot startup window so the new sandbox
+        # actually appears in the registry snapshot. Without it, all.key?(name) is
+        # false during the ~0.2-0.5s window on the v0.6.1 runtime and the
+        # assertion below would silently no-op (passing green having asserted
+        # nothing). See wait_for_metrics_slot.
+        wait_for_metrics_slot(sb)
         all = Microsandbox.all_sandbox_metrics
         expect(all).to be_a(Hash)
-        # The running sandbox should appear with a Metrics snapshot.
-        expect(all[name]).to be_a(Microsandbox::Metrics) if all.key?(name)
+        # The running sandbox must now appear with a Metrics snapshot.
+        expect(all[name]).to be_a(Microsandbox::Metrics)
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,3 +74,21 @@ end
 def default_test_image
   ENV.fetch("MICROSANDBOX_TEST_IMAGE", "public.ecr.aws/docker/library/alpine:latest")
 end
+
+# Block until a freshly-created sandbox's metrics slot is live, returning the
+# first successful Metrics snapshot. The per-sandbox metrics slot goes live a
+# beat AFTER Sandbox.create returns on the v0.6.1 runtime — the spawn handshake
+# (upstream #1036) no longer blocks create until the first sample is written, so
+# `metrics`/`metrics_stream` briefly raise "sandbox N has no live metrics slot"
+# right after boot. Poll past that startup window so streaming assertions don't
+# race it; this mirrors how a real caller must treat the window (see the metrics
+# docs). Only the transient slot error is retried — any other error propagates.
+def wait_for_metrics_slot(sandbox, attempts: 50, delay: 0.1)
+  attempts.times do
+    return sandbox.metrics
+  rescue Microsandbox::Error => e
+    raise unless e.message.include?("no live metrics slot")
+    sleep delay
+  end
+  raise "metrics slot never went live after #{attempts} attempts"
+end


### PR DESCRIPTION
## Summary

Adopts the upstream microsandbox runtime **`v0.5.10` -> `v0.6.1`** (spanning the upstream `v0.6.0` and `v0.6.1` releases) and bumps the gem **`0.8.2` -> `0.9.0`** (minor, per the runtime-adoption precedent `0.7.0 -> 0.8.0`).

The upstream public SDK API is **purely additive** across `v0.5.10..v0.6.1` (no removed or re-signatured items), so the existing native bindings compile against `v0.6.1` untouched and the gem's Ruby surface is unchanged. Most of the v0.6.x churn (Windows support, `--no-tty`/self-downgrade/cross-platform `doctor` CLI, winget) is irrelevant to the macOS/Linux synchronous bindings.

### Changes

- Both `microsandbox`/`microsandbox-network` git deps `tag` -> `v0.6.1`; `Cargo.lock` regenerated against the pinned tag (`msb_krun` `0.1.17 -> 0.1.19`, new `msb_krun_utils`/`msb-imago`).
- Lock-step `VERSION` + Cargo `[package].version` -> `0.9.0`, `RUNTIME_VERSION` -> `v0.6.1`.
- `CHANGELOG` `[0.9.0]` entry (+ backfilled `0.8.0`-`0.9.0` reference links and fixed the stale `[Unreleased]` base), README gem->runtime map row, `DESIGN.md` "currently v0.5.10" -> `v0.6.1`.

### Inherited upstream fixes

- `#1036` stop waiting on zombie sandbox runtimes
- `#1022` substitute secrets through `CONNECT` proxies
- `#1050` stop/clean up stale sandboxes

### One behavior change found + handled

On `v0.6.1` the per-sandbox metrics slot goes live a beat **after** `Sandbox.create` returns (the spawn handshake no longer blocks create until the first sample), so `metrics`/`metrics_stream.first` raise `sandbox N has no live metrics slot` for a ~0.2-0.5s window post-boot, then succeed. Decision: **mirror upstream** (no binding change -- keeps `Result`-stream parity with the Python/Node SDKs). The integration test now waits past the window via a new `wait_for_metrics_slot` helper, and the `metrics`/`metrics_stream` YARD docs document it. This was caught only by the real-VM integration run -- unit specs stub the native layer and stayed green.

### Not done

The new host-directory bind rootfs (`ImageBuilder::bind`, upstream `#1021`) is intentionally not exposed: the Python parity reference only stubs the type (never wires it into the sandbox builder), and it needs a real microVM boot to exercise. Tracked as a possible follow-up.

## Test plan

- `cargo fmt --check` / `cargo clippy -- -D warnings` / `standardrb` -- clean
- `bundle exec rspec spec/unit` -- 312 examples, 0 failures
- `MICROSANDBOX_INTEGRATION=1 bundle exec rspec spec/integration` (real microVM, macOS Apple Silicon, ECR image) -- **33 examples, 0 failures, 1 pending** (the pending `attach` test needs a real TTY)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxUoUeRyPEZffUUaQqYAQ5
