### PR TITLE
ci(release): fix GitHub Release job checkout on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -210,7 +210,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true # need every version tag to decide if this one is newest
+          # Full history + all tags, so the "is this the newest tag?" check below
+          # (git tag --sort=-v:refname) sees every version. NOT fetch-tags:true —
+          # on a tag-triggered run checkout resolves github.ref to the commit SHA
+          # and fetch-tags then races the tag onto the same ref, failing with
+          # "Cannot fetch both <sha> and refs/tags/<tag>" (actions/checkout#1781).
+          fetch-depth: 0
       - name: Create GitHub Release from CHANGELOG
         env:
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Summary

Fixes the `github-release` job in `release.yml`, which fails at **`actions/checkout`** on every tag-triggered run — before it can reach `gh release create`:

```
fatal: Cannot fetch both <sha> and refs/tags/vX.Y.Z to refs/tags/vX.Y.Z
```

On a tag-triggered run, checkout resolves `github.ref` to the commit SHA, and `fetch-tags: true` then tries to fetch **both** the SHA and the tag onto the same `refs/tags/vX.Y.Z`, colliding ([actions/checkout#1781](https://github.com/actions/checkout/issues/1781)). It's deterministic — every future tag hits it.

`v0.9.0` was the **first tag to actually exercise this job** (the v0.6.0–v0.8.2 Releases were hand-backfilled before the job reliably ran), so it surfaced there: the gem **published fine** to RubyGems via OIDC, but the GitHub Release had to be created by hand.

## Fix

Swap `fetch-tags: true` → `fetch-depth: 0`. A full fetch pulls all history and tags with no shallow-refspec collision, and the job needs every tag anyway for its `git tag --sort=-v:refname` newest-version check. The CHANGELOG-slice, `--latest`, and `--verify-tag` logic is unchanged.

```diff
       - uses: actions/checkout@v4
         with:
-          fetch-tags: true # need every version tag to decide if this one is newest
+          fetch-depth: 0   # full history + all tags; fetch-tags:true collides with
+                           # the tag-triggered ref ("Cannot fetch both <sha> and
+                           # refs/tags/<tag>")
```

## Notes

- `v0.9.0` is already fully released (gem live on RubyGems + GitHub Release backfilled by hand with the `--latest` badge), so this is forward-looking — it just stops the next tag from going red and needing a manual backfill.
- Verified the file still parses as valid YAML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BxUoUeRyPEZffUUaQqYAQ5
