### PR TITLE
feat(runtime): adopt upstream v0.6.2, bump gem to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ All notable changes to this gem are documented here. The format is based on
 microsandbox runtime it embeds; each release notes the upstream runtime tag it
 wraps, and the README's Versioning section keeps the full gem→runtime map.
 
+## [0.9.1] - 2026-07-03
+
+Adopts upstream runtime **`v0.6.1` → `v0.6.2`**. The upstream SDK crate's public
+API is unchanged in this release — the only surface change attempted upstream (a
+`disk_size` builder rename, #983) was reverted before the release cut (#1078) —
+so this is a pure runtime bump with no Ruby API change.
+
+### Changed
+
+- **Embedded runtime is now `v0.6.2`** (`Microsandbox::RUNTIME_VERSION` /
+  `Microsandbox.runtime_version`). Upstream improvements inherited by the gem:
+  - **Faster image loads and pulls** (upstream #1075): an early cache gate skips
+    already-imported layers and OCI layer decompression switches to zlib-rs.
+    Inherited transitively through the SDK crate's `microsandbox-image`
+    dependency, so `Sandbox.create` image pulls benefit directly.
+  - `msb` CLI polish (terminal-aware help colors, aligned `doctor` runtime
+    diagnostics, image-load progress) ships in the prebuilt runtime binary but
+    does not affect the Ruby API surface.
+
 ## [0.9.0] - 2026-06-29
 
 Adopts upstream runtime **`v0.5.10` → `v0.6.1`** (spanning the upstream `v0.6.0`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1697,6 +1697,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -2974,8 +2975,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3028,8 +3029,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3041,8 +3042,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3053,8 +3054,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3066,8 +3067,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3092,8 +3093,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "chrono",
  "libc",
@@ -3104,8 +3105,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3113,8 +3114,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "base64",
  "bytes",
@@ -3155,8 +3156,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3170,8 +3171,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "bytes",
  "chrono",
@@ -3201,8 +3202,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "chrono",
  "serde",
@@ -3213,8 +3214,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.1"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.1#868ac5a8f04fadca357b377537e7a5740a856509"
+version = "0.6.2"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.2#e9043c89d3432a548908bb145581be4fa1e2e3d9"
 dependencies = [
  "dirs",
  "libc",
@@ -3226,7 +3227,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "chrono",
  "futures",
@@ -7417,6 +7418,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1418,7 +1418,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1616,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3301,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "msb-imago"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16db000f7280d4c8a78b8b95f64a41006d447fd116ecd69d984d93774cb85d09"
+checksum = "c3077f41d73d78575dd706fcb626778eea7942ab2f1402ec040a4e11badc5dfa"
 dependencies = [
  "async-trait",
  "bincode",
@@ -4761,7 +4761,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4829,7 +4829,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4850,7 +4850,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5430,7 +5430,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5870,7 +5870,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6230,7 +6230,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6656,7 +6656,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -106,7 +106,7 @@ out (air-gapped hosts that provision out of band). libkrunfw is `dlopen`'d by
 
 `ext/microsandbox/Cargo.toml` depends on the core crate via a **pinned git tag**
 (`microsandbox` / `microsandbox-network`, pinned to the same tag as
-`Microsandbox::RUNTIME_VERSION` — currently `v0.6.1`), so the gem builds anywhere
+`Microsandbox::RUNTIME_VERSION` — currently `v0.6.2`), so the gem builds anywhere
 — CI, `rake-compiler-dock` release containers, and end-user source installs —
 without an adjacent checkout. For fast local development against a sibling
 microsandbox checkout, copy `.cargo/config.toml.example` to `.cargo/config.toml`
@@ -211,7 +211,7 @@ create options, full mount options (tmpfs/disk + stat-virtualization/
 host-permissions), and snapshot inspection (`open`/`list_dir`/`reindex`).
 
 A few **secondary** upstream knobs remain unexposed (a genuine binding gap, not
-upstream-gated — they exist at the pinned `v0.6.1` runtime): per-published-port host
+upstream-gated — they exist at the pinned `v0.6.2` runtime): per-published-port host
 **bind address** (ports always bind loopback), network **interface overrides**,
 and inline **named-volume create-mode** (pre-create with `Volume.create`, then
 mount with `{ named: }`). These slot in module-by-module exactly as the existing

--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
 Microsandbox::VERSION          # => "0.9.0"  (the gem's own version)
-Microsandbox.runtime_version   # => "v0.6.1"  (the embedded upstream runtime tag)
+Microsandbox.runtime_version   # => "v0.6.2"  (the embedded upstream runtime tag)
 ```
 
 | Gem version | Upstream runtime | Notes |

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ end
 
 ```ruby
 Microsandbox::Sandbox.create("obs", image: "public.ecr.aws/docker/library/alpine:latest") do |sb|
-  # On the v0.6.1 runtime the metrics slot goes live a beat after create returns,
+  # On v0.6.x runtimes the metrics slot goes live a beat after create returns,
   # so `metrics` can briefly raise "no live metrics slot" right after boot —
   # retry for a few hundred ms rather than treating the first failure as fatal.
   m = sb.metrics                       # => Microsandbox::Metrics
@@ -411,6 +411,7 @@ Microsandbox.runtime_version   # => "v0.6.1"  (the embedded upstream runtime tag
 | `0.8.1`  | `v0.5.10` | gem-only: re-provision a stale local runtime; per-bind-mount `quota_mib:` override |
 | `0.8.2`  | `v0.5.10` | gem-only: redact secrets from errors, typed snapshot errors, panic-free durations, fat-gem loader + `extconf` preflight fixes, threading/streaming docs |
 | `0.9.0`  | `v0.6.1` | adopts upstream `v0.6.0`+`v0.6.1` (zombie-runtime wait fix, secret substitution through CONNECT proxies, stale-sandbox cleanup); upstream public API is additive — no Ruby surface change |
+| `0.9.1`  | `v0.6.2` | adopts upstream `v0.6.2` (faster image loads/pulls via early cache gate + zlib-rs); upstream API unchanged — no Ruby surface change |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,8 +6,8 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.6.1).
-version = "0.9.0"
+# The core-crate dependency below stays pinned at its own tag (v0.6.2).
+version = "0.9.1"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.1", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.1" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.2", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.2" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -931,7 +931,7 @@ module Microsandbox
     #
     # Raises a {Microsandbox::Error} ("sandbox N has no live metrics slot") when
     # called in the brief window right after {Sandbox.create} returns, before the
-    # runtime has registered the sandbox's metrics slot. On the `v0.6.1` runtime
+    # runtime has registered the sandbox's metrics slot. On `v0.6.x` runtimes
     # the spawn handshake no longer blocks create until the first sample is
     # written, so the slot goes live a beat *after* boot (within a few hundred
     # milliseconds); retry for that window rather than treating the first failure

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,12 +8,12 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in
   # ext/microsandbox/Cargo.toml. Exposed at runtime as
   # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
   # sync with the Cargo tag so it can't silently drift out of date.
-  RUNTIME_VERSION = "v0.6.1"
+  RUNTIME_VERSION = "v0.6.2"
 end

--- a/spec/integration/streams_lifecycle_spec.rb
+++ b/spec/integration/streams_lifecycle_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "lifecycle controls + streaming", :integration do
         sb.exec("true")
         # Wait out the post-create metrics-slot startup window so the new sandbox
         # actually appears in the registry snapshot. Without it, all.key?(name) is
-        # false during the ~0.2-0.5s window on the v0.6.1 runtime and the
+        # false during the ~0.2-0.5s window on v0.6.x runtimes and the
         # assertion below would silently no-op (passing green having asserted
         # nothing). See wait_for_metrics_slot.
         wait_for_metrics_slot(sb)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -77,7 +77,7 @@ end
 
 # Block until a freshly-created sandbox's metrics slot is live, returning the
 # first successful Metrics snapshot. The per-sandbox metrics slot goes live a
-# beat AFTER Sandbox.create returns on the v0.6.1 runtime — the spawn handshake
+# beat AFTER Sandbox.create returns on v0.6.x runtimes — the spawn handshake
 # (upstream #1036) no longer blocks create until the first sample is written, so
 # `metrics`/`metrics_stream` briefly raise "sandbox N has no live metrics slot"
 # right after boot. Poll past that startup window so streaming assertions don't


### PR DESCRIPTION
## Summary

Adopts upstream runtime **v0.6.2** (released 2026-07-01) — a pure runtime bump with **no Ruby API change**.

- `microsandbox` / `microsandbox-network` git deps: `v0.6.1` → `v0.6.2` (tag verified healthy: workspace version at the tag is `0.6.2`, unlike the broken v0.5.9 tag)
- Gem `0.9.0` → `0.9.1` (patch: zero public-API delta), `RUNTIME_VERSION` → `v0.6.2`, `Cargo.lock` regenerated and committed
- CHANGELOG entry + README gem→runtime map row; RBS untouched (no surface change)

## Upstream v0.6.1 → v0.6.2 audit

- **SDK crate (`sdk/rust`)**: only `setup/host.rs` changed — private doctor-diagnostics helpers + tests, **zero `pub` item changes**. The `disk_size` builder rename (#983) was reverted (#1078) before the release cut, so the net builder API is identical.
- **`crates/network`, `crates/runtime`, `agentd`**: untouched → boot protocol identical (no `--config-fd`-style hazard).
- **`crates/image`** (#1075): faster loads/pulls (early cache gate + zlib-rs decode) — inherited transitively; `Sandbox.create` pulls benefit.
- **CLI-only** polish (help colors, doctor alignment, load progress) ships in the prebuilt `msb` binary; all prebuilt release assets (incl. `msb-darwin-aarch64`, agentd, libkrunfw) are present on the v0.6.2 release.

## Verification

- `cargo fmt --check` ✅ · `cargo clippy -D warnings` ✅ (against the real v0.6.2 git tag, paths override disabled)
- `standardrb` ✅ · unit specs **312 examples, 0 failures** ✅ (version lock-step asserted by `version_spec`)
- Real-microVM integration must go green in CI before merge (unit-green alone proved insufficient in the v0.5.9 incident).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5wTzM2H6EPjYwCryPwLLD