### PR TITLE
feat(runtime): adopt upstream v0.6.6, bump gem to 0.9.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ All notable changes to this gem are documented here. The format is based on
 microsandbox runtime it embeds; each release notes the upstream runtime tag it
 wraps, and the README's Versioning section keeps the full gem→runtime map.
 
+## [0.9.3] - 2026-07-09
+
+Adopts upstream runtime **`v0.6.3` → `v0.6.6`** (spanning upstream `v0.6.4` and
+`v0.6.6`; `v0.6.5` was yanked upstream — its GitHub release was pulled and the
+type-model refactor it shipped, #1014, was reverted in `v0.6.6`, #1143). The
+upstream SDK crate's public API grew only *additive* surface (live
+modify/resize, ping/touch — Ruby bindings for these land in the next minor),
+so this is a pure runtime bump with no Ruby API change.
+
+### Fixed
+
+- **Snapshot restore survives upstream tag republishes** (upstream #1130):
+  restore now pulls the OCI image by its pinned manifest digest
+  (`<repo>@sha256:…`) instead of re-resolving the mutable tag, fixing a fatal
+  `v0.6.3` regression where a republished base-image tag made existing
+  snapshots unrestorable.
+- **Fragmented UDP and PMTU relay traffic is forwarded correctly** (upstream
+  #1086) by the sandbox network relay.
+- **`exec` termination kills the whole process group, not just the direct
+  child** (upstream #1104): guest commands that spawn children (e.g. shell
+  pipelines) no longer leave orphaned grandchildren running after a kill.
+- **Stop waits tolerate ephemeral cleanup** (upstream #1087, inherited in
+  `Sandbox#stop`/`SandboxHandle#wait_until_stopped`): if an ephemeral
+  sandbox's persisted state is cleaned up while a stop wait is in flight, the
+  wait now resolves to a synthetic `stopped` result instead of raising
+  `SandboxNotFoundError`. Persistent sandboxes are unaffected.
+- **Filesystem snapshot `readdir` streams entries** (upstream #1133), fixing
+  unbounded memory growth (RSS leak) when listing very large directories.
+
+### Changed
+
+- **Embedded runtime is now `v0.6.6`** (`Microsandbox::RUNTIME_VERSION` /
+  `Microsandbox.runtime_version`). Also inherited:
+  - `Sandbox.create`/`.start` persist an active-config snapshot of the booted
+    sandbox in the runtime database (upstream SDK behavior; groundwork for
+    live modification).
+  - The runtime's shutdown flush timeout can be overridden via the
+    `MSB_SHUTDOWN_FLUSH_TIMEOUT_MS` environment variable (upstream #1088).
+  - The prebuilt `msb` binary gains `modify`/`ping`/`restart`/`touch`
+    subcommands and `metrics --watch`; these are CLI-level for now — the
+    corresponding Ruby APIs (`#modify`, `#ping`, `#touch`) ship in the next
+    minor release.
+
 ## [0.9.2] - 2026-07-08
 
 Adopts upstream runtime **`v0.6.2` → `v0.6.3`**. No Ruby API change; the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ Deeper architecture is in `DESIGN.md`; usage in `README.md`.
    change bumps the minor and a fix bumps the patch. See the Versioning section of `README.md` for
    the gem→runtime map.
 2. **Upstream runtime tag** — the `microsandbox` and `microsandbox-network` git deps in
-   `ext/microsandbox/Cargo.toml` are pinned to a `tag` (currently `v0.5.8`). This tracks the
+   `ext/microsandbox/Cargo.toml` are pinned to a `tag` (see `Microsandbox::RUNTIME_VERSION` for
+   the current pin — the hardcoded value here kept going stale). This tracks the
    upstream runtime, NOT the gem version. Bump it only when adopting a new upstream release, keep
    both deps on the same tag, AND update `Microsandbox::RUNTIME_VERSION` in
    `lib/microsandbox/version.rb` to match — `spec/unit/version_spec.rb` asserts the constant equals

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,7 +122,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -133,7 +133,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -577,9 +577,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bzip2"
@@ -1418,7 +1418,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1616,7 +1616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2532,7 +2532,7 @@ checksum = "ae8e22120c32fb4d19ec55fba35015f57095cd95a2e3b732e44457f5915b2ee8"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_core 0.10.1",
 ]
 
@@ -2975,8 +2975,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "anyhow",
  "astral-tokio-tar",
@@ -3007,7 +3007,7 @@ dependencies = [
  "microsandbox-utils",
  "nix 0.31.3",
  "notify",
- "rand 0.10.1",
+ "rand 0.10.2",
  "reqwest",
  "russh",
  "russh-sftp",
@@ -3025,12 +3025,13 @@ dependencies = [
  "typed-builder",
  "which",
  "windows-sys 0.61.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "microsandbox-agent-client"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "ciborium",
  "microsandbox-protocol",
@@ -3042,8 +3043,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-db"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "async-trait",
  "sea-orm",
@@ -3054,8 +3055,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-filesystem"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "libc",
  "microsandbox-utils",
@@ -3067,8 +3068,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-image"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "astral-tokio-tar",
  "async-compression",
@@ -3093,8 +3094,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-metrics"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "chrono",
  "libc",
@@ -3105,8 +3106,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-migration"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "sea-orm-migration",
  "serde_json",
@@ -3114,8 +3115,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-network"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "base64",
  "bytes",
@@ -3131,6 +3132,7 @@ dependencies = [
  "libc",
  "lru",
  "microsandbox-protocol",
+ "microsandbox-types",
  "microsandbox-utils",
  "msb_krun",
  "msb_krun_utils",
@@ -3152,12 +3154,13 @@ dependencies = [
  "tokio-rustls",
  "tracing",
  "windows-sys 0.61.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "microsandbox-protocol"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "chrono",
  "ciborium",
@@ -3171,8 +3174,8 @@ dependencies = [
 
 [[package]]
 name = "microsandbox-runtime"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "bytes",
  "chrono",
@@ -3198,24 +3201,26 @@ dependencies = [
  "tokio",
  "tracing",
  "windows-sys 0.61.2",
+ "zeroize",
 ]
 
 [[package]]
 name = "microsandbox-types"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "chrono",
  "serde",
  "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
 name = "microsandbox-utils"
-version = "0.6.3"
-source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.3#7121a8c3385252d9a9ec83677fea5a49a475cdb2"
+version = "0.6.6"
+source = "git+https://github.com/superradcompany/microsandbox?tag=v0.6.6#2367d506103f87fe733d7252c3202b278eadef88"
 dependencies = [
  "dirs",
  "libc",
@@ -3227,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.9.2"
+version = "0.9.3"
 dependencies = [
  "chrono",
  "futures",
@@ -3321,9 +3326,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fb3437734ef4103d3891d3cbd51a8726f196af350c68cb044a1860207c64d3"
+checksum = "70bc09516a8ed366b6f20504f434d619991dc879101462d86b24ae133937bd3b"
 dependencies = [
  "crossbeam-channel",
  "kvm-bindings",
@@ -3341,9 +3346,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e25fe665643d66900ec9407ef0d3afdb5cd4ca97ad394c46b8243bfa6344bfc0"
+checksum = "0d63ddae3ce5ba871a2b90bad6d789bf43583b8e587620580376222aed65e96a"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3356,15 +3361,15 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_arch_gen"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e50dfac228ad088917f8ffb2920c4a56d762ebc5a90950ee7bf5414253b02aa"
+checksum = "b14a030e7cd5740010a9d6eedd1002d2d42cc1481670cfa22a4dc5a89143048f"
 
 [[package]]
 name = "msb_krun_cpuid"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd5221749c0224858b075b61f3f2a0964dbfe367093e9ee650b6b0e3d690c3b2"
+checksum = "f33e9fbcbf5e27657d62177689a499a0dd64d4321afde53463f17b66c1acc2d7"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -3373,9 +3378,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_devices"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee50bfdf1a1258e33bcf0ee8631bb805db79b8d442161ab63d700689a992a8"
+checksum = "ca9d5c0ea156c5253c18c880aa29f038e639e9f5526d93ebb848e60d46b2bdca"
 dependencies = [
  "bitflags 1.3.2",
  "capng",
@@ -3403,9 +3408,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_hvf"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f2300bbe4dbd56bdc3ffc2384baf82e299fff8a45e844f41c4a0be64210ed47"
+checksum = "500d2d1d56525119b374ca622c351115eade0a75fb4ff8a16d1cc7117b29d169"
 dependencies = [
  "crossbeam-channel",
  "libloading",
@@ -3415,9 +3420,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_kernel"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3402b8879bd5b91f33d069fefa00fd0416f12cd660cfd7538da8e77201f2dda5"
+checksum = "836b43c16a0932baebf32b657f34153fd90f2e839a33e0002d54c6f91b4019b7"
 dependencies = [
  "msb_krun_utils",
  "vm-memory",
@@ -3425,9 +3430,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_polly"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da550bf268cb9217255ed152bfca9f61275a2796237fd180989958c7f54dc137"
+checksum = "6457213dc30bdb1a8bcb3ceba3a548f442fc913874f11b970745f779a6bf4842"
 dependencies = [
  "libc",
  "msb_krun_utils",
@@ -3435,18 +3440,18 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_smbios"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0737818e69346348f8ba2a7197cbec2336e807e5f7f094c80e0ca1635ca054"
+checksum = "91f33a174635431e57a0d59a4aed487599c2ff2ac9ca1ea2346626112a2499af"
 dependencies = [
  "vm-memory",
 ]
 
 [[package]]
 name = "msb_krun_utils"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb370035195bfd6d60e0b4ad8b0d68dcf9d138f144d033087a960117920a126e"
+checksum = "54d6f5ee4b160d020de8c91d9237a9592472ee6353b1b72cd08d51b2149c9433"
 dependencies = [
  "bitflags 1.3.2",
  "crossbeam-channel",
@@ -3460,9 +3465,9 @@ dependencies = [
 
 [[package]]
 name = "msb_krun_vmm"
-version = "0.1.19"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68e9f485f720981fda9071b2711d4f8406b6c67ebf6bfa2bb8e83f3cc6c2aaea"
+checksum = "816b34f9bf7eef3f101e84452e663cf9ac6e173377d5ff277192fb8c82cf3199"
 dependencies = [
  "bzip2",
  "crossbeam-channel",
@@ -3881,7 +3886,7 @@ dependencies = [
  "delegate",
  "futures",
  "log",
- "rand 0.10.1",
+ "rand 0.10.2",
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
@@ -4279,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.45"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -4331,9 +4336,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
@@ -4459,9 +4464,9 @@ dependencies = [
 
 [[package]]
 name = "reflink-copy"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13362233b147e57674c37b802d216b7c5e3dcccbed8967c84f0d8d223868ae27"
+checksum = "d9dd7ab4af0363d5ccfd2838d782a28196cf32a5cc2e4fe3c5dc83f2be588b8b"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4660,7 +4665,7 @@ dependencies = [
  "pkcs5",
  "pkcs8 0.11.0",
  "polyval",
- "rand 0.10.1",
+ "rand 0.10.2",
  "rand_core 0.10.1",
  "rsa 0.10.0-rc.18",
  "russh-cryptovec",
@@ -4761,14 +4766,14 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.40"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4829,7 +4834,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4850,7 +4855,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5430,7 +5435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5870,7 +5875,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5924,9 +5929,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.49"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
  "num-conv",
@@ -5944,9 +5949,9 @@ checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.29"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c652a3727a9cbb9a02f707f530b618ce00d0ccd762009c8c23bd191df3c17d"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6230,7 +6235,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6656,7 +6661,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7372,6 +7377,7 @@ version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
+ "serde",
  "zeroize_derive",
 ]
 

--- a/README.md
+++ b/README.md
@@ -393,8 +393,8 @@ change diverged the two numbers — the gem version is **not** a reliable indica
 of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
-Microsandbox::VERSION          # => "0.9.2"  (the gem's own version)
-Microsandbox.runtime_version   # => "v0.6.3"  (the embedded upstream runtime tag)
+Microsandbox::VERSION          # => "0.9.3"  (the gem's own version)
+Microsandbox.runtime_version   # => "v0.6.6"  (the embedded upstream runtime tag)
 ```
 
 | Gem version | Upstream runtime | Notes |
@@ -413,6 +413,7 @@ Microsandbox.runtime_version   # => "v0.6.3"  (the embedded upstream runtime tag
 | `0.9.0`  | `v0.6.1` | adopts upstream `v0.6.0`+`v0.6.1` (zombie-runtime wait fix, secret substitution through CONNECT proxies, stale-sandbox cleanup); upstream public API is additive — no Ruby surface change |
 | `0.9.1`  | `v0.6.2` | adopts upstream `v0.6.2` (faster image loads/pulls via early cache gate + zlib-rs); upstream API unchanged — no Ruby surface change |
 | `0.9.2`  | `v0.6.3` | adopts upstream `v0.6.3` (v4-only sandboxes stop advertising AAAA DNS answers — fixes guest gRPC/c-ares preferring unreachable IPv6; scoped upstream TLS verification); glue moves to `*_local` SDK variants — no Ruby surface change |
+| `0.9.3`  | `v0.6.6` | adopts upstream `v0.6.4`+`v0.6.6` (`v0.6.5` was yanked upstream): snapshot restore by pinned digest — fixes fatal restore-after-tag-republish bug, fragmented-UDP/PMTU relay fixes, exec kills the whole process group, ephemeral stop-wait tolerance, readdir RSS-leak fix; upstream API growth is additive-only — no Ruby surface change |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -6,8 +6,8 @@ name = "microsandbox_rb"
 description = "Ruby SDK native extension for microsandbox — secure, fast microVM-based sandboxing."
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
-# The core-crate dependency below stays pinned at its own tag (v0.6.3).
-version = "0.9.2"
+# The core-crate dependency below stays pinned at its own tag (v0.6.6).
+version = "0.9.3"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"
@@ -35,8 +35,8 @@ rb-sys = "0.9"
 # `.cargo/config.toml.example`). "ssh" matches the feature set the Python/Node
 # SDKs ship with; default features add "prebuilt" (provisions msb + libkrunfw at
 # build time), "net", and "keyring".
-microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.3", default-features = true, features = ["ssh"] }
-microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.3" }
+microsandbox = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.6", default-features = true, features = ["ssh"] }
+microsandbox-network = { git = "https://github.com/superradcompany/microsandbox", tag = "v0.6.6" }
 
 # Async core bridged to Ruby's synchronous API via a blocking tokio runtime.
 tokio = { version = "1", features = ["rt-multi-thread", "sync", "time"] }

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,12 +8,12 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in
   # ext/microsandbox/Cargo.toml. Exposed at runtime as
   # {Microsandbox.runtime_version}. spec/unit/version_spec.rb asserts it stays in
   # sync with the Cargo tag so it can't silently drift out of date.
-  RUNTIME_VERSION = "v0.6.3"
+  RUNTIME_VERSION = "v0.6.6"
 end


### PR DESCRIPTION
## Summary

Adopts upstream runtime **v0.6.3 → v0.6.6**, spanning upstream v0.6.4 and v0.6.6. **v0.6.5 is skipped deliberately: it was yanked upstream** (no GitHub release exists for it; v0.6.6 added the release-yank CI workflow, and the type-model refactor v0.6.5 shipped — #1014 — was reverted in v0.6.6 via #1143).

The upstream SDK crate's public API growth in this range is **additive-only** (live `modify`/resize, `ping`/`touch`, create-time `max_cpus`/`max_memory`), verified by a full `sdk/rust` diff — existing glue compiles unchanged. This PR is therefore a **pure runtime bump with no Ruby surface change**, gem `0.9.2 → 0.9.3` (patch). Ruby bindings for the new API surface follow in a separate parity PR (`0.10.0`).

## Inherited upstream fixes

- **Snapshot restore by pinned manifest digest** (#1130) — fixes a fatal v0.6.3 regression: a republished base-image tag made existing snapshots unrestorable.
- **Fragmented UDP / PMTU relay traffic** forwarded correctly (#1086).
- **`exec` termination kills the whole process group** (#1104) — no more orphaned grandchildren after a kill.
- **Stop waits tolerate ephemeral cleanup** (#1087) — inherited in `Sandbox#stop` / `SandboxHandle#wait_until_stopped`; ephemeral-sandbox stop waits resolve to a synthetic `stopped` result instead of raising `SandboxNotFoundError`.
- **Streaming readdir** fixes an RSS leak on huge directory listings (#1133).
- Runtime shutdown flush timeout overridable via `MSB_SHUTDOWN_FLUSH_TIMEOUT_MS` (#1088).

## Lockfile alignment (transitive deps)

Aligned to upstream's v0.6.6 `Cargo.lock` per the established process: `msb_krun` family ×11 `0.1.19 → 0.1.25`, `rand 0.10.1 → 0.10.2`, plus behind-upstream crates brought to the upstream-tested versions (`rustls 0.23.41`, `bytes 1.12.0`, `time 0.3.51`, `reflink-copy 0.1.30`, `quote 1.0.46`). `cmov` was already at `0.5.4`.

## Compatibility notes

- v0.6.6 release assets are complete (all-platform `msb` + `libkrunfw` + `agentd`), and the prebuilt download URL logic is byte-identical upstream — no repeat of the v0.5.9 tag/binary mismatch.
- The new-SDK-drives-old-`msb` risk from the added `--max-vcpus`/`--max-memory-mib` flags is moot here: the flags are only passed when max resources are configured (no Ruby API for them yet), and the version-aware `ensure_runtime!` re-provisioning from 0.8.1 (#18) keeps the binary paired with the crate anyway.

## Verification

- `cargo fmt --check` ✅ / `cargo clippy -D warnings` ✅ (against the v0.6.6 git dep, local paths override disabled)
- `bundle exec standardrb` ✅
- Unit specs: **312 examples, 0 failures** ✅ (includes `version_spec` lock-step assertions: gem `VERSION` == crate version, `RUNTIME_VERSION` == Cargo tag)
- Real-microVM integration: ✅ **33 examples, 0 failures, 1 pending** (dispatch run [28961185524](https://github.com/ya-luotao/microsandbox-rb/actions/runs/28961185524) — all 11 jobs green, booting the real v0.6.6 runtime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uutVDpgRxL2NKRLbMRSbQ
