### PR TITLE
feat(sandbox): live modify/resize, ping/touch — v0.6.6 API parity, gem 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ All notable changes to this gem are documented here. The format is based on
 microsandbox runtime it embeds; each release notes the upstream runtime tag it
 wraps, and the README's Versioning section keeps the full gem→runtime map.
 
+## [0.10.0] - 2026-07-09
+
+Ruby bindings for the additive `v0.6.6` SDK surface (upstream #1099 / #1128),
+bringing the gem to parity with the Python and Node SDKs, which already ship
+this API. The embedded runtime tag is unchanged (`v0.6.6`); this is a pure
+binding addition with no breaking change.
+
+### Added
+
+- **Live sandbox modification** — `Sandbox#modify` and `SandboxHandle#modify`
+  plan or apply a change to a running (or stopped) sandbox without recreating
+  it: resize CPU/memory (`cpus:`, `max_cpus:`, `memory:`, `max_memory:`, MiB),
+  adjust `env:`/`remove_env:`, `labels:`/`remove_labels:`, and `workdir:`, and
+  rotate/remove secrets (`secrets:` keyed by name with mutually-exclusive
+  `env:`/`store:`/`value:` plus `placeholder:`/`allowed_hosts:`,
+  `remove_secrets:`). `policy:` selects `:no_restart` (default), `:next_start`,
+  or `:restart`; `dry_run: true` computes the plan without applying it. Returns
+  a typed `ModificationPlan` (`#sandbox`, `#status`, `#applied?`, `#policy`,
+  `#changes`, `#conflicts`, `#warnings`, `#resize_status`) whose nested entries
+  are frozen, symbol-keyed Hashes carrying the runtime's canonical snake_case
+  fields verbatim.
+- **Health checks** — `Sandbox#ping` / `SandboxHandle#ping` return a
+  `PingResult` (`#name`, `#latency` in seconds, `#latency_ms`) confirming the
+  guest agent is reachable **without** refreshing the idle timer; `#touch`
+  returns a `TouchResult` (`#name`, `#activity_seq`) that explicitly refreshes
+  the idle-activity timer. On the handle, both raise `SandboxNotRunningError`
+  for a stopped sandbox (it is not started implicitly).
+- **Create-time resource ceilings** — `Sandbox.create` accepts `max_cpus:` and
+  `max_memory:` (MiB), the boot-time maxima a later live `modify` can grow up
+  to (each defaults to its `cpus:`/`memory:` value and must be >= it).
+- **`SandboxNotRunningError`** is now raised by the runtime's not-running guard
+  (the class already existed; the new core `SandboxNotRunning` variant is now
+  mapped to it instead of falling back to the base `Error`).
+
+Deliberately **not** exposed, matching the Python and Node SDKs (both surface
+these only through the CLI): `modify`'s `oci_upper_size` overlay-grow field, and
+the `SandboxMetricsReport` / per-sandbox metrics-report helpers.
+
 ## [0.9.3] - 2026-07-09
 
 Adopts upstream runtime **`v0.6.3` → `v0.6.6`** (spanning upstream `v0.6.4` and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "microsandbox_rb"
-version = "0.9.3"
+version = "0.10.0"
 dependencies = [
  "chrono",
  "futures",

--- a/README.md
+++ b/README.md
@@ -229,6 +229,55 @@ Microsandbox::Sandbox.create("obs", image: "public.ecr.aws/docker/library/alpine
 end
 ```
 
+### Live modification & health
+
+Resize, reconfigure, or rotate secrets on a sandbox **without recreating it**,
+and probe the guest agent's liveness. To leave headroom for a live CPU/memory
+resize, reserve a ceiling at create time with `max_cpus:`/`max_memory:`:
+
+```ruby
+Microsandbox::Sandbox.create("live", image: "public.ecr.aws/docker/library/alpine:latest",
+  cpus: 1, max_cpus: 4, memory: 512, max_memory: 2048) do |sb|
+  # Health check — does NOT refresh the idle timer:
+  ping = sb.ping                       # => Microsandbox::PingResult
+  ping.latency_ms                      # round-trip latency
+
+  # Explicitly refresh the idle-activity timer (resets any idle_timeout:):
+  sb.touch.activity_seq                # => Microsandbox::TouchResult
+
+  # Preview a change without applying it:
+  plan = sb.modify(cpus: 2, memory: 1024, dry_run: true)
+  plan.applied?                        # => false
+  plan.changes                         # => [{ kind: "config", field: "cpus", ... }, ...]
+
+  # Live resize — applies to the running VM under the default :no_restart policy:
+  sb.modify(cpus: 2, memory: 1024)
+
+  # env/labels/workdir changes on a *running* sandbox require a restart, so the
+  # default :no_restart policy rejects the whole apply (it raises rather than
+  # partially applying). Persist them for the next start — or restart now —
+  # by saying so explicitly:
+  sb.modify(env: { "TIER" => "prod" }, remove_env: ["DEBUG"],
+    labels: { "role" => "worker" }, policy: :next_start)  # or policy: :restart
+
+  # Rotating/removing an *existing* secret (or updating its allowed hosts) is
+  # live; *adding* a new secret is restart-required, like env. Specs are keyed
+  # by name; env:/store:/value: are mutually exclusive:
+  sb.modify(
+    secrets: { "API_KEY" => { env: "HOST_API_KEY", allowed_hosts: ["api.example.com"] } },
+    remove_secrets: ["OLD_TOKEN"],
+  )
+end
+```
+
+The apply is **all-or-nothing**: under a given `policy:` every planned change
+must be applicable, or the whole `modify` raises — nothing is partially
+applied. Use `dry_run: true` to inspect each change's `disposition` (`"live"`,
+`"next start"`, `"requires restart"`) before committing.
+
+`SandboxHandle` (from `Sandbox.get`/`list`) carries the same `#ping`/`#touch`/
+`#modify`; on a stopped sandbox `#ping`/`#touch` raise `SandboxNotRunningError`.
+
 ### Streaming output
 
 For long-running commands, stream events as they arrive instead of waiting:
@@ -393,7 +442,7 @@ change diverged the two numbers — the gem version is **not** a reliable indica
 of the embedded runtime version. To learn which runtime a build wraps, ask it:
 
 ```ruby
-Microsandbox::VERSION          # => "0.9.3"  (the gem's own version)
+Microsandbox::VERSION          # => "0.10.0"  (the gem's own version)
 Microsandbox.runtime_version   # => "v0.6.6"  (the embedded upstream runtime tag)
 ```
 
@@ -414,6 +463,7 @@ Microsandbox.runtime_version   # => "v0.6.6"  (the embedded upstream runtime tag
 | `0.9.1`  | `v0.6.2` | adopts upstream `v0.6.2` (faster image loads/pulls via early cache gate + zlib-rs); upstream API unchanged — no Ruby surface change |
 | `0.9.2`  | `v0.6.3` | adopts upstream `v0.6.3` (v4-only sandboxes stop advertising AAAA DNS answers — fixes guest gRPC/c-ares preferring unreachable IPv6; scoped upstream TLS verification); glue moves to `*_local` SDK variants — no Ruby surface change |
 | `0.9.3`  | `v0.6.6` | adopts upstream `v0.6.4`+`v0.6.6` (`v0.6.5` was yanked upstream): snapshot restore by pinned digest — fixes fatal restore-after-tag-republish bug, fragmented-UDP/PMTU relay fixes, exec kills the whole process group, ephemeral stop-wait tolerance, readdir RSS-leak fix; upstream API growth is additive-only — no Ruby surface change |
+| `0.10.0` | `v0.6.6` | `v0.6.6` API parity: live `modify`/resize, `ping`/`touch`, create `max_cpus`/`max_memory` |
 
 **Going forward** — the gem version moves on its own semver track and no longer
 mirrors the upstream tag:

--- a/ext/microsandbox/Cargo.toml
+++ b/ext/microsandbox/Cargo.toml
@@ -7,7 +7,7 @@ description = "Ruby SDK native extension for microsandbox — secure, fast micro
 # Must equal Microsandbox::VERSION (lib/microsandbox/version.rb) — Native.version
 # returns this via env!("CARGO_PKG_VERSION") and version_spec.rb asserts equality.
 # The core-crate dependency below stays pinned at its own tag (v0.6.6).
-version = "0.9.3"
+version = "0.10.0"
 authors = ["Super Rad Company <development@superrad.company>"]
 repository = "https://github.com/superradcompany/microsandbox"
 license = "Apache-2.0"

--- a/ext/microsandbox/src/error.rs
+++ b/ext/microsandbox/src/error.rs
@@ -17,6 +17,12 @@ fn class_name(err: &MicrosandboxError) -> &'static str {
         SandboxNotFound(_) => "SandboxNotFoundError",
         SandboxAlreadyExists(_) => "SandboxAlreadyExistsError",
         SandboxStillRunning(_) => "SandboxStillRunningError",
+        // v0.6.6 (#1099): the sandbox exists but isn't running. Raised by the
+        // handle's exec/attach/ping/touch not-running guards and the fs
+        // agent-endpoint lookup. The `SandboxNotRunningError` class already
+        // existed (mirroring the Python SDK); this wires the new core variant to
+        // it instead of letting it collapse to the base `Error`.
+        SandboxNotRunning(_) => "SandboxNotRunningError",
         ExecTimeout(_) => "ExecTimeoutError",
         ExecFailed(_) => "ExecFailedError",
         SandboxFsOps(_) => "FilesystemError",

--- a/ext/microsandbox/src/sandbox.rs
+++ b/ext/microsandbox/src/sandbox.rs
@@ -18,10 +18,11 @@ use microsandbox::logs::{
     LogCursor, LogEntry, LogOptions, LogSource, LogStreamOptions, LogStreamStart,
 };
 use microsandbox::sandbox::{
-    AttachOptionsBuilder, DiskImageFormat, FsEntry, FsEntryKind, FsMetadata, HostPermissions,
-    Patch, PullPolicy, PullProgress, PullProgressHandle, RlimitResource, SandboxBuilder,
-    SandboxFilter, SandboxHandle, SandboxMetrics, SandboxStatus, SandboxStopResult, SecretBuilder,
-    SecurityProfile, StatVirtualization,
+    AttachOptionsBuilder, DiskImageFormat, EnvVar, FsEntry, FsEntryKind, FsMetadata,
+    HostPermissions, Patch, PullPolicy, PullProgress, PullProgressHandle, RlimitResource,
+    SandboxBuilder, SandboxFilter, SandboxHandle, SandboxMetrics, SandboxModificationBuilder,
+    SandboxModificationPatch, SandboxStatus, SandboxStopResult, SecretBuilder,
+    SecretModificationPatch, SecretSource, SecurityProfile, StatVirtualization,
 };
 use microsandbox::LogLevel;
 use microsandbox::MicrosandboxResult;
@@ -92,8 +93,18 @@ impl Sandbox {
         if let Some(v) = conv::opt_u8(opts, "cpus")? {
             b = b.cpus(v);
         }
+        // v0.6.6 (#1099): boot-time maximum vCPU / memory ceilings that a later
+        // live `modify` can grow up to. `cpus`/`memory` above already raise these
+        // to their own value if lower, so a bare `cpus`/`memory` still works;
+        // setting these explicitly reserves headroom for a live resize.
+        if let Some(v) = conv::opt_u8(opts, "max_cpus")? {
+            b = b.max_cpus(v);
+        }
         if let Some(v) = conv::opt_u32(opts, "memory")? {
             b = b.memory(v);
+        }
+        if let Some(v) = conv::opt_u32(opts, "max_memory")? {
+            b = b.max_memory(v);
         }
         if let Some(v) = conv::opt_string(opts, "workdir")? {
             b = b.workdir(v);
@@ -582,6 +593,34 @@ impl Sandbox {
     fn metrics(&self) -> Result<RHash, Error> {
         let m = block_on(self.inner.metrics()).map_err(error::to_ruby)?;
         Ok(metrics_to_hash(&m))
+    }
+
+    //----------------------------------------------------------------------
+    // Health & modification (v0.6.6 / #1099)
+    //----------------------------------------------------------------------
+
+    /// Health-check the guest agent without refreshing the idle timer. Returns
+    /// `{ name, latency_secs }` (round-trip latency as f64 seconds; the Ruby
+    /// layer exposes both seconds and milliseconds).
+    fn ping(&self) -> Result<RHash, Error> {
+        let result = block_on(self.inner.ping()).map_err(error::to_ruby)?;
+        Ok(ping_result_to_hash(&result))
+    }
+
+    /// Explicitly refresh the idle-activity timer. Returns
+    /// `{ name, activity_seq }`.
+    fn touch(&self) -> Result<RHash, Error> {
+        let result = block_on(self.inner.touch()).map_err(error::to_ruby)?;
+        Ok(touch_result_to_hash(&result))
+    }
+
+    /// Plan or apply a live sandbox modification. `opts` is the string-keyed
+    /// modify Hash normalized by the Ruby layer; returns the resulting
+    /// `SandboxModificationPlan` as a JSON string, which the Ruby layer parses
+    /// into a `ModificationPlan`. Mirrors the Node native binding (native returns
+    /// JSON, the wrapper shapes it).
+    fn modify(&self, opts: RHash) -> Result<String, Error> {
+        run_modify(self.inner.modify(), opts)
     }
 
     /// Read captured logs as an Array of Hashes. `opts`: tail, since_ms,
@@ -1737,6 +1776,133 @@ fn stop_result_to_hash(result: &SandboxStopResult) -> RHash {
 }
 
 //--------------------------------------------------------------------------------------------------
+// Health & live modification (v0.6.6 / #1099)
+//--------------------------------------------------------------------------------------------------
+
+/// A `SandboxPingResult` as `{ name, latency_secs }`. Latency is a `Duration`;
+/// we hand it to Ruby as f64 seconds and let the Ruby layer derive milliseconds
+/// (the Python/Node SDKs expose only `latency_ms`).
+fn ping_result_to_hash(result: &microsandbox::sandbox::SandboxPingResult) -> RHash {
+    let hash = ruby().hash_new();
+    let _ = hash.aset("name", result.name.clone());
+    let _ = hash.aset("latency_secs", result.latency.as_secs_f64());
+    hash
+}
+
+/// A `SandboxTouchResult` as `{ name, activity_seq }`.
+fn touch_result_to_hash(result: &microsandbox::sandbox::SandboxTouchResult) -> RHash {
+    let hash = ruby().hash_new();
+    let _ = hash.aset("name", result.name.clone());
+    let _ = hash.aset("activity_seq", result.activity_seq);
+    hash
+}
+
+/// Drive a modify builder to a plan (dry-run or apply) and return it serialized
+/// as a JSON string. Shared by `Sandbox::modify` and `SbHandle::modify`. The
+/// canonical `SandboxModificationPlan` serde shape (snake_case keys, literal-space
+/// enum strings) is parsed verbatim by the Ruby layer — matching the Python SDK's
+/// raw-dict contract rather than re-casing it.
+fn run_modify(builder: SandboxModificationBuilder, opts: RHash) -> Result<String, Error> {
+    let patch = build_modify_patch(opts)?;
+    let policy = conv::opt_string(opts, "policy")?.unwrap_or_else(|| "no_restart".to_string());
+    let dry_run = conv::opt_bool(opts, "dry_run")?;
+    let builder = apply_modify_policy(builder.with_patch(patch), &policy)?;
+    let plan = block_on(async move {
+        if dry_run {
+            builder.dry_run().await
+        } else {
+            builder.apply().await
+        }
+    })
+    .map_err(error::to_ruby)?;
+    serde_json::to_string(&plan)
+        .map_err(|e| error::base_error(format!("failed to serialize modification plan: {e}")))
+}
+
+/// Build the canonical `SandboxModificationPatch` from the modify Hash. Env and
+/// label pairs are sorted so repeated calls with the same arguments produce the
+/// same patch (and plan) ordering, mirroring the Python binding. `oci_upper_size`
+/// is deliberately not surfaced (CLI-only upstream; the Python/Node SDKs omit it
+/// too), so it stays unset via `..Default::default()`.
+fn build_modify_patch(opts: RHash) -> Result<SandboxModificationPatch, Error> {
+    let mut env_pairs = conv::opt_string_map(opts, "env")?;
+    env_pairs.sort();
+    let mut label_pairs = conv::opt_string_map(opts, "labels")?;
+    label_pairs.sort();
+
+    Ok(SandboxModificationPatch {
+        cpus: conv::opt_u8(opts, "cpus")?,
+        max_cpus: conv::opt_u8(opts, "max_cpus")?,
+        memory_mib: conv::opt_u32(opts, "memory")?,
+        max_memory_mib: conv::opt_u32(opts, "max_memory")?,
+        env: env_pairs
+            .into_iter()
+            .map(|(k, v)| EnvVar::new(k, v))
+            .collect(),
+        env_remove: conv::opt_string_vec(opts, "remove_env")?,
+        labels: label_pairs,
+        labels_remove: conv::opt_string_vec(opts, "remove_labels")?,
+        workdir: conv::opt_string(opts, "workdir")?,
+        secrets: parse_modify_secrets(opts)?,
+        secrets_remove: conv::opt_string_vec(opts, "remove_secrets")?,
+        ..Default::default()
+    })
+}
+
+/// Parse the `secrets` modify option (an Array of string-keyed Hashes normalized
+/// by the Ruby layer) into canonical `SecretModificationPatch`es. Each Hash
+/// carries `name` plus at most one of `env`/`store` (source) or `value` (raw
+/// material) — the Ruby layer enforces that mutual exclusion — plus optional
+/// `placeholder` and `allowed_hosts`. The raw `value` moves straight into the
+/// `Zeroizing` field; it is never echoed in an error.
+fn parse_modify_secrets(opts: RHash) -> Result<Vec<SecretModificationPatch>, Error> {
+    let mut out = Vec::new();
+    for h in conv::opt_hash_vec(opts, "secrets")? {
+        let name = conv::opt_string(h, "name")?
+            .ok_or_else(|| error::base_error("secret modification spec requires :name"))?;
+        let env = conv::opt_string(h, "env")?;
+        let store = conv::opt_string(h, "store")?;
+        let value = conv::opt_string(h, "value")?;
+        let source = match (env, store) {
+            (Some(var), None) => Some(SecretSource::Env { var }),
+            (None, Some(reference)) => Some(SecretSource::Store { reference }),
+            (None, None) => None,
+            // The Ruby layer rejects >1 source; guard defensively without
+            // echoing any value.
+            (Some(_), Some(_)) => {
+                return Err(error::base_error(format!(
+                    "secret {name:?}: \"env\" and \"store\" are mutually exclusive"
+                )))
+            }
+        };
+        out.push(SecretModificationPatch {
+            name,
+            source,
+            value: value.unwrap_or_default().into(),
+            placeholder: conv::opt_string(h, "placeholder")?,
+            allowed_hosts: conv::opt_string_vec(h, "allowed_hosts")?,
+        });
+    }
+    Ok(out)
+}
+
+/// Apply the parsed `policy` string to a modify builder. `no_restart` (default)
+/// leaves the builder untouched; `next_start`/`restart` select those policies.
+fn apply_modify_policy(
+    builder: SandboxModificationBuilder,
+    policy: &str,
+) -> Result<SandboxModificationBuilder, Error> {
+    match policy {
+        "no_restart" => Ok(builder),
+        "next_start" => Ok(builder.next_start()),
+        "restart" => Ok(builder.restart()),
+        other => Err(error::base_error(format!(
+            "unknown policy {other:?}; expected \"no_restart\", \"next_start\", or \"restart\""
+        ))),
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
 // Pull progress (streaming image-pull during create_with_progress)
 //--------------------------------------------------------------------------------------------------
 
@@ -1987,6 +2153,27 @@ impl SbHandle {
         let snap = block_on(self.inner.snapshot_to(path)).map_err(error::to_ruby)?;
         Ok(crate::snapshot::snapshot_to_hash(&snap))
     }
+
+    /// Health-check the guest agent without refreshing the idle timer. A stopped
+    /// sandbox raises `SandboxNotRunningError` (the handle does not start it
+    /// implicitly). Returns `{ name, latency_secs }`.
+    fn ping(&self) -> Result<RHash, Error> {
+        let result = block_on(self.inner.ping()).map_err(error::to_ruby)?;
+        Ok(ping_result_to_hash(&result))
+    }
+
+    /// Explicitly refresh the idle-activity timer. A stopped sandbox raises
+    /// `SandboxNotRunningError`. Returns `{ name, activity_seq }`.
+    fn touch(&self) -> Result<RHash, Error> {
+        let result = block_on(self.inner.touch()).map_err(error::to_ruby)?;
+        Ok(touch_result_to_hash(&result))
+    }
+
+    /// Plan or apply a live sandbox modification (see `Sandbox::modify`). Returns
+    /// the `SandboxModificationPlan` as a JSON string.
+    fn modify(&self, opts: RHash) -> Result<String, Error> {
+        run_modify(self.inner.modify(), opts)
+    }
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -2100,6 +2287,9 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     class.define_method("owns_lifecycle", method!(Sandbox::owns_lifecycle, 0))?;
     class.define_method("detach", method!(Sandbox::detach, 0))?;
     class.define_method("metrics", method!(Sandbox::metrics, 0))?;
+    class.define_method("ping", method!(Sandbox::ping, 0))?;
+    class.define_method("touch", method!(Sandbox::touch, 0))?;
+    class.define_method("modify", method!(Sandbox::modify, 1))?;
     class.define_method("metrics_stream", method!(Sandbox::metrics_stream, 1))?;
     class.define_method("logs", method!(Sandbox::logs, 1))?;
     class.define_method("log_stream", method!(Sandbox::log_stream, 1))?;
@@ -2148,6 +2338,9 @@ pub fn define(ruby: &Ruby, native: &RModule) -> Result<(), Error> {
     handle.define_method("config_json", method!(SbHandle::config_json, 0))?;
     handle.define_method("snapshot", method!(SbHandle::snapshot, 1))?;
     handle.define_method("snapshot_to", method!(SbHandle::snapshot_to, 1))?;
+    handle.define_method("ping", method!(SbHandle::ping, 0))?;
+    handle.define_method("touch", method!(SbHandle::touch, 0))?;
+    handle.define_method("modify", method!(SbHandle::modify, 1))?;
 
     let session = native.define_class("PullSession", ruby.class_object())?;
     session.define_method("recv", method!(PullSession::recv, 0))?;

--- a/lib/microsandbox.rb
+++ b/lib/microsandbox.rb
@@ -30,6 +30,7 @@ require_relative "microsandbox/patch"
 require_relative "microsandbox/network"
 require_relative "microsandbox/agent"
 require_relative "microsandbox/ssh"
+require_relative "microsandbox/modification"
 require_relative "microsandbox/sandbox"
 
 # Microsandbox — lightweight microVM sandboxes for Ruby.

--- a/lib/microsandbox/modification.rb
+++ b/lib/microsandbox/modification.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+module Microsandbox
+  # The result of {Sandbox#ping} / {SandboxHandle#ping}: a lightweight health
+  # check that confirms the guest agent is reachable without refreshing the
+  # sandbox idle timer. Mirrors the official SDKs' `SandboxPingResult`.
+  #
+  # The native layer reports latency as seconds; {#latency} is the canonical
+  # value and {#latency_ms} the convenience the Python/Node SDKs expose.
+  class PingResult
+    # @return [String] the sandbox name that was pinged
+    attr_reader :name
+    # @return [Float] round-trip latency in seconds
+    attr_reader :latency
+
+    def initialize(data)
+      @name = data["name"]
+      @latency = data["latency_secs"]
+    end
+
+    # @return [Float] round-trip latency in milliseconds
+    def latency_ms
+      @latency * 1000.0
+    end
+
+    def inspect
+      "#<Microsandbox::PingResult name=#{@name.inspect} latency_ms=#{format("%.3f", latency_ms)}>"
+    end
+  end
+
+  # The result of {Sandbox#touch} / {SandboxHandle#touch}: an explicit refresh of
+  # the sandbox idle-activity timer. Mirrors the official SDKs' `SandboxTouchResult`.
+  class TouchResult
+    # @return [String] the sandbox name that was touched
+    attr_reader :name
+    # @return [Integer] the agent activity sequence after this touch was recorded
+    attr_reader :activity_seq
+
+    def initialize(data)
+      @name = data["name"]
+      @activity_seq = data["activity_seq"]
+    end
+
+    def inspect
+      "#<Microsandbox::TouchResult name=#{@name.inspect} activity_seq=#{@activity_seq}>"
+    end
+  end
+
+  # The plan produced by {Sandbox#modify} / {SandboxHandle#modify}: the classified
+  # set of changes a modification requested, and (for a non-dry-run apply) whether
+  # they were applied plus any live-resize convergence outcomes. Mirrors the
+  # official SDKs' `SandboxModificationPlan`.
+  #
+  # The nested collections ({#changes}, {#conflicts}, {#warnings},
+  # {#resize_status}) are frozen Arrays of frozen, symbol-keyed Hashes carrying
+  # the canonical snake_case fields verbatim (e.g. a config change is
+  # `{ kind: "config", field:, change:, before:, after:, disposition:, reason: }`;
+  # a secret change adds `name:`, `before_ref:`, `after_ref:`, `allow_hosts:`).
+  # Enum values stay as the runtime's strings (e.g. a `disposition` of
+  # `"next start"`, a `state` of `"guest-refused"`).
+  class ModificationPlan
+    # @return [String] the sandbox the plan applies to
+    attr_reader :sandbox
+    # @return [String] the sandbox status used to classify the changes
+    attr_reader :status
+    # @return [Symbol] :no_restart, :next_start, or :restart
+    attr_reader :policy
+    # @return [Array<Hash>] the planned changes (config and secret)
+    attr_reader :changes
+    # @return [Array<Hash>] conflicts that must be resolved before applying
+    attr_reader :conflicts
+    # @return [Array<Hash>] non-fatal warnings about the patch
+    attr_reader :warnings
+    # @return [Array<Hash>] live resource-resize outcomes (populated by an apply)
+    attr_reader :resize_status
+
+    def initialize(data)
+      @sandbox = data["sandbox"]
+      @status = data["status"]
+      @applied = data["applied"]
+      @policy = data["policy"]&.to_sym
+      @changes = freeze_items(data["changes"])
+      @conflicts = freeze_items(data["conflicts"])
+      @warnings = freeze_items(data["warnings"])
+      @resize_status = freeze_items(data["resize_status"])
+    end
+
+    # @return [Boolean] whether the changes were applied (false for a dry run)
+    def applied?
+      @applied
+    end
+
+    def inspect
+      "#<Microsandbox::ModificationPlan sandbox=#{@sandbox.inspect} applied=#{@applied} " \
+        "policy=#{@policy} changes=#{@changes.size} conflicts=#{@conflicts.size} " \
+        "warnings=#{@warnings.size}>"
+    end
+
+    private
+
+    # Convert a JSON array of plan entries (string-keyed Hashes) into a frozen
+    # Array of frozen, symbol-keyed Hashes. The entries are shallow (all values
+    # are scalars or string arrays), so a single `transform_keys` suffices.
+    def freeze_items(items)
+      Array(items).map { |item| item.transform_keys(&:to_sym).freeze }.freeze
+    end
+  end
+end

--- a/lib/microsandbox/sandbox.rb
+++ b/lib/microsandbox/sandbox.rb
@@ -116,6 +116,30 @@ module Microsandbox
       JSON.parse(@native.config_json)
     end
 
+    # Health-check the guest agent without refreshing the idle timer. Connects
+    # to the running sandbox and sends `core.ping`; a stopped sandbox raises
+    # {SandboxNotRunningError} (it is not started implicitly). Mirrors the
+    # official SDKs' `ping`.
+    # @return [PingResult]
+    def ping
+      PingResult.new(@native.ping)
+    end
+
+    # Explicitly refresh this sandbox's idle-activity timer. A stopped sandbox
+    # raises {SandboxNotRunningError}. Mirrors the official SDKs' `touch`.
+    # @return [TouchResult]
+    def touch
+      TouchResult.new(@native.touch)
+    end
+
+    # Plan or apply a live modification of this sandbox. See {Sandbox#modify} for
+    # the full option set.
+    # @return [ModificationPlan]
+    def modify(**kwargs)
+      opts = Sandbox.send(:build_modify_opts, **kwargs)
+      ModificationPlan.new(JSON.parse(@native.modify(opts)))
+    end
+
     # Snapshot this (stopped) sandbox under a bare name, resolved under the
     # snapshots dir. Convenience equivalent of
     # `Snapshot.create(name, name: <snapshot-name>)` addressed by this handle.
@@ -213,7 +237,12 @@ module Microsandbox
       # @param name [String] sandbox name (max 128 UTF-8 bytes)
       # @param image [String, nil] OCI image reference (e.g. "python")
       # @param cpus [Integer, nil] number of vCPUs
+      # @param max_cpus [Integer, nil] boot-time maximum vCPU ceiling a later live
+      #   {Sandbox#modify} can grow up to (defaults to `cpus`; must be >= `cpus`)
       # @param memory [Integer, nil] memory in MiB
+      # @param max_memory [Integer, nil] boot-time maximum memory ceiling (MiB) a
+      #   later live {Sandbox#modify} can grow up to (defaults to `memory`; must
+      #   be >= `memory`)
       # @param env [Hash, nil] environment variables
       # @param workdir [String, nil] working directory inside the guest
       # @param shell [String, nil] default shell (for {#shell})
@@ -334,7 +363,8 @@ module Microsandbox
 
       # @api private
       # Shared keyword-option builder for {create}/{create_with_progress}.
-      def build_create_opts(image: nil, cpus: nil, memory: nil, env: nil, workdir: nil,
+      def build_create_opts(image: nil, cpus: nil, max_cpus: nil, memory: nil, max_memory: nil,
+        env: nil, workdir: nil,
         shell: nil, user: nil, hostname: nil, labels: nil, scripts: nil,
         entrypoint: nil, ports: nil, ports_udp: nil, volumes: nil, network: nil,
         dns: nil, tls: nil, ipv4_pool: nil, ipv6_pool: nil,
@@ -370,7 +400,9 @@ module Microsandbox
         opts["from_snapshot"] = from_snapshot.to_s if from_snapshot
         opts["fstype"] = fstype.to_s if fstype
         opts["cpus"] = Integer(cpus) if cpus
+        opts["max_cpus"] = Integer(max_cpus) if max_cpus
         opts["memory"] = Integer(memory) if memory
+        opts["max_memory"] = Integer(max_memory) if max_memory
         opts["workdir"] = workdir.to_s if workdir
         opts["shell"] = shell.to_s if shell
         opts["user"] = user.to_s if user
@@ -520,6 +552,99 @@ module Microsandbox
       # {#normalize_violation}).
       def normalize_secrets(secrets)
         Array(secrets).map { |spec| normalize_secret(spec) }
+      end
+
+      # @api private
+      # Shared keyword-option builder for {Sandbox#modify}/{SandboxHandle#modify}.
+      # Produces the string-keyed Hash the native `modify` reads. `policy` is
+      # always set (defaulting to "no_restart"); everything else is included only
+      # when provided so an unset option means "leave unchanged".
+      def build_modify_opts(cpus: nil, max_cpus: nil, memory: nil, max_memory: nil,
+        env: nil, remove_env: nil, labels: nil, remove_labels: nil, workdir: nil,
+        secrets: nil, remove_secrets: nil, policy: nil, dry_run: false)
+        opts = {}
+        opts["cpus"] = Integer(cpus) if cpus
+        opts["max_cpus"] = Integer(max_cpus) if max_cpus
+        opts["memory"] = Integer(memory) if memory
+        opts["max_memory"] = Integer(max_memory) if max_memory
+        opts["env"] = stringify(env) if env
+        opts["remove_env"] = Array(remove_env).map(&:to_s) if remove_env
+        opts["labels"] = stringify(labels) if labels
+        opts["remove_labels"] = Array(remove_labels).map(&:to_s) if remove_labels
+        opts["workdir"] = workdir.to_s if workdir
+        opts["secrets"] = normalize_modify_secrets(secrets) if secrets
+        opts["remove_secrets"] = Array(remove_secrets).map(&:to_s) if remove_secrets
+        opts["policy"] = normalize_modify_policy(policy)
+        opts["dry_run"] = true if dry_run
+        opts
+      end
+
+      # Normalize the `secrets:` modify option — a Hash of `{ name => spec }` —
+      # into the native array of specs, sorted by name for deterministic patch
+      # (and plan) ordering. The modify secret vocabulary differs from create's
+      # (source-or-value with `env:`/`store:`/`value:` mutually exclusive, keyed
+      # by secret name), mirroring the upstream `SecretModifySpec`.
+      def normalize_modify_secrets(secrets)
+        unless secrets.is_a?(Hash)
+          raise ArgumentError, "secrets: must be a Hash of { name => spec } (got #{secrets.class})"
+        end
+        out = secrets.map { |name, spec| normalize_modify_secret(name, spec) }
+          .sort_by { |h| h["name"] }
+        # A Symbol and a String key stringify to the same secret name, yielding
+        # two same-name specs. Upstream's fluent API dedupes those; the patch
+        # path we drive does not, and duplicates make the live value and the
+        # persisted config diverge nondeterministically — reject them loudly.
+        dup = out.group_by { |h| h["name"] }.find { |_, specs| specs.size > 1 }
+        if dup
+          raise ArgumentError,
+            "secrets: duplicate entries for #{dup.first.inspect} (a Symbol and a String key stringify to the same name)"
+        end
+        out
+      end
+
+      def normalize_modify_secret(name, spec)
+        spec ||= {}
+        unless spec.is_a?(Hash)
+          # Reject before any spec access: a non-Hash spec (e.g. the tempting
+          # `{ name => raw_value }` shorthand) must never reach a method call
+          # whose NoMethodError would embed the receiver — cleartext — in the
+          # message on Ruby < 3.3.
+          raise ArgumentError,
+            "secret #{name.to_s.inspect}: spec must be a Hash (e.g. { value: ... } or { env: ... }), got #{spec.class}"
+        end
+        env = fetch_opt(spec, :env)
+        value = fetch_opt(spec, :value)
+        store = fetch_opt(spec, :store)
+        present = {"env" => env, "value" => value, "store" => store}.reject { |_, v| v.nil? }
+        if present.size > 1
+          # Report only the conflicting KEYS, never the values — a secret spec's
+          # :value is cleartext and error messages routinely land in logs and
+          # error trackers. Mirrors normalize_secret above.
+          keys = present.keys.map(&:inspect).join(" and ")
+          raise ArgumentError,
+            "secret #{name.to_s.inspect}: #{keys} are mutually exclusive; set at most one"
+        end
+        out = {"name" => name.to_s}
+        out["env"] = env.to_s if env
+        out["value"] = value.to_s if value
+        out["store"] = store.to_s if store
+        pl = fetch_opt(spec, :placeholder)
+        out["placeholder"] = pl.to_s if pl
+        hosts = spec[:allowed_hosts] || spec["allowed_hosts"]
+        out["allowed_hosts"] = Array(hosts).map(&:to_s) if hosts
+        out
+      end
+
+      # Normalize the `policy:` modify option (Symbol or String) to the native
+      # string, defaulting to "no_restart".
+      def normalize_modify_policy(policy)
+        return "no_restart" if policy.nil?
+        s = policy.to_s
+        unless %w[no_restart next_start restart].include?(s)
+          raise ArgumentError,
+            "policy: must be :no_restart, :next_start, or :restart (got #{policy.inspect})"
+        end
+        s
       end
 
       def normalize_secret(spec)
@@ -939,6 +1064,57 @@ module Microsandbox
     # @return [Metrics]
     def metrics
       Metrics.new(@native.metrics)
+    end
+
+    # Health-check the guest agent without refreshing the idle timer. Sends
+    # `core.ping` to the running sandbox and reports the round-trip latency.
+    # Mirrors the official SDKs' `ping`.
+    # @return [PingResult]
+    def ping
+      PingResult.new(@native.ping)
+    end
+
+    # Explicitly refresh this sandbox's idle-activity timer (resetting any
+    # `idle_timeout:` countdown). Mirrors the official SDKs' `touch`.
+    # @return [TouchResult]
+    def touch
+      TouchResult.new(@native.touch)
+    end
+
+    # Plan or apply a live modification of this sandbox: resize CPU/memory,
+    # adjust env/labels/workdir, and rotate/remove secrets, without recreating
+    # the sandbox. The apply is all-or-nothing under the chosen `policy:`: the
+    # default `:no_restart` applies only changes that are live-capable *right
+    # now* and raises if any requested change needs a restart (on a running
+    # sandbox that includes env/labels/workdir and *adding* a secret — rotating
+    # or removing an existing one is live). Pass `policy: :next_start` to
+    # persist restart-required changes for the next start, or `:restart` to
+    # restart and apply them now; use `dry_run: true` to preview each change's
+    # disposition without applying anything. Mirrors the official SDKs'
+    # `modify`. Returns a {ModificationPlan} classifying each change.
+    #
+    # @param cpus [Integer, nil] desired effective vCPU count
+    # @param max_cpus [Integer, nil] desired boot-time maximum vCPU ceiling
+    # @param memory [Integer, nil] desired effective guest memory in MiB
+    # @param max_memory [Integer, nil] desired boot-time maximum memory (MiB)
+    # @param env [Hash, nil] environment variables to set for future execs
+    # @param remove_env [Array<String>, nil] environment variable names to remove
+    # @param labels [Hash, nil] labels to set
+    # @param remove_labels [Array<String>, nil] label keys to remove
+    # @param workdir [String, nil] desired working directory for future execs
+    # @param secrets [Hash, nil] desired secret specs keyed by secret name. Each
+    #   spec is a Hash with at most one of `env:` (host env var to read),
+    #   `store:` (host secret-store reference), or `value:` (raw material), plus
+    #   optional `placeholder:` and `allowed_hosts:` (Array of host patterns).
+    # @param remove_secrets [Array<String>, nil] secret names to remove
+    # @param policy [Symbol, String, nil] `:no_restart` (default — apply only
+    #   changes that need no restart), `:next_start` (persist for the next
+    #   start), or `:restart` (restart to apply restart-required changes)
+    # @param dry_run [Boolean] compute the plan without applying anything
+    # @return [ModificationPlan]
+    def modify(**kwargs)
+      opts = Sandbox.send(:build_modify_opts, **kwargs)
+      ModificationPlan.new(JSON.parse(@native.modify(opts)))
     end
 
     # Read captured logs.

--- a/lib/microsandbox/version.rb
+++ b/lib/microsandbox/version.rb
@@ -8,7 +8,7 @@ module Microsandbox
   # Versioning section of the README for the full gem-to-runtime map. Must equal
   # the native ext's Cargo crate version (`Native.version`), enforced by
   # spec/unit/version_spec.rb.
-  VERSION = "0.9.3"
+  VERSION = "0.10.0"
 
   # The upstream microsandbox runtime release this gem build embeds — the `tag`
   # pinned on the `microsandbox`/`microsandbox-network` git deps in

--- a/sig/microsandbox.rbs
+++ b/sig/microsandbox.rbs
@@ -174,6 +174,14 @@ module Microsandbox
     def config: () -> Hash[String, untyped]
     def snapshot: (String name) -> SnapshotInfo
     def snapshot_to: (String path) -> SnapshotInfo
+    def ping: () -> PingResult
+    def touch: () -> TouchResult
+    def modify: (?cpus: Integer?, ?max_cpus: Integer?, ?memory: Integer?, ?max_memory: Integer?,
+                 ?env: Hash[untyped, untyped]?, ?remove_env: Array[String]?,
+                 ?labels: Hash[untyped, untyped]?, ?remove_labels: Array[String]?,
+                 ?workdir: String?, ?secrets: Hash[untyped, untyped]?,
+                 ?remove_secrets: Array[String]?, ?policy: (Symbol | String)?,
+                 ?dry_run: bool) -> ModificationPlan
   end
 
   # Deprecated alias for SandboxHandle (was a read-only metadata type pre-v0.5.8).
@@ -190,8 +198,34 @@ module Microsandbox
     def observed_at: () -> Time
   end
 
+  class PingResult
+    def initialize: (Hash[String, untyped] data) -> void
+    def name: () -> String
+    def latency: () -> Float
+    def latency_ms: () -> Float
+  end
+
+  class TouchResult
+    def initialize: (Hash[String, untyped] data) -> void
+    def name: () -> String
+    def activity_seq: () -> Integer
+  end
+
+  class ModificationPlan
+    def initialize: (Hash[String, untyped] data) -> void
+    def sandbox: () -> String
+    def status: () -> String
+    def policy: () -> Symbol
+    def applied?: () -> bool
+    def changes: () -> Array[Hash[Symbol, untyped]]
+    def conflicts: () -> Array[Hash[Symbol, untyped]]
+    def warnings: () -> Array[Hash[Symbol, untyped]]
+    def resize_status: () -> Array[Hash[Symbol, untyped]]
+  end
+
   class Sandbox
-    def self.create: (String name, ?image: String?, ?cpus: Integer?, ?memory: Integer?,
+    def self.create: (String name, ?image: String?, ?cpus: Integer?, ?max_cpus: Integer?,
+                      ?memory: Integer?, ?max_memory: Integer?,
                       ?env: Hash[untyped, untyped]?, ?workdir: String?, ?shell: String?,
                       ?user: String?, ?hostname: String?, ?labels: Hash[untyped, untyped]?,
                       ?scripts: Hash[untyped, untyped]?, ?entrypoint: Array[String]?,
@@ -238,6 +272,14 @@ module Microsandbox
     def fs: () -> FS
     def ssh: () -> SshOps
     def metrics: () -> Metrics
+    def ping: () -> PingResult
+    def touch: () -> TouchResult
+    def modify: (?cpus: Integer?, ?max_cpus: Integer?, ?memory: Integer?, ?max_memory: Integer?,
+                 ?env: Hash[untyped, untyped]?, ?remove_env: Array[String]?,
+                 ?labels: Hash[untyped, untyped]?, ?remove_labels: Array[String]?,
+                 ?workdir: String?, ?secrets: Hash[untyped, untyped]?,
+                 ?remove_secrets: Array[String]?, ?policy: (Symbol | String)?,
+                 ?dry_run: bool) -> ModificationPlan
     def logs: (?tail: Integer?, ?since_ms: Numeric?, ?until_ms: Numeric?,
                ?sources: Array[String | Symbol]?) -> Array[LogEntry]
     def metrics_stream: (?interval: Numeric) -> MetricsStream

--- a/spec/integration/modify_health_spec.rb
+++ b/spec/integration/modify_health_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+# Real-microVM integration coverage for the v0.6.6 parity surface: ping/touch
+# health checks and live modify (plan + apply). Opt-in via
+# MICROSANDBOX_INTEGRATION=1. This is the ONLY place the new native bindings
+# run against a real guest — the unit suite stubs the native layer entirely.
+RSpec.describe "Sandbox live modification & health", :integration do
+  let(:image) { default_test_image }
+
+  it "pings and touches a running sandbox" do
+    Microsandbox::Sandbox.create(unique_sandbox_name, image: image) do |sb|
+      ping = sb.ping
+      expect(ping).to be_a(Microsandbox::PingResult)
+      expect(ping.name).to eq(sb.name)
+      expect(ping.latency).to be_a(Float)
+      expect(ping.latency).to be >= 0
+      expect(ping.latency_ms).to be_within(0.001).of(ping.latency * 1000.0)
+
+      touch = sb.touch
+      expect(touch).to be_a(Microsandbox::TouchResult)
+      expect(touch.name).to eq(sb.name)
+      expect(touch.activity_seq).to be_a(Integer)
+      # A second touch advances the activity sequence.
+      expect(sb.touch.activity_seq).to be > touch.activity_seq
+    end
+  end
+
+  it "raises SandboxNotRunningError from a stopped handle's ping/touch" do
+    name = unique_sandbox_name
+    Microsandbox::Sandbox.create(name, image: image) { |_sb| }
+    handle = Microsandbox::Sandbox.get(name)
+    expect(handle.stopped?).to be(true)
+    expect { handle.ping }.to raise_error(Microsandbox::SandboxNotRunningError)
+    expect { handle.touch }.to raise_error(Microsandbox::SandboxNotRunningError)
+  ensure
+    begin
+      Microsandbox::Sandbox.remove(name)
+    rescue Microsandbox::Error
+      nil
+    end
+  end
+
+  it "dry-runs a plan, live-resizes resources, and gates restart-required changes" do
+    name = unique_sandbox_name
+    Microsandbox::Sandbox.create(name, image: image,
+      cpus: 1, max_cpus: 2, memory: 512, max_memory: 1024) do |sb|
+      # Dry run: classified but not applied.
+      plan = sb.modify(cpus: 2, memory: 1024, dry_run: true)
+      expect(plan).to be_a(Microsandbox::ModificationPlan)
+      expect(plan.applied?).to be(false)
+      expect(plan.policy).to eq(:no_restart)
+      fields = plan.changes.map { |c| c[:field] }
+      expect(fields).to include("cpus", "memory")
+      expect(plan.changes).to all(satisfy { |c| c[:disposition].is_a?(String) })
+
+      # Live resize within the boot-time ceilings applies without a restart.
+      applied = sb.modify(cpus: 2, memory: 1024)
+      expect(applied.applied?).to be(true)
+      expect(applied.conflicts).to be_empty
+
+      # env on a RUNNING sandbox requires a restart → the default :no_restart
+      # policy refuses the whole apply (this is the documented all-or-nothing
+      # contract; nothing is partially applied).
+      expect { sb.modify(env: {"TIER" => "prod"}) }.to raise_error(Microsandbox::Error)
+
+      # ...but the same change is accepted for the next start when asked for.
+      deferred = sb.modify(env: {"TIER" => "prod"}, policy: :next_start)
+      expect(deferred.applied?).to be(true)
+      env_change = deferred.changes.find { |c| c[:field] == "env" }
+      expect(env_change).not_to be_nil
+    end
+  end
+end

--- a/spec/unit/modify_spec.rb
+++ b/spec/unit/modify_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require "json"
+
+# Exercises the pure-Ruby normalization and value objects for the v0.6.6 parity
+# surface — modify / ping / touch — WITHOUT booting a real microVM, by stubbing
+# the native layer. The native binding itself is exercised only by the
+# environment-gated integration suite (spec/integration/modify_health_spec.rb);
+# a green run here proves nothing about real-VM behavior.
+RSpec.describe "v0.6.6 modify/ping/touch parity" do
+  # A representative apply plan as the native layer serializes it (canonical
+  # snake_case keys, literal-space enum strings), used to assert Ruby-side parsing.
+  let(:plan_json) do
+    JSON.generate(
+      "sandbox" => "box",
+      "status" => "running",
+      "applied" => true,
+      "policy" => "no_restart",
+      "changes" => [
+        {"kind" => "config", "field" => "cpus", "change" => "updated",
+         "before" => "1", "after" => "2", "disposition" => "live"},
+        {"kind" => "secret", "field" => "secret", "name" => "API_KEY",
+         "change" => "hosts updated", "disposition" => "next start",
+         "allow_hosts" => ["api.example.com"]}
+      ],
+      "conflicts" => [{"field" => "memory", "message" => "exceeds max_memory"}],
+      "warnings" => [{"field" => "cpus", "message" => "guest may refuse"}],
+      "resize_status" => [
+        {"resource" => "cpus", "requested" => "2", "actual" => "2",
+         "enforced" => "2", "state" => "applied"}
+      ]
+    )
+  end
+
+  describe Microsandbox::Sandbox do
+    let(:native) { instance_double(Microsandbox::Native::Sandbox, name: "box", stop: nil) }
+    let(:sandbox) { described_class.new(native) }
+
+    describe "#modify option mapping" do
+      before { allow(native).to receive(:modify).and_return(plan_json) }
+
+      it "normalizes resource, env, label, and workdir kwargs into a string-keyed hash" do
+        sandbox.modify(
+          cpus: 2, max_cpus: 4, memory: 1024, max_memory: 2048,
+          env: {:FOO => 1, "BAR" => :baz}, remove_env: [:DEBUG, "STALE"],
+          labels: {team: "core"}, remove_labels: ["old"],
+          workdir: "/srv"
+        )
+
+        expect(native).to have_received(:modify).with(
+          hash_including(
+            "cpus" => 2, "max_cpus" => 4, "memory" => 1024, "max_memory" => 2048,
+            "env" => {"FOO" => "1", "BAR" => "baz"}, "remove_env" => ["DEBUG", "STALE"],
+            "labels" => {"team" => "core"}, "remove_labels" => ["old"],
+            "workdir" => "/srv", "policy" => "no_restart"
+          )
+        )
+      end
+
+      it "always sets a policy, defaulting to no_restart, and omits unspecified options" do
+        sandbox.modify(cpus: 1)
+        expect(native).to have_received(:modify).with({"cpus" => 1, "policy" => "no_restart"})
+      end
+
+      it "accepts a policy Symbol or String and maps it to the native string" do
+        sandbox.modify(policy: :next_start)
+        sandbox.modify(policy: "restart")
+        expect(native).to have_received(:modify).with(hash_including("policy" => "next_start"))
+        expect(native).to have_received(:modify).with(hash_including("policy" => "restart"))
+      end
+
+      it "rejects an unknown policy with a clear ArgumentError" do
+        expect { sandbox.modify(policy: :reboot) }
+          .to raise_error(ArgumentError, /policy: must be :no_restart, :next_start, or :restart/)
+        expect(native).not_to have_received(:modify)
+      end
+
+      it "sets dry_run only when requested" do
+        sandbox.modify(cpus: 1, dry_run: true)
+        expect(native).to have_received(:modify).with(hash_including("dry_run" => true))
+      end
+    end
+
+    describe "#modify secret normalization" do
+      before { allow(native).to receive(:modify).and_return(plan_json) }
+
+      it "normalizes a { name => spec } Hash into a name-sorted array of specs" do
+        sandbox.modify(
+          secrets: {
+            "ZED" => {store: "vault://zed", placeholder: "<zed>"},
+            "API_KEY" => {env: "HOST_API_KEY", allowed_hosts: ["api.example.com", :extra]}
+          },
+          remove_secrets: [:OLD, "GONE"]
+        )
+
+        expect(native).to have_received(:modify).with(
+          hash_including(
+            "secrets" => [
+              {"name" => "API_KEY", "env" => "HOST_API_KEY",
+               "allowed_hosts" => ["api.example.com", "extra"]},
+              {"name" => "ZED", "store" => "vault://zed", "placeholder" => "<zed>"}
+            ],
+            "remove_secrets" => ["OLD", "GONE"]
+          )
+        )
+      end
+
+      it "carries a raw value spec through" do
+        sandbox.modify(secrets: {"TOK" => {value: "s3cret"}})
+        expect(native).to have_received(:modify).with(
+          hash_including("secrets" => [{"name" => "TOK", "value" => "s3cret"}])
+        )
+      end
+
+      it "rejects mutually-exclusive sources naming only the keys, never the value" do
+        expect {
+          sandbox.modify(secrets: {"TOK" => {env: "HOST", value: "s3cret"}})
+        }.to raise_error(ArgumentError) { |e|
+          expect(e.message).to match(/secret "TOK": .* are mutually exclusive/)
+          expect(e.message).to include('"env"', '"value"')
+          expect(e.message).not_to include("s3cret")
+        }
+        expect(native).not_to have_received(:modify)
+      end
+
+      it "rejects a non-Hash secrets option" do
+        expect { sandbox.modify(secrets: [{env: "X"}]) }
+          .to raise_error(ArgumentError, /secrets: must be a Hash/)
+      end
+
+      it "rejects a non-Hash spec without leaking its value into the message" do
+        # The tempting-but-wrong `{ name => raw_value }` shorthand: on
+        # Ruby < 3.3 an unguarded spec.key? call would embed the receiver —
+        # the cleartext secret — in a NoMethodError.
+        expect {
+          sandbox.modify(secrets: {"API_KEY" => "sk-live-abc123"})
+        }.to raise_error(ArgumentError) { |e|
+          expect(e.message).to match(/secret "API_KEY": spec must be a Hash/)
+          expect(e.message).not_to include("sk-live-abc123")
+        }
+        expect(native).not_to have_received(:modify)
+      end
+
+      it "rejects a Symbol/String key collision instead of sending duplicate specs" do
+        # Both keys stringify to one secret name; duplicates bypass upstream's
+        # fluent-API dedup and make the live value diverge from the persisted
+        # config nondeterministically.
+        expect {
+          sandbox.modify(secrets: {:API_KEY => {value: "a"}, "API_KEY" => {value: "b"}})
+        }.to raise_error(ArgumentError) { |e|
+          expect(e.message).to match(/duplicate entries for "API_KEY"/)
+          expect(e.message).not_to include("a\"", "b\"")
+        }
+        expect(native).not_to have_received(:modify)
+      end
+    end
+
+    describe "#modify return value" do
+      before { allow(native).to receive(:modify).and_return(plan_json) }
+
+      it "parses the native JSON plan into a ModificationPlan" do
+        plan = sandbox.modify(cpus: 2)
+        expect(plan).to be_a(Microsandbox::ModificationPlan)
+        expect(plan.sandbox).to eq("box")
+        expect(plan.status).to eq("running")
+        expect(plan.applied?).to be(true)
+        expect(plan.policy).to eq(:no_restart)
+      end
+    end
+
+    describe "#ping / #touch" do
+      it "wraps the native ping hash in a PingResult (seconds + ms)" do
+        allow(native).to receive(:ping).and_return("name" => "box", "latency_secs" => 0.25)
+        result = sandbox.ping
+        expect(result).to be_a(Microsandbox::PingResult)
+        expect(result.name).to eq("box")
+        expect(result.latency).to eq(0.25)
+        expect(result.latency_ms).to eq(250.0)
+      end
+
+      it "wraps the native touch hash in a TouchResult" do
+        allow(native).to receive(:touch).and_return("name" => "box", "activity_seq" => 42)
+        result = sandbox.touch
+        expect(result).to be_a(Microsandbox::TouchResult)
+        expect(result.name).to eq("box")
+        expect(result.activity_seq).to eq(42)
+      end
+    end
+  end
+
+  describe Microsandbox::SandboxHandle do
+    let(:native) { instance_double(Microsandbox::Native::SandboxHandle) }
+    let(:handle) { described_class.new(native) }
+
+    it "delegates #modify through the shared builder and parses the plan" do
+      allow(native).to receive(:modify).and_return(plan_json)
+      plan = handle.modify(memory: 1024, policy: :restart)
+      expect(native).to have_received(:modify).with(
+        hash_including("memory" => 1024, "policy" => "restart")
+      )
+      expect(plan).to be_a(Microsandbox::ModificationPlan)
+    end
+
+    it "delegates #ping and #touch" do
+      allow(native).to receive(:ping).and_return("name" => "box", "latency_secs" => 0.1)
+      allow(native).to receive(:touch).and_return("name" => "box", "activity_seq" => 7)
+      expect(handle.ping).to be_a(Microsandbox::PingResult)
+      expect(handle.touch.activity_seq).to eq(7)
+    end
+  end
+
+  describe Microsandbox::ModificationPlan do
+    subject(:plan) { described_class.new(JSON.parse(plan_json)) }
+
+    it "exposes typed top-level fields" do
+      expect(plan.sandbox).to eq("box")
+      expect(plan.status).to eq("running")
+      expect(plan.applied?).to be(true)
+      expect(plan.policy).to eq(:no_restart)
+    end
+
+    it "returns nested entries as frozen, symbol-keyed Hashes with values verbatim" do
+      config_change = plan.changes.first
+      expect(config_change).to eq(
+        {kind: "config", field: "cpus", change: "updated",
+         before: "1", after: "2", disposition: "live"}
+      )
+      expect(config_change).to be_frozen
+      expect(plan.changes).to be_frozen
+
+      secret_change = plan.changes.last
+      # literal-space enum strings are preserved (not re-cased):
+      expect(secret_change[:change]).to eq("hosts updated")
+      expect(secret_change[:disposition]).to eq("next start")
+      expect(secret_change[:allow_hosts]).to eq(["api.example.com"])
+    end
+
+    it "parses conflicts, warnings, and resize_status" do
+      expect(plan.conflicts).to eq([{field: "memory", message: "exceeds max_memory"}])
+      expect(plan.warnings).to eq([{field: "cpus", message: "guest may refuse"}])
+      expect(plan.resize_status.first).to include(resource: "cpus", state: "applied")
+    end
+
+    it "treats an absent resize_status as an empty array (dry-run plans omit it)" do
+      dry = described_class.new(
+        "sandbox" => "box", "status" => "running", "applied" => false,
+        "policy" => "next_start", "changes" => [], "conflicts" => [], "warnings" => []
+      )
+      expect(dry.applied?).to be(false)
+      expect(dry.policy).to eq(:next_start)
+      expect(dry.resize_status).to eq([])
+    end
+  end
+
+  describe "error classes" do
+    it "defines SandboxNotRunningError for the v0.6.6 not-running guard" do
+      expect(Microsandbox::SandboxNotRunningError).to be < Microsandbox::Error
+      expect(Microsandbox::SandboxNotRunningError.code).to eq("sandbox-not-running")
+    end
+  end
+end

--- a/spec/unit/sandbox_spec.rb
+++ b/spec/unit/sandbox_spec.rb
@@ -46,6 +46,15 @@ RSpec.describe Microsandbox::Sandbox do
       )
     end
 
+    it "passes through max_cpus / max_memory resource ceilings (v0.6.6)" do
+      Microsandbox::Sandbox.create("box", image: "alpine", cpus: 1, max_cpus: 4,
+        memory: 512, max_memory: 2048)
+      expect(Microsandbox::Native::Sandbox).to have_received(:create).with(
+        "box",
+        hash_including("cpus" => 1, "max_cpus" => 4, "memory" => 512, "max_memory" => 2048)
+      )
+    end
+
     it "ensures the runtime is provisioned before creating" do
       Microsandbox::Sandbox.create("box", image: "x")
       expect(Microsandbox).to have_received(:ensure_runtime!)


### PR DESCRIPTION
> [!NOTE]
> Was stacked on #50; #50 is now **merged** and this PR has been retargeted to `main` — the diff is the single parity commit and it is ready to merge on its own.

## Summary

Ruby bindings for the additive v0.6.6 SDK surface (upstream #1099 / #1128), bringing the gem to **parity with the Python and Node SDKs**, which already ship this API. Gem `0.9.3 → 0.10.0` (minor — new public API on the 0.x track). The embedded runtime stays `v0.6.6`.

## New API

- **`Sandbox#modify` / `SandboxHandle#modify`** — plan or apply a live modification without recreating the sandbox: `cpus:`/`max_cpus:`/`memory:`/`max_memory:` (MiB), `env:`/`remove_env:`, `labels:`/`remove_labels:`, `workdir:`, `secrets:`/`remove_secrets:` (specs keyed by name; `env:`/`store:`/`value:` mutually exclusive + `placeholder:`/`allowed_hosts:`), `policy:` (`:no_restart` default / `:next_start` / `:restart`), `dry_run:`. Returns a typed `ModificationPlan` (`#changes`/`#conflicts`/`#warnings`/`#resize_status` as frozen symbol-keyed Hashes, runtime's snake_case fields verbatim). The apply is **all-or-nothing** under the chosen policy, mirroring upstream's atomic validation.
- **`Sandbox#ping` / `#touch`** (and on the handle) — `PingResult` (`#latency` seconds / `#latency_ms`; does **not** refresh the idle timer — verified in agentd source) and `TouchResult` (`#activity_seq`; explicitly refreshes it). A stopped handle raises `SandboxNotRunningError` (the new core `SandboxNotRunning` variant is now mapped to the pre-existing Ruby class).
- **`Sandbox.create` gains `max_cpus:` / `max_memory:`** — boot-time ceilings a later live resize can grow up to.

Deliberately **not** exposed, matching Python/Node (both CLI-only upstream): `modify`'s `oci_upper_size`, and the `SandboxMetricsReport` helpers.

## Adversarial review (fable-tier critic) — 4 confirmed findings, all fixed here

1. **Secret-value leak path** *(security)*: a non-Hash secret spec (the tempting `{ name => raw_value }` shorthand) reached `spec.key?` — on Ruby 3.1/3.2 the resulting `NoMethodError` embeds the receiver, i.e. **the cleartext secret**, in a message that routinely lands in logs/error trackers. Now rejected with a value-free `ArgumentError` before any spec access (+ regression spec asserting the value is absent from the message).
2. **README example raised at runtime**: env/labels/workdir on a *running* sandbox classify as restart-required, so the default `:no_restart` policy **raises** (upstream validates up-front, atomically) — the docs claimed they'd silently persist. Example + docs rewritten to the real semantics (verified against upstream `modify.rs` classification, including secret-change dispositions: rotate/remove/hosts-update of an existing secret is live, adding one is not).
3. **Symbol/String secret-name collision** produced two same-name patches, bypassing upstream's fluent-API dedup — traced through upstream apply: the **live value and the persisted config diverge**, nondeterministically (find-first vs last-write). Now rejected loudly (+ spec).
4. **Zero integration coverage** for the new native surface (and an overclaiming spec comment — the exact unit-green-hides-real-breakage pattern of the v0.5.9 incident): added env-gated `spec/integration/modify_health_spec.rb` (ping/touch, stopped-handle errors, dry-run plan, live resize within ceilings, the all-or-nothing `:no_restart` rejection, `:next_start` deferral) and corrected the comment.

Verified clean by the same review: GVL/magnus safety (no Ruby object crosses the no-GVL boundary), builder field mapping (no accidental clears via `..Default::default()`), plan JSON field-name fidelity, native secret redaction (`Zeroizing` + value-free errors), handle ownership, `max < base` rejection upstream at start.

## Verification

- `cargo fmt --check` ✅ / `cargo clippy -D warnings` ✅ / `bundle exec standardrb` ✅
- Unit specs: **334 examples, 0 failures** (312 existing + 22 new)
- `rbs -I sig validate` ✅; version lock-step asserted by `version_spec` (0.10.0 everywhere, `RUNTIME_VERSION` = `v0.6.6`)
- Real-microVM integration: ✅ **36 examples, 0 failures, 1 pending** (dispatch run [28963666819](https://github.com/ya-luotao/microsandbox-rb/actions/runs/28963666819) on real KVM — includes the 3 new `Sandbox live modification & health` examples: ping/touch, stopped-handle errors, dry-run plan, live resize, the all-or-nothing `:no_restart` rejection and `:next_start` deferral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uutVDpgRxL2NKRLbMRSbQ

